### PR TITLE
Remove `host` from server.config.js

### DIFF
--- a/config/server.config.js
+++ b/config/server.config.js
@@ -2,7 +2,6 @@ require('dotenv').config()
 
 const config = {
   port: process.env.PORT,
-  host: 'localhost',
   // The routes section is used to set default configuration for every route
   // in the app. In our case we want to Hapi to set a bunch of common security
   // heades. See https://hapi.dev/api/?v=20.0.0#-routeoptionssecurity for


### PR DESCRIPTION
When attempting to create a vagrant box for the project (something we do across all our projects) we hit a snag. All requests to the API from the host on `http://localhost:3003` were returning `Recv failure: Connection reset by peer`.

After some investigation we found it was because we are setting `host` to `localhost` in the server config. When run directly on the host this is fine. But when run in the vagrantbox this is caused port forwarding to break.

After double checking the existing charging-module-api we confirmed `host` never gets set. So we removed it and found both local and running in the vagrantbox started working with us being able to connect to the API in both cases at `http://localhost:3003`.