### PR TITLE
Add disinfect plugin to santize inputs to the API

### DIFF
--- a/app/plugins/disinfect.plugin.js
+++ b/app/plugins/disinfect.plugin.js
@@ -1,0 +1,19 @@
+/*
+  This plugin applies Google's Caja HTML Sanitizer on route query, payload, and
+  params. It was added specifically to protect us from issues such as XSS.
+
+  https://github.com/google/caja
+  https://github.com/genediazjr/disinfect
+*/
+const Disinfect = require('disinfect')
+
+const disinfect = {
+  plugin: Disinfect,
+  options: {
+    disinfectQuery: true,
+    disinfectParams: true,
+    disinfectPayload: true
+  }
+}
+
+module.exports = disinfect

--- a/package-lock.json
+++ b/package-lock.json
@@ -1104,6 +1104,14 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
+    "async": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "requires": {
+        "lodash": "^4.17.14"
+      }
+    },
     "atob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
@@ -1804,6 +1812,17 @@
           "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
           "dev": true
         }
+      }
+    },
+    "disinfect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/disinfect/-/disinfect-1.1.0.tgz",
+      "integrity": "sha512-ZxFp9MD8RBTmJEsrIe8SuqxUXGkLAMxeNR2b2ankitUqAP/VI5MvfqbcAfdWs31pPAq9eBja/UzNt0zESkulOg==",
+      "requires": {
+        "async": "^2.6.0",
+        "hoek": "^5.0.3",
+        "joi": "^13.1.2",
+        "sanitizer": "^0.1.3"
       }
     },
     "doctrine": {
@@ -2891,6 +2910,11 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
+    "hoek": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.4.tgz",
+      "integrity": "sha512-Alr4ZQgoMlnere5FZJsIyfIjORBqZll5POhDsF4q64dPuJR6rNxXdDxtHSQq8OXRurhmx+PWYEE8bXRROY8h0w=="
+    },
     "homedir-polyfill": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
@@ -3462,6 +3486,14 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
+    "isemail": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
+      "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
+      "requires": {
+        "punycode": "2.x.x"
+      }
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -3471,6 +3503,16 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+    },
+    "joi": {
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-13.7.0.tgz",
+      "integrity": "sha512-xuY5VkHfeOYK3Hdi91ulocfuFopwgbSORmIwzcwHKESQhC7w1kD5jaVSPnqDxS2I8t3RZ9omCKAxNwXN5zG1/Q==",
+      "requires": {
+        "hoek": "5.x.x",
+        "isemail": "3.x.x",
+        "topo": "3.x.x"
+      }
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -4866,6 +4908,11 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "sanitizer": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/sanitizer/-/sanitizer-0.1.3.tgz",
+      "integrity": "sha1-1PCvdHXZp7ryqeWmEXGLqheKOeE="
+    },
     "seedrandom": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
@@ -5424,6 +5471,21 @@
       "requires": {
         "is-number": "^3.0.0",
         "repeat-string": "^1.6.1"
+      }
+    },
+    "topo": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.3.tgz",
+      "integrity": "sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==",
+      "requires": {
+        "hoek": "6.x.x"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "6.1.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
+          "integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ=="
+        }
       }
     },
     "touch": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@hapi/hapi": "^20.0.1",
     "@now-ims/hapi-now-auth": "^2.0.2",
     "blipp": "^4.0.1",
+    "disinfect": "^1.1.0",
     "dotenv": "^8.2.0",
     "jwk-to-pem": "^2.0.4",
     "knex": "^0.21.6",

--- a/server.js
+++ b/server.js
@@ -5,14 +5,17 @@ exports.deployment = async (start) => {
   // Create the hapi server
   const server = Hapi.server(ServerConfig)
 
+  // Register our auth plugin and then the strategies (needs to be done in this
+  // order)
   await server.register(require('./app/plugins/hapi_now_auth.plugin'))
   server.auth.strategy('jwt-strategy', 'hapi-now-auth', require('./app/auth/jwt_strategy.auth'))
   server.auth.default('jwt-strategy')
 
-  // Register the plugins
+  // Register the remaining plugins
   await server.register(require('./app/plugins/router.plugin'))
   await server.register(require('./app/plugins/blipp.plugin'))
   await server.register(require('./app/plugins/hpal_debug.plugin'))
+  await server.register(require('./app/plugins/disinfect.plugin'))
 
   server.ext('onRequest', require('./app/hooks/on_request.hook'))
   server.ext('onCredentials', require('./app/hooks/on_credentials.hook'))


### PR DESCRIPTION
https://trello.com/c/cjqqnLGs

During PEN testing of the [charging-module-api](https://github.com/DEFRA/charging-mdoule-api) it was found that the project is susceptible to XSS. This was because inputs to the API were not properly being sanitized. Rather than roll our own santizer, we're opting to use a plugin on this project.

[Disinfect](https://github.com/genediazjr/disinfect) has been used on a number of Defra projects. It applies Google's [Caja](https://github.com/google/caja) HTML Sanitizer on route query, payload, and params.

This change adds it to this project.