### PR TITLE
Enable  show scope option in Blipp plugin

### DIFF
--- a/app/plugins/blipp.plugin.js
+++ b/app/plugins/blipp.plugin.js
@@ -2,13 +2,25 @@
   Plugin to display the routes table to console at startup. It organizes the
   display per connection so if you have multiple connections you can easily
   ensure that you've done your routing table correctly.
+
+  An example of the output
+
+  method  path                     auth          scope  description
+  ------  -----------------------  ------------  -----  -----------
+  GET     /                        none          none
+  GET     /regimes                 jwt-strategy  admin
+  GET     /regimes/{id}            jwt-strategy  admin
+  GET     /status                  none          none
+  GET     /v1/{regimeId}/billruns  jwt-strategy  none
+  GET     /v2/{regimeId}/billruns  jwt-strategy  none
 */
 const Blipp = require('blipp')
 
 const blipp = {
   plugin: Blipp,
   options: {
-    showAuth: true
+    showAuth: true,
+    showScope: true
   }
 }
 


### PR DESCRIPTION
We use the [blipp](https://github.com/danielb2/blipp) to display our routes when the service starts up. As we are now using [Route scopes](https://hapi.dev/api/?v=20.0.0#-routeoptionsauthaccessscope) as part of our authorisation solution being able to see the scopes in the Blipp output will be handy.

This change enables the scope output and expands the current documentation for the plugin.