### PR TITLE
Add Airbrake error logging to the project

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
+# Airbrake config
+AIRBRAKE_HOST=https://my-errbit-instance.com
+AIRBRAKE_KEY=longvaluefullofnumbersandlettersinlowercase
+
 # Authentication config
 ENVIRONMENT=dev
 ADMIN_CLIENT_ID=cognitoclientidforadminuser

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ addons:
 env:
   global:
     - ADMIN_CLIENT_ID=shortvaluefullofnumbersandlettersinlowercase
+    - AIRBRAKE_HOST=https://my-errbit-instance.com
+    - AIRBRAKE_KEY=longvaluefullofnumbersandlettersinlowercase
     - PORT=3000
     - PGUSER=charge
     - PGPASSWORD=pinafore

--- a/app/controllers/airbrake.controller.js
+++ b/app/controllers/airbrake.controller.js
@@ -1,9 +1,9 @@
 class AirbrakeController {
-  static async auto (req, h) {
+  static async auto (_req, _h) {
     throw new Error('Airbrake test error - automatic')
   }
 
-  static async manual (req, h) {
+  static async manual (req, _h) {
     req.server.methods.notify(
       new Error('Airbrake test error - manual'),
       { message: 'Use me to log other events' }

--- a/app/controllers/airbrake.controller.js
+++ b/app/controllers/airbrake.controller.js
@@ -1,0 +1,15 @@
+class AirbrakeController {
+  static async auto (req, h) {
+    throw new Error('Airbrake test error - automatic')
+  }
+
+  static async manual (req, h) {
+    req.server.methods.notify(
+      new Error('Airbrake test error - manual'),
+      { message: 'Use me to log other events' }
+    )
+    return 'Manual notification sent using Airbrake to Errbit'
+  }
+}
+
+module.exports = AirbrakeController

--- a/app/controllers/airbrake.controller.js
+++ b/app/controllers/airbrake.controller.js
@@ -1,14 +1,10 @@
 class AirbrakeController {
-  static async auto (_req, _h) {
-    throw new Error('Airbrake test error - automatic')
-  }
-
-  static async manual (req, _h) {
+  static async index (req, _h) {
     req.server.methods.notify(
       new Error('Airbrake test error - manual'),
       { message: 'Use me to log other events' }
     )
-    return 'Manual notification sent using Airbrake to Errbit'
+    throw new Error('Airbrake test error - automatic')
   }
 }
 

--- a/app/plugins/airbrake.plugin.js
+++ b/app/plugins/airbrake.plugin.js
@@ -22,12 +22,12 @@ const airbrakeNotifier = new Airbrake.Notifier({
   performanceStats: false
 })
 
-const notificationLogged = (notice) => {
+const notificationLogged = notice => {
   if (!notice.id) {
     console.log('Airbrake notification failed', notice.error)
   }
 }
-const notificationDropped = (error) => {
+const notificationDropped = error => {
   console.log('Airbrake notification failed', error)
 }
 

--- a/app/plugins/airbrake.plugin.js
+++ b/app/plugins/airbrake.plugin.js
@@ -1,0 +1,73 @@
+/*
+  We use Airbrake to capture errors thrown within the service and send them to
+  an instance of Errbit we maintain in Defra.
+
+  https://hapi.dev/api/?v=20.0.0#-request-event
+
+  Airbrake doesn't provide a specific Hapi plugin. We've avoided others as they
+  are very out of date. So instead we roll our own plugin using the following
+  as references
+
+  https://github.com/DEFRA/node-hapi-airbrake/blob/master/lib/index.js
+  https://github.com/DEFRA/charging-module-api/blob/master/app/plugins/airbrake.js
+*/
+const Airbrake = require('@airbrake/node')
+const AirbrakeConfig = require('../../config/airbrake.config')
+
+const airbrakeNotifier = new Airbrake.Notifier({
+  host: AirbrakeConfig.host,
+  projectId: AirbrakeConfig.projectId,
+  projectKey: AirbrakeConfig.projectKey,
+  environment: AirbrakeConfig.environment,
+  performanceStats: false
+})
+
+const airbrake = {
+  name: 'airbrake',
+  register: (server, options) => {
+    // When Hapi emits a request event with an error we capture the details and
+    // use Airbrake to send a request to our Errbit instance
+    server.events.on({ name: 'request', channels: 'error' }, (req, event, tags) => {
+
+      const promise = airbrakeNotifier.notify({
+        error: event.error,
+        session: {
+          route: req.route.path,
+          method: req.method,
+          url: req.url.href
+        }
+      })
+      promise
+        .then((notice) => {
+          if (!notice.id) {
+            console.log('Airbrake notification failed', notice.error)
+          }
+        })
+        .catch((error) => {
+          console.log('Airbrake notification failed', error)
+        })
+    })
+
+    // To enable us to send notifications via Airbrake to Errbit manually we
+    // register a method with the server
+    //
+    // https://hapi.dev/api/?v=20.0.0#-servermethods
+    server.method('notify', (error, session) => {
+      const promise = airbrakeNotifier.notify({
+        error: error,
+        session: session
+      })
+      promise
+        .then((notice) => {
+          if (!notice.id) {
+            console.log('Airbrake notification failed', notice.error)
+          }
+        })
+        .catch((error) => {
+          console.log('Airbrake notification failed', error)
+        })
+    })
+  }
+}
+
+module.exports = airbrake

--- a/app/plugins/airbrake.plugin.js
+++ b/app/plugins/airbrake.plugin.js
@@ -22,6 +22,15 @@ const airbrakeNotifier = new Airbrake.Notifier({
   performanceStats: false
 })
 
+const notificationLogged = (notice) => {
+  if (!notice.id) {
+    console.log('Airbrake notification failed', notice.error)
+  }
+}
+const notificationDropped = (error) => {
+  console.log('Airbrake notification failed', error)
+}
+
 const airbrake = {
   name: 'airbrake',
   register: (server, options) => {
@@ -37,14 +46,8 @@ const airbrake = {
         }
       })
       promise
-        .then(notice => {
-          if (!notice.id) {
-            console.log('Airbrake notification failed', notice.error)
-          }
-        })
-        .catch(error => {
-          console.log('Airbrake notification failed', error)
-        })
+        .then(notice => notificationLogged(notice))
+        .catch(err => notificationDropped(err))
     })
 
     // To enable us to send notifications via Airbrake to Errbit manually we
@@ -57,14 +60,8 @@ const airbrake = {
         session: session
       })
       promise
-        .then(notice => {
-          if (!notice.id) {
-            console.log('Airbrake notification failed', notice.error)
-          }
-        })
-        .catch(error => {
-          console.log('Airbrake notification failed', error)
-        })
+        .then(notice => notificationLogged(notice))
+        .catch(err => notificationDropped(err))
     })
   }
 }

--- a/app/plugins/airbrake.plugin.js
+++ b/app/plugins/airbrake.plugin.js
@@ -37,15 +37,15 @@ const airbrake = {
     // When Hapi emits a request event with an error we capture the details and
     // use Airbrake to send a request to our Errbit instance
     server.events.on({ name: 'request', channels: 'error' }, (req, event, tags) => {
-      const promise = airbrakeNotifier.notify({
-        error: event.error,
-        session: {
-          route: req.route.path,
-          method: req.method,
-          url: req.url.href
-        }
-      })
-      promise
+      airbrakeNotifier
+        .notify({
+          error: event.error,
+          session: {
+            route: req.route.path,
+            method: req.method,
+            url: req.url.href
+          }
+        })
         .then(notice => notificationLogged(notice))
         .catch(err => notificationDropped(err))
     })
@@ -55,11 +55,11 @@ const airbrake = {
     //
     // https://hapi.dev/api/?v=20.0.0#-servermethods
     server.method('notify', (error, session) => {
-      const promise = airbrakeNotifier.notify({
-        error: error,
-        session: session
-      })
-      promise
+      airbrakeNotifier
+        .notify({
+          error: error,
+          session: session
+        })
         .then(notice => notificationLogged(notice))
         .catch(err => notificationDropped(err))
     })

--- a/app/plugins/airbrake.plugin.js
+++ b/app/plugins/airbrake.plugin.js
@@ -28,7 +28,6 @@ const airbrake = {
     // When Hapi emits a request event with an error we capture the details and
     // use Airbrake to send a request to our Errbit instance
     server.events.on({ name: 'request', channels: 'error' }, (req, event, tags) => {
-
       const promise = airbrakeNotifier.notify({
         error: event.error,
         session: {
@@ -38,12 +37,12 @@ const airbrake = {
         }
       })
       promise
-        .then((notice) => {
+        .then(notice => {
           if (!notice.id) {
             console.log('Airbrake notification failed', notice.error)
           }
         })
-        .catch((error) => {
+        .catch(error => {
           console.log('Airbrake notification failed', error)
         })
     })
@@ -58,12 +57,12 @@ const airbrake = {
         session: session
       })
       promise
-        .then((notice) => {
+        .then(notice => {
           if (!notice.id) {
             console.log('Airbrake notification failed', notice.error)
           }
         })
-        .catch((error) => {
+        .catch(error => {
           console.log('Airbrake notification failed', error)
         })
     })

--- a/app/plugins/airbrake.plugin.js
+++ b/app/plugins/airbrake.plugin.js
@@ -33,10 +33,10 @@ const notificationDropped = error => {
 
 const airbrake = {
   name: 'airbrake',
-  register: (server, options) => {
+  register: (server, _options) => {
     // When Hapi emits a request event with an error we capture the details and
     // use Airbrake to send a request to our Errbit instance
-    server.events.on({ name: 'request', channels: 'error' }, (req, event, tags) => {
+    server.events.on({ name: 'request', channels: 'error' }, (req, event, _tags) => {
       airbrakeNotifier
         .notify({
           error: event.error,

--- a/app/plugins/router.plugin.js
+++ b/app/plugins/router.plugin.js
@@ -10,12 +10,14 @@
 */
 
 const RootRoutes = require('../routes/root.routes')
+const AirbrakeRoutes = require('../routes/airbrake.routes')
 const BillRunRoutes = require('../routes/bill_run.routes')
 const TransactionRoutes = require('../routes/transaction.routes')
 const RegimesRoutes = require('../routes/regimes.routes')
 
 const routes = [
   ...RootRoutes,
+  ...AirbrakeRoutes,
   ...BillRunRoutes,
   ...TransactionRoutes,
   ...RegimesRoutes

--- a/app/routes/airbrake.routes.js
+++ b/app/routes/airbrake.routes.js
@@ -4,12 +4,22 @@ const routes = [
   {
     method: 'GET',
     path: '/airbrake/auto',
-    handler: AirbrakeController.auto
+    handler: AirbrakeController.auto,
+    options: {
+      auth: {
+        scope: ['admin']
+      }
+    }
   },
   {
     method: 'GET',
     path: '/airbrake/manual',
-    handler: AirbrakeController.manual
+    handler: AirbrakeController.manual,
+    options: {
+      auth: {
+        scope: ['admin']
+      }
+    }
   }
 ]
 

--- a/app/routes/airbrake.routes.js
+++ b/app/routes/airbrake.routes.js
@@ -3,19 +3,11 @@ const AirbrakeController = require('../controllers/airbrake.controller')
 const routes = [
   {
     method: 'GET',
-    path: '/airbrake/auto',
-    handler: AirbrakeController.auto,
+    path: '/status/airbrake',
+    handler: AirbrakeController.index,
     options: {
-      auth: {
-        scope: ['admin']
-      }
-    }
-  },
-  {
-    method: 'GET',
-    path: '/airbrake/manual',
-    handler: AirbrakeController.manual,
-    options: {
+      description: 'Used by the delivery team to confirm error logging is working correctly in an environment. ' +
+        'NOTE. We expect this endpoint to return a 500',
       auth: {
         scope: ['admin']
       }

--- a/app/routes/airbrake.routes.js
+++ b/app/routes/airbrake.routes.js
@@ -1,0 +1,16 @@
+const AirbrakeController = require('../controllers/airbrake.controller')
+
+const routes = [
+  {
+    method: 'GET',
+    path: '/airbrake/auto',
+    handler: AirbrakeController.auto
+  },
+  {
+    method: 'GET',
+    path: '/airbrake/manual',
+    handler: AirbrakeController.manual
+  }
+]
+
+module.exports = routes

--- a/config/airbrake.config.js
+++ b/config/airbrake.config.js
@@ -1,0 +1,10 @@
+require('dotenv').config()
+
+const config = {
+  host: process.env.AIRBRAKE_HOST,
+  projectKey: process.env.AIRBRAKE_KEY,
+  projectId: 1,
+  environment: process.env.ENVIRONMENT
+}
+
+module.exports = config

--- a/package-lock.json
+++ b/package-lock.json
@@ -1193,7 +1193,6 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
-<<<<<<< HEAD
     "async": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
@@ -1201,12 +1200,11 @@
       "requires": {
         "lodash": "^4.17.14"
       }
-=======
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
->>>>>>> 607c187... Add airbrake implementation
     },
     "atob": {
       "version": "2.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,30 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@airbrake/browser": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@airbrake/browser/-/browser-1.4.1.tgz",
+      "integrity": "sha512-4KChn2eGDllwqYJ4c6MFqIiJ2RZgg49inYiIsdpAj5MLtOpZRlPF8MsOSLGHxkEDX6u5M9KRidUfktuQ/C9lKA==",
+      "requires": {
+        "@types/promise-polyfill": "^6.0.3",
+        "@types/request": "2.48.5",
+        "cross-fetch": "^3.0.4",
+        "error-stack-parser": "^2.0.4",
+        "promise-polyfill": "^8.1.3",
+        "tdigest": "^0.1.1"
+      }
+    },
+    "@airbrake/node": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@airbrake/node/-/node-1.4.1.tgz",
+      "integrity": "sha512-8K9S4mDLgMXOGM4iMJt4qXeV4wfK8L7siIxR+IS0x9O92xUsyjIfc17NRxwkAzx+sEn8IBRjCXX9Og1Va831Wg==",
+      "requires": {
+        "@airbrake/browser": "^1.4.1",
+        "cross-fetch": "^3.0.4",
+        "error-stack-parser": "^2.0.4",
+        "tdigest": "^0.1.1"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
@@ -888,6 +912,11 @@
         "defer-to-connect": "^1.0.1"
       }
     },
+    "@types/caseless": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
+      "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w=="
+    },
     "@types/glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
@@ -907,8 +936,28 @@
     "@types/node": {
       "version": "14.11.8",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.8.tgz",
-      "integrity": "sha512-KPcKqKm5UKDkaYPTuXSx8wEP7vE9GnuaXIZKijwRYcePpZFDVuy2a57LarFKiORbHOuTOOwYzxVxcUzsh2P2Pw==",
-      "dev": true
+      "integrity": "sha512-KPcKqKm5UKDkaYPTuXSx8wEP7vE9GnuaXIZKijwRYcePpZFDVuy2a57LarFKiORbHOuTOOwYzxVxcUzsh2P2Pw=="
+    },
+    "@types/promise-polyfill": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/promise-polyfill/-/promise-polyfill-6.0.3.tgz",
+      "integrity": "sha512-f/BFgF9a+cgsMseC7rpv9+9TAE3YNjhfYrtwCo/pIeCDDfQtE6PY0b5bao2eIIEpZCBUy8Y5ToXd4ObjPSJuFw=="
+    },
+    "@types/request": {
+      "version": "2.48.5",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.5.tgz",
+      "integrity": "sha512-/LO7xRVnL3DxJ1WkPGDQrp4VTV1reX9RkC85mJ+Qzykj2Bdw+mG15aAfDahc76HtknjzE16SX/Yddn6MxVbmGQ==",
+      "requires": {
+        "@types/caseless": "*",
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "form-data": "^2.5.0"
+      }
+    },
+    "@types/tough-cookie": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.0.tgz",
+      "integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A=="
     },
     "abbrev": {
       "version": "1.1.1",
@@ -1104,6 +1153,7 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
+<<<<<<< HEAD
     "async": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
@@ -1111,6 +1161,12 @@
       "requires": {
         "lodash": "^4.17.14"
       }
+=======
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+>>>>>>> 607c187... Add airbrake implementation
     },
     "atob": {
       "version": "2.1.2",
@@ -1198,6 +1254,11 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
       "dev": true
+    },
+    "bintrees": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
+      "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
     },
     "blipp": {
       "version": "4.0.1",
@@ -1589,6 +1650,14 @@
       "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
       "dev": true
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "commander": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
@@ -1629,6 +1698,14 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+    },
+    "cross-fetch": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.6.tgz",
+      "integrity": "sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==",
+      "requires": {
+        "node-fetch": "2.6.1"
+      }
     },
     "cross-spawn": {
       "version": "6.0.5",
@@ -1786,6 +1863,11 @@
         }
       }
     },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
     "detect-file": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
@@ -1923,6 +2005,14 @@
       "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "error-stack-parser": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.6.tgz",
+      "integrity": "sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==",
+      "requires": {
+        "stackframe": "^1.1.1"
       }
     },
     "es-abstract": {
@@ -2643,6 +2733,16 @@
       "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
       "requires": {
         "for-in": "^1.0.1"
+      }
+    },
+    "form-data": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
       }
     },
     "fragment-cache": {
@@ -3884,6 +3984,21 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.45.0.tgz",
       "integrity": "sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w=="
     },
+    "mime-types": {
+      "version": "2.1.27",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+      "requires": {
+        "mime-db": "1.44.0"
+      },
+      "dependencies": {
+        "mime-db": {
+          "version": "1.44.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+          "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
+        }
+      }
+    },
     "mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -4004,6 +4119,11 @@
       "requires": {
         "lodash.toarray": "^4.4.0"
       }
+    },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "nodemon": {
       "version": "2.0.4",
@@ -4645,6 +4765,11 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "promise-polyfill": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.3.tgz",
+      "integrity": "sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g=="
+    },
     "prop-types": {
       "version": "15.7.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
@@ -5205,6 +5330,11 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "stackframe": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
+      "integrity": "sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA=="
+    },
     "standard": {
       "version": "14.3.4",
       "resolved": "https://registry.npmjs.org/standard/-/standard-14.3.4.tgz",
@@ -5391,6 +5521,14 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/tarn/-/tarn-3.0.0.tgz",
       "integrity": "sha512-PKUnlDFODZueoA8owLehl8vLcgtA8u4dRuVbZc92tspDYZixjJL6TqYOmryf/PfP/EBX+2rgNcrj96NO+RPkdQ=="
+    },
+    "tdigest": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.1.tgz",
+      "integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
+      "requires": {
+        "bintrees": "1.0.1"
+      }
     },
     "term-size": {
       "version": "2.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -903,6 +903,46 @@
       "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
       "dev": true
     },
+    "@sinonjs/commons": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
+      "integrity": "sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==",
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+      "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-5.0.1.tgz",
+      "integrity": "sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==",
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^5.0.2"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.2.0.tgz",
+      "integrity": "sha512-CaIcyX5cDsjcW/ab7HposFWzV1kC++4HNsfnEdFJa7cP1QIuILAKV+BgfeqRXhcnSAc76r/Rh/O5C+300BwUIw==",
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ=="
+    },
     "@szmarczak/http-timer": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
@@ -1876,8 +1916,7 @@
     "diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
     },
     "dir-glob": {
       "version": "3.0.1",
@@ -3693,6 +3732,11 @@
         "object.assign": "^4.1.0"
       }
     },
+    "just-extend": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.1.tgz",
+      "integrity": "sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA=="
+    },
     "jwa": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
@@ -3838,6 +3882,11 @@
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
       "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
     "lodash.includes": {
       "version": "4.3.0",
@@ -4110,6 +4159,18 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "nise": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-4.0.4.tgz",
+      "integrity": "sha512-bTTRUNlemx6deJa+ZyoCUTRvH3liK5+N6VQZ4NIw90AgDXY6iPnsqplNFf6STcj+ePk0H/xqxnP75Lr0J0Fq3A==",
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^6.0.0",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
     },
     "node-emoji": {
       "version": "1.10.0",
@@ -4519,6 +4580,21 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
       "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0="
+    },
+    "path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        }
+      }
     },
     "path-type": {
       "version": "2.0.0",
@@ -5101,6 +5177,35 @@
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
     },
+    "sinon": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.0.tgz",
+      "integrity": "sha512-eSNXz1XMcGEMHw08NJXSyTHIu6qTCOiN8x9ODACmZpNQpr0aXTBXBnI4xTzQzR+TEpOmLiKowGf9flCuKIzsbw==",
+      "requires": {
+        "@sinonjs/commons": "^1.8.1",
+        "@sinonjs/fake-timers": "^6.0.1",
+        "@sinonjs/formatio": "^5.0.1",
+        "@sinonjs/samsam": "^5.2.0",
+        "diff": "^4.0.2",
+        "nise": "^4.0.4",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -5666,6 +5771,11 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
     },
     "type-fest": {
       "version": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "knex": "^0.21.6",
     "objection": "^2.2.3",
     "pg": "^8.4.0",
-    "pg-hstore": "^2.3.3"
+    "pg-hstore": "^2.3.3",
+    "sinon": "^9.2.0"
   },
   "devDependencies": {
     "@hapi/code": "^8.0.2",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "author": "SRoC service team",
   "license": "OGL-UK-3.0",
   "dependencies": {
+    "@airbrake/node": "^1.4.1",
     "@hapi/hapi": "^20.0.1",
     "@now-ims/hapi-now-auth": "^2.0.2",
     "blipp": "^4.0.1",

--- a/server.js
+++ b/server.js
@@ -15,11 +15,8 @@ exports.deployment = async (start) => {
   await server.register(require('./app/plugins/router.plugin'))
   await server.register(require('./app/plugins/blipp.plugin'))
   await server.register(require('./app/plugins/hpal_debug.plugin'))
-<<<<<<< HEAD
   await server.register(require('./app/plugins/disinfect.plugin'))
-=======
   await server.register(require('./app/plugins/airbrake.plugin'))
->>>>>>> 607c187... Add airbrake implementation
 
   server.ext('onRequest', require('./app/hooks/on_request.hook'))
   server.ext('onCredentials', require('./app/hooks/on_credentials.hook'))

--- a/server.js
+++ b/server.js
@@ -15,7 +15,11 @@ exports.deployment = async (start) => {
   await server.register(require('./app/plugins/router.plugin'))
   await server.register(require('./app/plugins/blipp.plugin'))
   await server.register(require('./app/plugins/hpal_debug.plugin'))
+<<<<<<< HEAD
   await server.register(require('./app/plugins/disinfect.plugin'))
+=======
+  await server.register(require('./app/plugins/airbrake.plugin'))
+>>>>>>> 607c187... Add airbrake implementation
 
   server.ext('onRequest', require('./app/hooks/on_request.hook'))
   server.ext('onCredentials', require('./app/hooks/on_credentials.hook'))

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,48 @@
+# Test guidance
+
+## Authenticating with JWTs
+
+[Oauth2](https://oauth.net/2/) is the pattern used to authenticate with the API. Client systems use [JSON Web Tokens (JWTs)](https://jwt.io/) generated after authenticating with [AWS Cognito](https://aws.amazon.com/cognito/). These are added to an `Authorization` header as a [Bearer token](https://oauth.net/2/bearer-tokens) in the request to the API.
+
+[hapi-now-auth](https://github.com/now-ims/hapi-now-auth) is the plugin we use to implement a JWT based [Hapi authentication strategy](https://hapi.dev/tutorials/auth). Whenever a request is made the plugin handles extracting the bearer token, verifying it came from AWS Cognito, and decoding it. We then extract the `clientId` from the payload which is how we determine the client system trying to authenticate.
+
+### Authenticating in the tests
+
+Buried in the **hapi-now-auth** plugin is a call to `jsonwebtoken.verify()`. We can't emulate how AWS Cognito emulates and signs JWTs so this will always fail with the JWTs we create in our tests. To solve this you will see most tests will use [Sinon to stub](https://sinonjs.org/releases/v9.2.0/stubs/) the method.
+
+This allows us to return a decoded version of the tokens we generate in the tests. Because of this you will see this pattern frequently in the tests.
+
+- Generate a token using [AuthorisationHelper](test/support/helpers/authorisation.helper.js)
+- `require()` **jsonwebtoken** so we can stub it using **Sinon**
+- Stub `verify()` to return a decoded version of the token also provided by `AuthorisationHelper`
+
+```javascript
+//...
+
+const Sinon = require('sinon')
+
+const AuthorisationHelper = require('../support/helpers/authorisation.helper')
+
+const JsonWebToken = require('jsonwebtoken')
+
+describe('Some controller: GET /path/to/endpoint', () => {
+  const authToken = AuthorisationHelper.adminToken()
+
+  before(async () => {
+
+    // ...
+
+    Sinon
+      .stub(JsonWebToken, 'verify')
+      .returns(AuthorisationHelper.decodeToken(authToken))
+  })
+
+  after(async () => {
+    Sinon.restore()
+  })
+
+  it('displays the correct message', async () => {
+    // ...
+  })
+})
+```

--- a/test/controllers/airbrake.controller.test.js
+++ b/test/controllers/airbrake.controller.test.js
@@ -14,6 +14,7 @@ const AuthorisationHelper = require('../support/helpers/authorisation.helper')
 
 // Things we need to stub
 const JsonWebToken = require('jsonwebtoken')
+const Airbrake = require('@airbrake/node')
 
 describe('Airbrake controller: GET /status/airbrake', () => {
   let server
@@ -39,5 +40,24 @@ describe('Airbrake controller: GET /status/airbrake', () => {
 
     const response = await server.inject(options)
     expect(response.statusCode).to.equal(500)
+  })
+
+  it('causes Airbrake to send a notification', async () => {
+    const options = {
+      method: 'GET',
+      url: '/status/airbrake',
+      headers: { authorization: `Bearer ${authToken}` }
+    }
+
+    // We stub Airbrake in the test as currently this is the only test using it
+    const airbrakeStub = Sinon
+      .stub(Airbrake.Notifier.prototype, 'notify')
+      .resolves({ id: 1 })
+
+    await server.inject(options)
+
+    expect(airbrakeStub.called).to.equal(true)
+
+    airbrakeStub.restore()
   })
 })

--- a/test/controllers/airbrake.controller.test.js
+++ b/test/controllers/airbrake.controller.test.js
@@ -1,0 +1,43 @@
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, before, after } = exports.lab = Lab.script()
+const { expect } = Code
+
+// For running our service
+const { deployment } = require('../../server')
+
+// Test helpers
+const AuthorisationHelper = require('../support/helpers/authorisation.helper')
+
+// Things we need to stub
+const JsonWebToken = require('jsonwebtoken')
+
+describe('Airbrake controller: GET /status/airbrake', () => {
+  let server
+  const authToken = AuthorisationHelper.adminToken()
+
+  before(async () => {
+    server = await deployment()
+    Sinon
+      .stub(JsonWebToken, 'verify')
+      .returns(AuthorisationHelper.decodeToken(authToken))
+  })
+
+  after(async () => {
+    Sinon.restore()
+  })
+
+  it('returns a 500 error', async () => {
+    const options = {
+      method: 'GET',
+      url: '/status/airbrake',
+      headers: { authorization: `Bearer ${authToken}` }
+    }
+
+    const response = await server.inject(options)
+    expect(response.statusCode).to.equal(500)
+  })
+})

--- a/test/support/helpers/authorisation.helper.js
+++ b/test/support/helpers/authorisation.helper.js
@@ -1,0 +1,18 @@
+const JsonWebToken = require('jsonwebtoken')
+const AuthorisationConfig = require('../../../config/authentication.config')
+
+class AuthorisationHelper {
+  static adminToken () {
+    return this._createToken(AuthorisationConfig.adminClientId)
+  }
+
+  static decodeToken (token) {
+    return JsonWebToken.decode(token)
+  }
+
+  static _createToken (clientId) {
+    return JsonWebToken.sign({ client_id: clientId }, 'supersecretkey')
+  }
+}
+
+module.exports = AuthorisationHelper


### PR DESCRIPTION
It's a standard across Defra projects to use the relevant [Airbrake package](https://www.npmjs.com/package/@airbrake/node) to capture errors within our apps and automatically record them in an instance of [Errbit](https://github.com/errbit/errbit) we maintain. Doing so means teams can monitor and track issues in our apps without resorting to scanning logs for issues or waiting for calls from users.

This project is no exception. So this change adds support for Airbrake.