### PR TITLE
Create authorised systems

### DIFF
--- a/app/auth/jwt_strategy.auth.js
+++ b/app/auth/jwt_strategy.auth.js
@@ -9,9 +9,7 @@ const authOptions = {
     algorithms: ['RS256'],
     ignoreExpiration: true
   },
-  validate: async (request, token, h) => {
-    let isValid = false
-
+  validate: async (req, token, h) => {
     /**
      * we asked the plugin to verify the JWT
      * we will get back the decodedJWT as token.decodedJWT
@@ -37,8 +35,8 @@ const authOptions = {
      * route authentication options
      * https://hapijs.com/api#authentication-options
      */
-    isValid = true
-    return { isValid, credentials }
+
+    return { isValid: true, credentials }
   }
 }
 

--- a/app/auth/jwt_strategy.auth.js
+++ b/app/auth/jwt_strategy.auth.js
@@ -1,5 +1,6 @@
 const AuthenticationConfig = require('../../config/authentication.config')
 const CognitoJwtToPemService = require('../services/cognito_jwt_to_pem.service')
+const AuthorisedSystemModel = require('../models/authorised_system.model')
 
 const authOptions = {
   verifyJWT: true,
@@ -19,14 +20,17 @@ const authOptions = {
 
     const { client_id: clientId } = token.decodedJWT
 
-    const scope = ['system']
-    const isAdmin = AuthenticationConfig.adminClientId === clientId
+    const authorisedSystem = await AuthorisedSystemModel
+      .query()
+      .findById(clientId)
 
-    if (isAdmin) {
+    const scope = ['system']
+
+    if (authorisedSystem.admin) {
       scope.push('admin')
     }
 
-    const credentials = { clientId, scope, isAdmin }
+    const credentials = { clientId, scope, user: authorisedSystem }
 
     /**
      * return the decodedJWT to take advantage of hapi's

--- a/app/hooks/on_credentials.hook.js
+++ b/app/hooks/on_credentials.hook.js
@@ -1,8 +1,8 @@
 const Boom = require('@hapi/boom')
 
-const onCredentials = (request, h) => {
-  const { user } = request.auth.credentials
-  const { regimeId } = request.params
+const onCredentials = (req, h) => {
+  const { user } = req.auth.credentials
+  const { regimeId } = req.params
 
   // admin is always authorised to access regimes
   if (user.admin) {

--- a/app/hooks/on_credentials.hook.js
+++ b/app/hooks/on_credentials.hook.js
@@ -1,7 +1,23 @@
+const Boom = require('@hapi/boom')
+
 const onCredentials = (request, h) => {
-  if (request.auth.credentials.isAdmin) {
+  const { user } = request.auth.credentials
+  const { regimeId } = request.params
+
+  // admin is always authorised to access regimes
+  if (user.admin) {
     console.log('ADMIN')
     return h.continue
+  }
+
+  // No specific authorisation is needed if the endpoint doesn't contain a regime
+  if (!regimeId) {
+    console.log('No authorisation needed for this endpoint')
+    return h.continue
+  }
+
+  if (regimeId !== user.name) {
+    return Boom.forbidden(`Unauthorised for regime '${regimeId}'`)
   }
 
   return h.continue

--- a/app/hooks/on_request.hook.js
+++ b/app/hooks/on_request.hook.js
@@ -1,7 +1,7 @@
 const Boom = require('@hapi/boom')
 
-const onRequest = (request, h) => {
-  if (request.method === 'post' && !request.payload) {
+const onRequest = (req, h) => {
+  if (req.method === 'post' && !req.payload) {
     // return HTTP 400
     return Boom.badRequest('No payload')
   }

--- a/app/models/authorised_system.model.js
+++ b/app/models/authorised_system.model.js
@@ -1,0 +1,12 @@
+const db = require('../../db')
+const { Model } = require('objection')
+
+Model.knex(db)
+
+class AuthorisedSystemModel extends Model {
+  static get tableName () {
+    return 'authorised_systems'
+  }
+}
+
+module.exports = AuthorisedSystemModel

--- a/db/migrations/20201012150934_create_authorised_systems.js
+++ b/db/migrations/20201012150934_create_authorised_systems.js
@@ -10,6 +10,7 @@ exports.up = async function (knex) {
       // Data
       table.string('name').notNullable()
       table.string('status').notNullable().defaultTo('active')
+      table.boolean('admin').defaultTo(false)
 
       // Automatic timestamps
       table.timestamps(false, true)

--- a/db/migrations/20201012150934_create_authorised_systems.js
+++ b/db/migrations/20201012150934_create_authorised_systems.js
@@ -1,0 +1,31 @@
+const tableName = 'authorised_systems'
+
+exports.up = async function (knex) {
+  await knex
+    .schema
+    .createTable(tableName, table => {
+      // Primary Key
+      table.string('id').primary()
+
+      // Data
+      table.string('name').notNullable()
+      table.string('status').notNullable().defaultTo('active')
+
+      // Automatic timestamps
+      table.timestamps(false, true)
+    })
+
+  await knex.raw(`
+    CREATE TRIGGER update_timestamp
+    BEFORE UPDATE
+    ON ${tableName}
+    FOR EACH ROW
+    EXECUTE PROCEDURE update_timestamp();
+  `)
+}
+
+exports.down = function (knex) {
+  return knex
+    .schema
+    .dropTableIfExists(tableName)
+}

--- a/db/seeds/02_authorised_systems.js
+++ b/db/seeds/02_authorised_systems.js
@@ -1,0 +1,14 @@
+exports.seed = function (knex) {
+  // Deletes ALL existing entries
+  return knex('authorised_systems').del()
+    .then(function () {
+      // Inserts seed entries
+      return knex('authorised_systems').insert([
+        {
+          id: '77oc8j0o19qc3ohcf82sq41s4a',
+          name: 'wrls',
+          status: 'active'
+        }
+      ])
+    })
+}

--- a/db/seeds/02_authorised_systems.js
+++ b/db/seeds/02_authorised_systems.js
@@ -1,3 +1,5 @@
+const config = require('../../config/authentication.config')
+
 exports.seed = function (knex) {
   // Deletes ALL existing entries
   return knex('authorised_systems').del()
@@ -5,8 +7,9 @@ exports.seed = function (knex) {
       // Inserts seed entries
       return knex('authorised_systems').insert([
         {
-          id: '77oc8j0o19qc3ohcf82sq41s4a',
-          name: 'wrls',
+          id: config.adminClientId,
+          name: 'admin',
+          admin: true,
           status: 'active'
         }
       ])


### PR DESCRIPTION
This PR relates to the `authorised_systems` table and includes the following:

- Sets up migration and seed data for the `authorised_systems` table
- Creates an `authorised_system` model which represents systems and the regimes they are authorised to access
- Puts user info (including their allowed regimes) into the `credentials` object returned by the authorisation strategy
- Implements a check to ensure that routes containing a regime ID can only be accessed by systems authorised to access them (or admin systems, which can access any route)