### PR TITLE
Enable JWT token expiry checking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ AIRBRAKE_KEY=longvaluefullofnumbersandlettersinlowercase
 # Authentication config
 ENVIRONMENT=dev
 ADMIN_CLIENT_ID=cognitoclientidforadminuser
+IGNORE_JWT_EXPIRATION=false
 
 # Database config
 PGUSER=myuser

--- a/app/auth/jwt_strategy.auth.js
+++ b/app/auth/jwt_strategy.auth.js
@@ -7,7 +7,7 @@ const authOptions = {
   keychain: CognitoJwtToPemService.call(AuthenticationConfig.environment),
   verifyOptions: {
     algorithms: ['RS256'],
-    ignoreExpiration: true
+    ignoreExpiration: AuthenticationConfig.ignoreJwtExpiration
   },
   validate: async (req, token, h) => {
     /**
@@ -15,7 +15,6 @@ const authOptions = {
      * we will get back the decodedJWT as token.decodedJWT
      * and we will get the JWT as token.token
      */
-
     const { client_id: clientId } = token.decodedJWT
 
     const authorisedSystem = await AuthorisedSystemModel

--- a/config/authentication.config.js
+++ b/config/authentication.config.js
@@ -2,7 +2,10 @@ require('dotenv').config()
 
 const config = {
   environment: process.env.ENVIRONMENT,
-  adminClientId: process.env.ADMIN_CLIENT_ID
+  adminClientId: process.env.ADMIN_CLIENT_ID,
+  // Credit to https://stackoverflow.com/a/323546/6117745 for how to handle
+  // converting the env var to a boolean
+  ignoreJwtExpiration: (String(process.env.IGNORE_JWT_EXPIRATION) === 'true') || false
 }
 
 module.exports = config

--- a/test/controllers/admin/health/airbrake.controller.test.js
+++ b/test/controllers/admin/health/airbrake.controller.test.js
@@ -10,7 +10,7 @@ const { expect } = Code
 const { deployment } = require('../../../../server')
 
 // Test helpers
-const { AuthorisationHelper, DatabaseHelper } = require('../../../support/helpers')
+const { AuthorisationHelper, ClientHelper, DatabaseHelper } = require('../support/helpers')
 
 // Things we need to stub
 const JsonWebToken = require('jsonwebtoken')
@@ -29,7 +29,7 @@ describe('Airbrake controller: GET /status/airbrake', () => {
 
   beforeEach(async () => {
     await DatabaseHelper.clean()
-    await DatabaseHelper.addAdminUser()
+    await ClientHelper.addAdminClient()
   })
 
   after(async () => {

--- a/test/controllers/admin/health/airbrake.controller.test.js
+++ b/test/controllers/admin/health/airbrake.controller.test.js
@@ -10,7 +10,7 @@ const { expect } = Code
 const { deployment } = require('../../../../server')
 
 // Test helpers
-const { AuthorisationHelper, ClientHelper, DatabaseHelper } = require('../support/helpers')
+const { AuthorisationHelper, AuthorisedSystemHelper, DatabaseHelper } = require('../support/helpers')
 
 // Things we need to stub
 const JsonWebToken = require('jsonwebtoken')
@@ -29,7 +29,7 @@ describe('Airbrake controller: GET /status/airbrake', () => {
 
   beforeEach(async () => {
     await DatabaseHelper.clean()
-    await ClientHelper.addAdminClient()
+    await AuthorisedSystemHelper.addAdminSystem()
   })
 
   after(async () => {

--- a/test/controllers/admin/health/airbrake.controller.test.js
+++ b/test/controllers/admin/health/airbrake.controller.test.js
@@ -10,7 +10,7 @@ const { expect } = Code
 const { deployment } = require('../../../../server')
 
 // Test helpers
-const { AuthorisationHelper, AuthorisedSystemHelper, DatabaseHelper } = require('../support/helpers')
+const { AuthorisationHelper, AuthorisedSystemHelper, DatabaseHelper } = require('../../../support/helpers')
 
 // Things we need to stub
 const JsonWebToken = require('jsonwebtoken')

--- a/test/features/authentication.test.js
+++ b/test/features/authentication.test.js
@@ -10,7 +10,7 @@ const { expect } = Code
 const { deployment } = require('../../server')
 
 // Test helpers
-const { AuthorisationHelper, ClientHelper, DatabaseHelper, RouteHelper } = require('../support/helpers')
+const { AuthorisationHelper, AuthorisedSystemHelper, DatabaseHelper, RouteHelper } = require('../support/helpers')
 
 // Things we need to stub
 const JsonWebToken = require('jsonwebtoken')
@@ -40,7 +40,7 @@ describe('Authenticating with the API', () => {
   describe('When accessing an /admin only route', () => {
     before(async () => {
       await DatabaseHelper.clean()
-      await ClientHelper.addAdminClient()
+      await AuthorisedSystemHelper.addAdminSystem()
 
       server = await deployment()
       RouteHelper.addAdminRoute(server)

--- a/test/features/authentication.test.js
+++ b/test/features/authentication.test.js
@@ -1,0 +1,134 @@
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, before, afterEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// For running our service
+const { deployment } = require('../../server')
+
+// Test helpers
+const { AuthorisationHelper, ClientHelper, DatabaseHelper, RouteHelper } = require('../support/helpers')
+
+// Things we need to stub
+const JsonWebToken = require('jsonwebtoken')
+
+describe('Authenticating with the API', () => {
+  let server
+  let authToken
+
+  describe('When accessing a public route', () => {
+    before(async () => {
+      server = await deployment()
+      RouteHelper.addPublicRoute(server)
+    })
+
+    it('returns a success response', async () => {
+      const options = {
+        method: 'GET',
+        url: '/test/public'
+      }
+
+      const response = await server.inject(options)
+
+      expect(response.statusCode).to.equal(200)
+    })
+  })
+
+  describe('When accessing an /admin only route', () => {
+    before(async () => {
+      await DatabaseHelper.clean()
+      await ClientHelper.addAdminClient()
+
+      server = await deployment()
+      RouteHelper.addAdminRoute(server)
+    })
+
+    afterEach(async () => {
+      Sinon.restore()
+    })
+
+    describe('but I do not have a bearer token', () => {
+      it('returns a 401 error', async () => {
+        const options = {
+          method: 'GET',
+          url: '/test/admin'
+        }
+
+        const response = await server.inject(options)
+
+        expect(response.statusCode).to.equal(401)
+      })
+    })
+
+    describe('and I have a valid bearer token', () => {
+      before(async () => {
+        authToken = AuthorisationHelper.adminToken()
+
+        Sinon
+          .stub(JsonWebToken, 'verify')
+          .returns(AuthorisationHelper.decodeToken(authToken))
+      })
+
+      it('returns a success response', async () => {
+        const options = {
+          method: 'GET',
+          url: '/test/admin',
+          headers: { authorization: `Bearer ${authToken}` }
+        }
+
+        const response = await server.inject(options)
+
+        expect(response.statusCode).to.equal(200)
+      })
+    })
+
+    describe('but I have an invalid bearer token', () => {
+      before(async () => {
+        authToken = AuthorisationHelper.adminToken()
+      })
+
+      describe('because it has expired', () => {
+        before(async () => {
+          Sinon
+            .stub(JsonWebToken, 'verify')
+            .throws(AuthorisationHelper.tokenExpiredError())
+        })
+
+        it('returns a 401 error', async () => {
+          const options = {
+            method: 'GET',
+            url: '/test/admin',
+            headers: { authorization: `Bearer ${authToken}` }
+          }
+
+          const response = await server.inject(options)
+
+          expect(response.statusCode).to.equal(401)
+        })
+      })
+
+      describe('because it was not signed by our AWS Cognito instance', () => {
+        before(async () => {
+          Sinon
+            .stub(JsonWebToken, 'verify')
+            .throws(AuthorisationHelper.tokenInvalidSignatureError())
+        })
+
+        it('returns a 401 error', async () => {
+          const options = {
+            method: 'GET',
+            url: '/test/admin',
+            headers: { authorization: `Bearer ${authToken}` }
+          }
+
+          const response = await server.inject(options)
+
+          expect(response.statusCode).to.equal(401)
+        })
+      })
+    })
+  })
+})

--- a/test/features/authorisation.test.js
+++ b/test/features/authorisation.test.js
@@ -10,7 +10,7 @@ const { expect } = Code
 const { deployment } = require('../../server')
 
 // Test helpers
-const { AuthorisationHelper, ClientHelper, DatabaseHelper, RouteHelper } = require('../support/helpers')
+const { AuthorisationHelper, AuthorisedSystemHelper, DatabaseHelper, RouteHelper } = require('../support/helpers')
 
 // Things we need to stub
 const JsonWebToken = require('jsonwebtoken')
@@ -23,8 +23,8 @@ describe('Authorisation with the API', () => {
   describe('When accessing an /admin only route', () => {
     before(async () => {
       await DatabaseHelper.clean()
-      await ClientHelper.addAdminClient()
-      await ClientHelper.addClient(nonAdminClientId, 'wrls')
+      await AuthorisedSystemHelper.addAdminSystem()
+      await AuthorisedSystemHelper.addSystem(nonAdminClientId, 'wrls')
 
       server = await deployment()
       RouteHelper.addAdminRoute(server)

--- a/test/features/authorisation.test.js
+++ b/test/features/authorisation.test.js
@@ -1,0 +1,81 @@
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, before, afterEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// For running our service
+const { deployment } = require('../../server')
+
+// Test helpers
+const { AuthorisationHelper, ClientHelper, DatabaseHelper, RouteHelper } = require('../support/helpers')
+
+// Things we need to stub
+const JsonWebToken = require('jsonwebtoken')
+
+describe('Authorisation with the API', () => {
+  let server
+  let authToken
+  const nonAdminClientId = 'k7ehotrs1fqer7hoaslv7ilmr'
+
+  describe('When accessing an /admin only route', () => {
+    before(async () => {
+      await DatabaseHelper.clean()
+      await ClientHelper.addAdminClient()
+      await ClientHelper.addClient(nonAdminClientId, 'wrls')
+
+      server = await deployment()
+      RouteHelper.addAdminRoute(server)
+    })
+
+    afterEach(async () => {
+      Sinon.restore()
+    })
+
+    describe('and I am an admin client', () => {
+      before(async () => {
+        authToken = AuthorisationHelper.adminToken()
+
+        Sinon
+          .stub(JsonWebToken, 'verify')
+          .returns(AuthorisationHelper.decodeToken(authToken))
+      })
+
+      it('returns a success response', async () => {
+        const options = {
+          method: 'GET',
+          url: '/test/admin',
+          headers: { authorization: `Bearer ${authToken}` }
+        }
+
+        const response = await server.inject(options)
+
+        expect(response.statusCode).to.equal(200)
+      })
+    })
+
+    describe('but I am not an admin client', () => {
+      before(async () => {
+        authToken = AuthorisationHelper.nonAdminToken(nonAdminClientId)
+
+        Sinon
+          .stub(JsonWebToken, 'verify')
+          .returns(AuthorisationHelper.decodeToken(authToken))
+      })
+
+      it('returns a 403 response', async () => {
+        const options = {
+          method: 'GET',
+          url: '/test/admin',
+          headers: { authorization: `Bearer ${authToken}` }
+        }
+
+        const response = await server.inject(options)
+
+        expect(response.statusCode).to.equal(403)
+      })
+    })
+  })
+})

--- a/test/support/helpers/authorisation.helper.js
+++ b/test/support/helpers/authorisation.helper.js
@@ -1,16 +1,76 @@
 const JsonWebToken = require('jsonwebtoken')
 const AuthorisationConfig = require('../../../config/authentication.config')
 
+/**
+ * Use to help with authentication in tests
+ *
+ * It contains methods for generating and decoding JSON Web Tokens (JWTs) as well as returning errors related to JWT
+ * verification.
+ *
+ * @see {@link https://jwt.io/|JWT.io}
+ */
 class AuthorisationHelper {
+  /**
+   * Generates a JWT with the admin client ID set in the payload
+   *
+   * @returns {string} A String that represents an encoded JWT
+   */
   static adminToken () {
     return this._createToken(AuthorisationConfig.adminClientId)
   }
 
+  /**
+   * Generates a JWT with the provided client ID set in the payload
+   *
+   * Intended for use when you need to generate a JWT which links to a non-admin user in the system. As long as the
+   * client ID matches that set when creating the `AuthorisedSystem` record authentication will succeed.
+   *
+   * @param {string} clientId The ID you wish encoded in the JWT
+   * @returns {string} A String that represents an encoded JWT
+   */
+  static nonAdminToken (clientId) {
+    return this._createToken(clientId)
+  }
+
+  /**
+   * Decode the provided JWT
+   *
+   * Intended to be used when stubbing the response `JsonWebToken.verify()` returns. You need a decoded version of the
+   * encoded bearer token you set in the header for authentication to work.
+   *
+   * @param {string} token The encoded version of a JWT you wish to be decoded
+   * @returns {Object} A decoded version of the token. It wil be made up of a header, payload, and signature. Our
+   * authentication strategy relies on the payload containing a `client_id:` that matches an `AuthorisedSystem` record.
+   */
   static decodeToken (token) {
     return JsonWebToken.decode(token)
   }
 
-  static _createToken (clientId) {
+  /**
+   * Returns an instance of `JsonWebToken.TokenExpiredError`
+   *
+   * To mimic our authentication strategy rejecting a request because the JWT bearer token is expired we need to throw
+   * an instance of `JsonWebToken.TokenExpiredError` when we stub `JsonWebToken.verify()`.
+   *
+   * @returns An instance of `JsonWebToken.TokenExpiredError`
+   */
+  static tokenExpiredError () {
+    return new JsonWebToken.TokenExpiredError('jwt expired', Date.now())
+  }
+
+  /**
+   * Returns an instance of `JsonWebToken.JsonWebTokenError`
+   *
+   * To mimic our authentication strategy rejecting a request because the JWT bearer token has an invalid signature we
+   * need to throw an instance of `JsonWebToken.JsonWebTokenError` when we stub `JsonWebToken.verify()`.
+   *
+   * @returns An instance of `JsonWebToken.JsonWebTokenError`
+   */
+  static tokenInvalidSignatureError () {
+    return new JsonWebToken.JsonWebTokenError('invalid signature')
+  }
+
+  static _createToken (clientId, expired = false) {
     return JsonWebToken.sign({ client_id: clientId }, 'supersecretkey')
   }
 }

--- a/test/support/helpers/authorised_system.helper.js
+++ b/test/support/helpers/authorised_system.helper.js
@@ -2,7 +2,7 @@ const authConfig = require('../../../config/authentication.config')
 const { AuthorisedSystemModel } = require('../../../app/models')
 
 /**
- * Use to help with creating 'client' records
+ * Use to help with creating `AuthorisedSystem` records
  *
  * Our clients are the systems permitted to use the API and they are recorded in the database as `AuthorisedSystems`.
  * We expect only one to be flagged as an admin client which is used by the delivery team for accessing endpoints on
@@ -10,31 +10,31 @@ const { AuthorisedSystemModel } = require('../../../app/models')
  *
  * Any others are expected to be our actual clients or 'users'
  */
-class ClientHelper {
+class AuthorisedSystemHelper {
   /**
-   * Create the admin client record
+   * Create the admin system record
    *
    * @param {string} [id] If not set will default to the configured admin client ID.
    * @returns {Object} The result of the db insertion for your reference
    */
-  static async addAdminClient (id) {
+  static async addAdminSystem (id) {
     const systemId = id || authConfig.adminClientId
 
-    return this._insertClient(systemId, 'admin', true, 'active')
+    return this._insertSystem(systemId, 'admin', true, 'active')
   }
 
   /**
-   * Create non-admin client record
+   * Create non-admin system record
    *
-   * @param {string} id ID you want set for the client
-   * @param {name} name Name you want to set for the client
+   * @param {string} id ID you want set for the system
+   * @param {name} name Name you want to set for the system
    * @returns {Object} The result of the db insertion for your reference
    */
-  static async addClient (id, name) {
-    return this._insertClient(id, name, false, 'active')
+  static async addSystem (id, name) {
+    return this._insertSystem(id, name, false, 'active')
   }
 
-  static async _insertClient (id, name, isAdmin, status) {
+  static async _insertSystem (id, name, isAdmin, status) {
     return await AuthorisedSystemModel
       .query()
       .insert({
@@ -47,4 +47,4 @@ class ClientHelper {
   }
 }
 
-module.exports = ClientHelper
+module.exports = AuthorisedSystemHelper

--- a/test/support/helpers/client.helper.js
+++ b/test/support/helpers/client.helper.js
@@ -1,0 +1,50 @@
+const authConfig = require('../../../config/authentication.config')
+const { AuthorisedSystemModel } = require('../../../app/models')
+
+/**
+ * Use to help with creating 'client' records
+ *
+ * Our clients are the systems permitted to use the API and they are recorded in the database as `AuthorisedSystems`.
+ * We expect only one to be flagged as an admin client which is used by the delivery team for accessing endpoints on
+ * the `/admin` path.
+ *
+ * Any others are expected to be our actual clients or 'users'
+ */
+class ClientHelper {
+  /**
+   * Create the admin client record
+   *
+   * @param {string} [id] If not set will default to the configured admin client ID.
+   * @returns {Object} The result of the db insertion for your reference
+   */
+  static async addAdminClient (id) {
+    const systemId = id || authConfig.adminClientId
+
+    return this._insertClient(systemId, 'admin', true, 'active')
+  }
+
+  /**
+   * Create non-admin client record
+   *
+   * @param {string} id ID you want set for the client
+   * @param {name} name Name you want to set for the client
+   * @returns {Object} The result of the db insertion for your reference
+   */
+  static async addClient (id, name) {
+    return this._insertClient(id, name, false, 'active')
+  }
+
+  static async _insertClient (id, name, isAdmin, status) {
+    return await AuthorisedSystemModel
+      .query()
+      .insert({
+        id: id,
+        name: name,
+        admin: isAdmin,
+        status: status
+      })
+      .returning('*')
+  }
+}
+
+module.exports = ClientHelper

--- a/test/support/helpers/database.helper.js
+++ b/test/support/helpers/database.helper.js
@@ -1,25 +1,24 @@
-const authConfig = require('../../../config/authentication.config')
 const { db, dbConfig } = require('../../../db')
-const { AuthorisedSystemModel } = require('../../../app/models')
 
+/**
+ * Use to help with cleaning the database between tests
+ *
+ * It's good practise to ensure the database is in a 'clean' state between tests to avoid any side effects caused by
+ * data from one test being present in another.
+ */
 class DatabaseHelper {
+  /**
+   * Call to clean the database of all data
+   *
+   * It works by identifying all the tables in the public schema (which we use). It then works out what the migration
+   * tables are called because those we should not be touching.
+   *
+   * Once it has that info it creates a query that tells PostgreSQL to TRUNCATE all the tables and restart their
+   * identity columns. For example, if a table relies on an incrementing ID the query will reset that to 1.
+   */
   static async clean () {
     const tables = await this._tableNames()
     return await db.raw(`TRUNCATE TABLE "${tables.join('","')}" RESTART IDENTITY`)
-  }
-
-  static async addAdminUser (id) {
-    const systemId = id || authConfig.adminClientId
-
-    await AuthorisedSystemModel
-      .query()
-      .insert({
-        id: systemId,
-        name: 'admin',
-        admin: true,
-        status: 'active'
-      })
-      .returning('*')
   }
 
   static _migrationTables () {

--- a/test/support/helpers/index.js
+++ b/test/support/helpers/index.js
@@ -1,9 +1,13 @@
 const AuthorisationHelper = require('./authorisation.helper')
+const ClientHelper = require('./client.helper')
 const DatabaseHelper = require('./database.helper')
+const RouteHelper = require('./route.helper')
 const RulesServiceHelper = require('./rules_service.helper')
 
 module.exports = {
   AuthorisationHelper,
+  ClientHelper,
   DatabaseHelper,
+  RouteHelper,
   RulesServiceHelper
 }

--- a/test/support/helpers/index.js
+++ b/test/support/helpers/index.js
@@ -1,12 +1,12 @@
 const AuthorisationHelper = require('./authorisation.helper')
-const ClientHelper = require('./client.helper')
+const AuthorisedSystemHelper = require('./authorised_system.helper')
 const DatabaseHelper = require('./database.helper')
 const RouteHelper = require('./route.helper')
 const RulesServiceHelper = require('./rules_service.helper')
 
 module.exports = {
   AuthorisationHelper,
-  ClientHelper,
+  AuthorisedSystemHelper,
   DatabaseHelper,
   RouteHelper,
   RulesServiceHelper

--- a/test/support/helpers/route.helper.js
+++ b/test/support/helpers/route.helper.js
@@ -1,0 +1,53 @@
+/**
+ * A helper that provides test routes.
+ *
+ * When testing you might need to add a route for which you control its config and options, for example, testing of
+ * public and private endpoints.
+ *
+ * Use this helper to access routes that can be added to the server as part of your tests.
+ */
+class RouteHelper {
+  /**
+   * Adds a route to a Hapi server instance which requires no authorisation to access.
+   *
+   * Intended to mimic routes such as `/` and `/status` which anyone can access.
+   *
+   * @param {Object} server A Hapi server instance
+   */
+  static addPublicRoute (server) {
+    server.route({
+      method: 'GET',
+      path: '/test/public',
+      handler: (_request, _h) => {
+        return { type: 'public' }
+      },
+      options: {
+        auth: false
+      }
+    })
+  }
+
+  /**
+   * Adds a route to a Hapi server instance which can only be accessed by the admin client.
+   *
+   * Intended to mimic routes such as `/admin/regimes` and those under `/admin/health/`.
+   *
+   * @param {Object} server A Hapi server instance
+   */
+  static addAdminRoute (server) {
+    server.route({
+      method: 'GET',
+      path: '/test/admin',
+      handler: (_request, _h) => {
+        return { type: 'admin' }
+      },
+      options: {
+        auth: {
+          scope: ['admin']
+        }
+      }
+    })
+  }
+}
+
+module.exports = RouteHelper


### PR DESCRIPTION
All JWT tokens have an expiry value. [Until recently](https://aws.amazon.com/about-aws/whats-new/2020/08/amazon-cognito-user-pools-supports-customization-of-token-expiration/) those generated by AWS Cognito all had an expiry of 1 hour.

The idea is tor protect against leaked tokens. Should one become compromised you want to limit how long it has access before it is required to refresh.

In the current [charging-module-api](https://github.com/defra/charging-module-api) we just decode the token. In this project at least we are verifying it. But we are still ignoring the expiry value.

This change will close that final security hole and update our auth strategy config to include checking the expiry value of tokens. To keep local development tolerable though we'll drive it through configuration. So locally we'll continue to ignore the expiry value but when deployed to our environments all tokens will be verified and checked properly.