### PR TITLE
Add Unescape sanitized HTML characters plugin

### DIFF
--- a/app/plugins/index.js
+++ b/app/plugins/index.js
@@ -6,6 +6,7 @@ const DisinfectPlugin = require('./disinfect.plugin')
 const HapiNowAuthPlugin = require('./hapi_now_auth.plugin')
 const HpalDebugPlugin = require('./hpal_debug.plugin')
 const RouterPlugin = require('./router.plugin')
+const UnescapePlugin = require('./unescape.plugin')
 
 module.exports = {
   AirbrakePlugin,
@@ -13,5 +14,6 @@ module.exports = {
   DisinfectPlugin,
   HapiNowAuthPlugin,
   HpalDebugPlugin,
-  RouterPlugin
+  RouterPlugin,
+  UnescapePlugin
 }

--- a/app/plugins/unescape.plugin.js
+++ b/app/plugins/unescape.plugin.js
@@ -1,0 +1,63 @@
+'use strict'
+
+const Sanitizer = require('sanitizer')
+
+/**
+ * Loop through an object and unescape any HTML escaped values
+ *
+ * This assumes you are passing in an object that may have child objects. For example
+ *
+ * ```
+ * {
+ *   age: 23,
+ *   location: 'Bristol',
+ *   name: {
+ *     firstname: 'Tom',
+ *     lastname: 'Thumb'
+ *   }
+ * }
+ * ```
+ *
+ * It uses recursion plus some ES10/2019 magic to loop through the keys (properties) in the object. When it encounters a
+ * string value it passes it to `Sanitizer.unescapeEntities()`. If it encounters another object it calls itself again!
+ *
+ * The magic comes from
+ * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries|Object.entries()}
+ * which returns an array of a given object's own enumerable string-keyed property `[key, value]` pairs. Also
+ * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/fromEntries|Object.fromEntries()}
+ * which transforms a list of key-value pairs into an object.
+ *
+ * Source: {@link https://stackoverflow.com/a/41550077/6117745}
+ *
+ * @param {Object} obj The object you wish to loop through and unescape any string values
+ *
+ */
+const unescapeObj = obj =>
+  Object.fromEntries(
+    Object.entries(obj).map(([key, val]) => {
+      if (val && typeof val === 'object') {
+        // The property is another object so use recursion and pass it back into this function
+        return [key, unescapeObj(val)]
+      } else {
+        // Unescape the value
+        return [key, Sanitizer.unescapeEntities(val)]
+      }
+    })
+  )
+
+const UnescapePlugin = {
+  name: 'unescape',
+  register: (server, _options) => {
+    server.ext('onPostAuth', (request, h) => {
+      if (!request.payload) {
+        return h.continue
+      }
+
+      request.payload = unescapeObj(request.payload)
+
+      return h.continue
+    })
+  }
+}
+
+module.exports = UnescapePlugin

--- a/server.js
+++ b/server.js
@@ -30,7 +30,9 @@ exports.deployment = async start => {
   await server.register(BlippPlugin)
   await server.register(HpalDebugPlugin)
 
-  server.ext('onRequest', OnRequestHook)
+  // TODO: Move hooks to plugins and deal with OnRequestHook being incorrectly
+  // named
+  server.ext('onCredentials', OnRequestHook)
   server.ext('onCredentials', OnCredentialsHook)
 
   await server.initialize()

--- a/server.js
+++ b/server.js
@@ -9,7 +9,8 @@ const {
   DisinfectPlugin,
   HapiNowAuthPlugin,
   HpalDebugPlugin,
-  RouterPlugin
+  RouterPlugin,
+  UnescapePlugin
 } = require('./app/plugins')
 const { OnCredentialsHook, OnRequestHook } = require('./app/hooks')
 
@@ -25,8 +26,9 @@ exports.deployment = async start => {
 
   // Register the remaining plugins
   await server.register(RouterPlugin)
-  await server.register(DisinfectPlugin)
   await server.register(AirbrakePlugin)
+  await server.register(DisinfectPlugin)
+  await server.register(UnescapePlugin)
   await server.register(BlippPlugin)
   await server.register(HpalDebugPlugin)
 

--- a/test/features/sanitise_payloads.test.js
+++ b/test/features/sanitise_payloads.test.js
@@ -1,0 +1,80 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, before } = exports.lab = Lab.script()
+const { expect } = Code
+
+// For running our service
+const { deployment } = require('../../server')
+
+// Test helpers
+const { RouteHelper } = require('../support/helpers')
+
+const options = payload => {
+  return {
+    method: 'POST',
+    url: '/test/post',
+    payload: payload
+  }
+}
+
+describe('Sanitizing requests to the API', () => {
+  let server
+
+  // Create server before each test
+  before(async () => {
+    server = await deployment()
+    RouteHelper.addPublicPostRoute(server)
+  })
+
+  describe('When a payload includes characters like &, <, and >', () => {
+    it('allows the original values to get through unescaped', async () => {
+      const requestPayload = {
+        reference: 'BESESAME001',
+        customerName: 'Bert & Ernie >< Ltd'
+      }
+
+      const response = await server.inject(options(requestPayload))
+      const responsePayload = JSON.parse(response.payload)
+
+      expect(response.statusCode).to.equal(200)
+      expect(responsePayload).to.equal(requestPayload)
+    })
+  })
+
+  describe('When a payload has sub-properties including characters like &, <, and >', () => {
+    it('allows the original values to get through unescaped', async () => {
+      const requestPayload = {
+        reference: 'BESESAME001',
+        details: {
+          customerName: 'Bert & Ernie <> Ltd',
+          location: 'Bristol'
+        }
+      }
+
+      const response = await server.inject(options(requestPayload))
+      const responsePayload = JSON.parse(response.payload)
+
+      expect(response.statusCode).to.equal(200)
+      expect(responsePayload).to.equal(requestPayload)
+    })
+  })
+
+  describe('When a payload includes malicious content', () => {
+    it('it strips it out', async () => {
+      const requestPayload = {
+        reference: 'BESESAME001',
+        customerName: '<script>alert(1)</script>'
+      }
+
+      const response = await server.inject(options(requestPayload))
+      const responsePayload = JSON.parse(response.payload)
+
+      expect(response.statusCode).to.equal(200)
+      expect(responsePayload.customerName).to.equal('')
+    })
+  })
+})

--- a/test/features/sanitise_payloads.test.js
+++ b/test/features/sanitise_payloads.test.js
@@ -34,7 +34,7 @@ describe('Sanitizing requests to the API', () => {
     it('allows the original values to get through unescaped', async () => {
       const requestPayload = {
         reference: 'BESESAME001',
-        customerName: 'Bert & Ernie >< Ltd'
+        customerName: 'Bert & Ernie <> Ltd'
       }
 
       const response = await server.inject(options(requestPayload))

--- a/test/support/helpers/route.helper.js
+++ b/test/support/helpers/route.helper.js
@@ -50,6 +50,26 @@ class RouteHelper {
       }
     })
   }
+
+  /**
+   * Adds a POST route to a Hapi server instance which will return whatever was in the payload
+   *
+   * Intended for testing plugins which may alter a payload before a controller has visibility of it.
+   *
+   * @param {Object} server A Hapi server instance
+   */
+  static addPublicPostRoute (server) {
+    server.route({
+      method: 'POST',
+      path: '/test/post',
+      handler: (request, _h) => {
+        return request.payload
+      },
+      options: {
+        auth: false
+      }
+    })
+  }
 }
 
 module.exports = RouteHelper


### PR DESCRIPTION
https://trello.com/c/cjqqnLGs
https://github.com/DEFRA/sroc-charging-module-api/pull/4

We added [Disinfect](https://github.com/genediazjr/disinfect) in PR #4 to deal with the fact we were susceptible to XSS attacks.

Disinfect not only deals with malicious content, it also escapes all content to make it safe for displaying in a browser. This means characters like `&`, `<` and `>` also get escaped. We're not worried about these in our data and feel it's for our clients to determine how to handle them in our responses.

So this change adds a new custom plugin that will unescape payloads after disinfect has escaped them.