### PR TITLE
Amend chargeValue and baselineCharge to be integers

### DIFF
--- a/app/models/charge.model.js
+++ b/app/models/charge.model.js
@@ -39,9 +39,9 @@ class Charge {
       regimeValue17: Joi.boolean().required(),
       lineAttr3: Joi.string().length(7).required(),
       chargeFinancialYear: Joi.number().required(),
-      chargeValue: Joi.number(),
+      chargeValue: Joi.number().integer(),
       lineAttr9: Joi.string(),
-      baselineCharge: Joi.number(),
+      baselineCharge: Joi.number().integer(),
       lineAttr10: Joi.string()
     }
   }


### PR DESCRIPTION
I spoke to Sally and confirmed that `chargeValue` and `baselineCharge` in the Charge model should be integers. This change amends the Joi validation to enforce this.