### PR TITLE
Update calculate charge service based on recent discussion

### DIFF
--- a/app/services/calculate_charge.service.js
+++ b/app/services/calculate_charge.service.js
@@ -1,13 +1,28 @@
 'use strict'
 
+/**
+ * This service handles the presentation of a calculate charge request to the rules
+ * service, and the translation of the response.
+ */
+
+/**
+ * Our standard is to destructure services etc. from the index, eg:
+ *   const { RulesService } = require('../services')
+ *
+ * However this cannot be done here, see https://stackoverflow.com/a/42365619 for info
+ */
 const RulesService = require('./rules.service')
 
-// This service passes a translator object to the rules service
-// The response from the rules service is used to create a new presenter which is returned
 class CalculateChargeService {
-  static async call (translator, Presenter) {
-    const response = await RulesService.call(translator)
-    return new Presenter(response)
+  /**
+   * Presents a calculate charge request to the rules service and translates the response.
+   * @param {object} presenter A presenter containing the request to be sent to the rules service
+   * @param {object} Translator A translator which will contain the response from the rules service
+   * @returns {object} An instance of Translator containing the response from the rules service
+   */
+  static async call (presenter, Translator) {
+    const response = await RulesService.call(presenter)
+    return new Translator(response)
   }
 }
 

--- a/test/services/rules.service.test.js
+++ b/test/services/rules.service.test.js
@@ -14,8 +14,8 @@ const { RulesServiceHelper } = require('../support/helpers')
 // Thing under test
 const { RulesService } = require('../../app/services')
 
-// Wraps regime, financial year and charge params in a dummy translator object for passing to rules service
-const dummyTranslator = (regime, financialYear, chargeParams = {}) => ({ regime, financialYear, chargeParams })
+// Wraps regime, financial year and charge params in a dummy presenter object for passing to rules service
+const dummyPresenter = (regime, financialYear, chargeParams = {}) => ({ regime, financialYear, chargeParams })
 
 describe('Rules service', () => {
   afterEach(async () => {
@@ -27,9 +27,9 @@ describe('Rules service', () => {
     Nock(RulesServiceHelper.url)
       .post(`/${wrls.application}/${wrls.ruleset}_2020_21`, wrls.request)
       .reply(200, wrls.response)
-    const translator = dummyTranslator('wrls', 2020, wrls.request)
+    const presenter = dummyPresenter('wrls', 2020, wrls.request)
 
-    const result = await RulesService.call(translator)
+    const result = await RulesService.call(presenter)
 
     expect(result.body).to.equal(wrls.response)
   })
@@ -44,21 +44,21 @@ describe('Rules service', () => {
     })
 
     it('for different regimes', async () => {
-      const translatorWrls = dummyTranslator('wrls', 2020)
-      const translatorCfd = dummyTranslator('cfd', 2020)
+      const presenterWrls = dummyPresenter('wrls', 2020)
+      const presenterCfd = dummyPresenter('cfd', 2020)
 
-      const { requestUrl: requestUrlWrls } = await RulesService.call(translatorWrls)
-      const { requestUrl: requestUrlCfd } = await RulesService.call(translatorCfd)
+      const { requestUrl: requestUrlWrls } = await RulesService.call(presenterWrls)
+      const { requestUrl: requestUrlCfd } = await RulesService.call(presenterCfd)
 
       expect(requestUrlWrls).to.not.equal(requestUrlCfd)
     })
 
     it('for different years', async () => {
-      const translator2019 = dummyTranslator('wrls', 2019)
-      const translator2020 = dummyTranslator('wrls', 2020)
+      const presenter2019 = dummyPresenter('wrls', 2019)
+      const presenter2020 = dummyPresenter('wrls', 2020)
 
-      const { requestUrl: requestUrl2019 } = await RulesService.call(translator2019)
-      const { requestUrl: requestUrl2020 } = await RulesService.call(translator2020)
+      const { requestUrl: requestUrl2019 } = await RulesService.call(presenter2019)
+      const { requestUrl: requestUrl2020 } = await RulesService.call(presenter2020)
 
       expect(requestUrl2019).to.not.equal(requestUrl2020)
     })


### PR DESCRIPTION
`CalculateChargeService` was one of the first bits of "calculate charge" work done. Subsequent discussion with @Cruikshanks has led to a re-evaluation of how we want it to work -- we now understand that we want to provide it with a presenter that it passes to the rules service and a translator to pass back to the caller. This change updates the terminology used in the service to reflect this, and adds some brief documentation to the service class. 