### PR TITLE
Add SOP data validation plugin

### DIFF
--- a/app/plugins/index.js
+++ b/app/plugins/index.js
@@ -6,6 +6,7 @@ const DisinfectPlugin = require('./disinfect.plugin')
 const HpalDebugPlugin = require('./hpal_debug.plugin')
 const HapiNowAuthPlugin = require('./hapi_now_auth.plugin')
 const HapiPinoPlugin = require('./hapi_pino.plugin')
+const InvalidCharactersPlugin = require('./invalid_characters.plugin')
 const RouterPlugin = require('./router.plugin')
 const UnescapePlugin = require('./unescape.plugin')
 
@@ -16,6 +17,7 @@ module.exports = {
   HpalDebugPlugin,
   HapiNowAuthPlugin,
   HapiPinoPlugin,
+  InvalidCharactersPlugin,
   RouterPlugin,
   UnescapePlugin
 }

--- a/app/plugins/invalid_characters.plugin.js
+++ b/app/plugins/invalid_characters.plugin.js
@@ -1,0 +1,38 @@
+'use strict'
+
+const Boom = require('@hapi/boom')
+
+/**
+ * Converts an object to a JSON string and then tests if it contains any of the following characters: ? £ ≤ ≥
+ *
+ * @param {Object} obj The object you wish to check for invalid characters
+ * @returns {boolean} `true` if the object contains an invalid character, else `false`
+ */
+const invalidCharacters = obj => {
+  const jsonObj = JSON.stringify(obj)
+
+  if (jsonObj.match(/[?£\u2014\u2264\u2265]/)) {
+    return true
+  }
+
+  return false
+}
+
+const InvalidCharactersPlugin = {
+  name: 'invalid_characters',
+  register: (server, _options) => {
+    server.ext('onPostAuth', (request, h) => {
+      if (!request.payload) {
+        return h.continue
+      }
+
+      if (invalidCharacters(request.payload)) {
+        throw Boom.badData('We cannot accept any request that contains the following characters: ? £ ≤ ≥')
+      }
+
+      return h.continue
+    })
+  }
+}
+
+module.exports = InvalidCharactersPlugin

--- a/server.js
+++ b/server.js
@@ -10,6 +10,7 @@ const {
   HpalDebugPlugin,
   HapiNowAuthPlugin,
   HapiPinoPlugin,
+  InvalidCharactersPlugin,
   RouterPlugin,
   UnescapePlugin
 } = require('./app/plugins')
@@ -28,6 +29,7 @@ exports.deployment = async start => {
   // Register the remaining plugins
   await server.register(RouterPlugin)
   await server.register(AirbrakePlugin)
+  await server.register(InvalidCharactersPlugin)
   await server.register(DisinfectPlugin)
   await server.register(UnescapePlugin)
   await server.register(HapiPinoPlugin(TestConfig.logInTest))

--- a/test/features/invalid_characters.test.js
+++ b/test/features/invalid_characters.test.js
@@ -1,0 +1,60 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, before } = exports.lab = Lab.script()
+const { expect } = Code
+
+// For running our service
+const { deployment } = require('../../server')
+
+// Test helpers
+const { RouteHelper } = require('../support/helpers')
+
+const options = payload => {
+  return {
+    method: 'POST',
+    url: '/test/post',
+    payload: payload
+  }
+}
+
+describe('Reject requests with invalid characters', () => {
+  let server
+
+  // Create server before each test
+  before(async () => {
+    server = await deployment()
+    RouteHelper.addPublicPostRoute(server)
+  })
+
+  describe('When a payload does not include an invalid character', () => {
+    it('accepts the request', async () => {
+      const requestPayload = {
+        reference: 'BESESAME001',
+        customerName: 'Bert & Ernie Ltd'
+      }
+
+      const response = await server.inject(options(requestPayload))
+
+      expect(response.statusCode).to.equal(200)
+    })
+  })
+
+  describe('When a payload does include an invalid character', () => {
+    it('rejects the request with the appropriate error message', async () => {
+      const requestPayload = {
+        reference: 'BESESAME001',
+        customerName: 'Bert & Ernie Ltd?'
+      }
+
+      const response = await server.inject(options(requestPayload))
+      const responsePayload = JSON.parse(response.payload)
+
+      expect(response.statusCode).to.equal(422)
+      expect(responsePayload.message).to.equal('We cannot accept any request that contains the following characters: ? £ ≤ ≥')
+    })
+  })
+})


### PR DESCRIPTION
https://trello.com/c/xa2xIrRg

The existing [charging-module-api](https://github.com/defra/charging-module-api) checks for certain characters we've been told SOP considers invalid and can't handle.

However, it does this on an ad-hoc basis at the points we currently understand to be at risk. This has the effect of making some controllers more complex and adds duplication to the code.

On the basis our purpose is to collect and transform data before sending it onto SOP we think it's clearer to just reject any request that includes these invalid characters. There is less risk if we ensure none of our data contains them. It also simplifies the code and makes it easier to maintain.

So this change adds a custom plugin which checks for the invalid characters in any request. Unlike our previous checks of the request payload this time we won't sanitize the data. Instead, we will return a 422 response highlighting that the request contains one of the SOP invalid characters.