### PR TITLE
Add back check for use of `only()` in tests to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,14 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of sonarcloud analysis
 
+      # Before we do anything, check we haven't accidentally left any `describe.only()` or `it.only(` statements in the
+      # tests
+      #
+      # Reworking of https://stackoverflow.com/a/21788642/6117745
+      - name: Temporary tag check
+        run: |
+          ! grep -R 'describe.only(\|it.only(' test
+
       # Our projects use .nvmrc files to specify the node version to use. We can read and then output it as the result
       # this step. Subsequent steps can then access the value
       - name: Read Node version


### PR DESCRIPTION
https://github.com/DEFRA/charging-module-api/pull/41
https://github.com/DEFRA/charging-module-api/pull/23

In PR #23 we added in a check to our CI for temporary tags. The original description was

---

The [Hapi Lab](https://github.com/hapijs/lab) test framework comes with the ability to run specific tests by adding `.only` to the describe block. For example

```javascript
describe.only('Sanitizing requests to the API', () => {
  // ...
})
```

This is great! Just don't forget to leave them in when pushing your commits to GitHub. Having not learnt my lesson, this adds a check for use of this to the Travis build.

---

When we moved the CI to GitHub actions in PR #41 we lost the check. Having figured how to do it, this adds the check back in.