### PR TITLE
Fix cleanse payload rejecting false booleans

### DIFF
--- a/app/plugins/clean_payload.plugin.js
+++ b/app/plugins/clean_payload.plugin.js
@@ -65,7 +65,7 @@ const cleanObj = obj =>
   )
 
 const filter = value => {
-  if (value && value !== '') {
+  if (value !== null && value !== '') {
     return true
   }
 
@@ -76,10 +76,13 @@ const cleanProperty = (key, value) => {
   if (typeof value === 'object') {
     // The property is another object so use recursion and pass it back into this function
     return [key, cleanObj(value)]
+  } else if (typeof value === 'string') {
+    // Call trim() on it and return the result
+    return [key, value.trim()]
   }
 
-  // Call trim() on it and return the result
-  return [key, value.trim()]
+  // Return the value as is
+  return [key, value]
 }
 
 const CleanPayloadPlugin = {

--- a/test/features/clean_payloads.test.js
+++ b/test/features/clean_payloads.test.js
@@ -123,4 +123,37 @@ describe('Cleaning data in requests', () => {
       expect(responsePayload.details.lastName).to.equal('Ernie')
     })
   })
+
+  describe.only('When a POST request contains boolean properties that are false', () => {
+    it('keeps them', async () => {
+      const requestPayload = {
+        reference: 'BESESAME001',
+        customerName: 'Bert & Ernie Ltd',
+        newCustomer: false
+      }
+
+      const response = await server.inject(options(requestPayload))
+      const responsePayload = JSON.parse(response.payload)
+
+      expect(response.statusCode).to.equal(200)
+      expect(responsePayload).to.contain('newCustomer')
+    })
+
+    it('keeps them in nested objects', async () => {
+      const requestPayload = {
+        reference: 'BESESAME001',
+        details: {
+          firstName: 'Bert',
+          lastName: 'Ernie',
+          newCustomer: false
+        }
+      }
+
+      const response = await server.inject(options(requestPayload))
+      const responsePayload = JSON.parse(response.payload)
+
+      expect(response.statusCode).to.equal(200)
+      expect(responsePayload.details).to.contain('newCustomer')
+    })
+  })
 })

--- a/test/features/clean_payloads.test.js
+++ b/test/features/clean_payloads.test.js
@@ -124,7 +124,7 @@ describe('Cleaning data in requests', () => {
     })
   })
 
-  describe.only('When a POST request contains boolean properties that are false', () => {
+  describe('When a POST request contains boolean properties that are false', () => {
     it('keeps them', async () => {
       const requestPayload = {
         reference: 'BESESAME001',


### PR DESCRIPTION
After merging we have spotted that the new custom `CleansePayload` plugin is filtering out properties which are boolean and set to `false`.

These are valid properties and should nto be filtered out. This change fixes the issue.