### PR TITLE
Update authorised_systems to use conventional id

### DIFF
--- a/app/auth/jwt_strategy.auth.js
+++ b/app/auth/jwt_strategy.auth.js
@@ -17,9 +17,8 @@ const authOptions = {
     const { client_id: clientId } = token.decodedJWT
 
     // Find the authorised system with a matching client ID
-    const authorisedSystem = await AuthorisedSystemModel
-      .query()
-      .findById(clientId)
+    const authorisedSystem = await AuthorisedSystemModel.query()
+      .findOne({ client_id: clientId })
 
     // We use the `options.auth.scope` property on our routes to manage authorisation and what endpoints a client can
     // access. Public endpoints have a scope of `system`. Admin can access these as well as those with only a scope of

--- a/db/migrations/20201012150934_create_authorised_systems.js
+++ b/db/migrations/20201012150934_create_authorised_systems.js
@@ -7,9 +7,10 @@ exports.up = async function (knex) {
     .schema
     .createTable(tableName, table => {
       // Primary Key
-      table.string('id').primary()
+      table.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'))
 
       // Data
+      table.string('client_id').notNullable()
       table.string('name').notNullable()
       table.string('status').notNullable().defaultTo('active')
       table.boolean('admin').defaultTo(false)

--- a/db/seeds/02_authorised_systems.js
+++ b/db/seeds/02_authorised_systems.js
@@ -9,7 +9,7 @@ exports.seed = function (knex) {
       // Inserts seed entries
       return knex('authorised_systems').insert([
         {
-          id: config.adminClientId,
+          client_id: config.adminClientId,
           name: 'admin',
           admin: true,
           status: 'active'

--- a/test/support/helpers/authorised_system.helper.js
+++ b/test/support/helpers/authorised_system.helper.js
@@ -16,11 +16,11 @@ class AuthorisedSystemHelper {
   /**
    * Create the admin system record
    *
-   * @param {string} [id] If not set will default to the configured admin client ID.
+   * @param {string} [clientId] If not set will default to the configured admin client ID.
    * @returns {Object} The result of the db insertion for your reference
    */
-  static async addAdminSystem (id) {
-    const systemId = id || AuthenticationConfig.adminClientId
+  static async addAdminSystem (clientId) {
+    const systemId = clientId || AuthenticationConfig.adminClientId
 
     return this._insertSystem(systemId, 'admin', true, 'active')
   }
@@ -28,19 +28,19 @@ class AuthorisedSystemHelper {
   /**
    * Create non-admin system record
    *
-   * @param {string} id ID you want set for the system
+   * @param {string} clientId Client ID you want set for the system
    * @param {name} name Name you want to set for the system
    * @returns {Object} The result of the db insertion for your reference
    */
-  static async addSystem (id, name) {
-    return this._insertSystem(id, name, false, 'active')
+  static async addSystem (clientId, name) {
+    return this._insertSystem(clientId, name, false, 'active')
   }
 
-  static async _insertSystem (id, name, isAdmin, status) {
+  static async _insertSystem (clientId, name, isAdmin, status) {
     return await AuthorisedSystemModel
       .query()
       .insert({
-        id: id,
+        client_id: clientId,
         name: name,
         admin: isAdmin,
         status: status


### PR DESCRIPTION
Prior to this change the ID of the authorised system record was actually the client ID generated by AWS Cognito.

We're trying to keep things as consistent as possible, so this change updates it to use a UUID as all our other tables do.

This means we need to add a new `client_id` field and use it to locate the authorised system record during the authorisation stage.