### PR TITLE
Hide skipped tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "createdbtest": "PGDATABASE=sroc_charge_test node db/create_database.js",
     "migratedb": "PGDATABASE=sroc_charge knex migrate:latest",
     "migratedbtest": "PGDATABASE=sroc_charge_test knex migrate:latest",
-    "unit-test": "PGDATABASE=sroc_charge_test lab"
+    "unit-test": "PGDATABASE=sroc_charge_test lab --silent-skips"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
By default lab lists all tests, even those that are skipped. This means having to scroll through 100+ tests to find the only one you're interested in if using `.only` to limit the tests being run. This change adds the `--silent-skips` parameter which removes skipped tests from the output.