### PR TITLE
Add new base model class

### DIFF
--- a/app/models/authorised_system.model.js
+++ b/app/models/authorised_system.model.js
@@ -1,8 +1,8 @@
 'use strict'
 
-const { Model } = require('objection')
+const BaseModel = require('./base.model')
 
-class AuthorisedSystemModel extends Model {
+class AuthorisedSystemModel extends BaseModel {
   static get tableName () {
     return 'authorised_systems'
   }

--- a/app/models/authorised_system.model.js
+++ b/app/models/authorised_system.model.js
@@ -1,9 +1,6 @@
 'use strict'
 
-const { db } = require('../../db')
 const { Model } = require('objection')
-
-Model.knex(db)
 
 class AuthorisedSystemModel extends Model {
   static get tableName () {

--- a/app/models/base.model.js
+++ b/app/models/base.model.js
@@ -1,0 +1,51 @@
+'use strict'
+
+const { db } = require('../../db')
+const { Model, snakeCaseMappers } = require('objection')
+
+Model.knex(db)
+
+class BaseModel extends Model {
+  /**
+   * An objective property we override to enable snakeCaseMappers
+   *
+   * Objective supports using snake_case names in the database and camelCase in the code. By overriding the
+   * `columnNameMappers()` static property we can tell Objective to use its snakeCaseMappers function.
+   *
+   * This means when we access a property on the model we can use camelCase even if the underlying database property
+   * was snake_case. It also means we get camelCase object keys, handy when you need to return a db query result as is
+   * in a response.
+   *
+   * Remember though that within the context of Objective queries, for example `MyModel.query().where()` we still need
+   * to use the actual database names.
+   *
+   * @see {@link https://vincit.github.io/objection.js/recipes/snake-case-to-camel-case-conversion.html}
+   */
+  static get columnNameMappers () {
+    return snakeCaseMappers()
+  }
+
+  /**
+   * An objective property we override to tell it where to search for models for relationships
+   *
+   * When setting a relationship in a model we have to provide a reference to the related model. As we need to set the
+   * relationship on both sides this leads to
+   * {@link https://vincit.github.io/objection.js/guide/relations.html#require-loops|require-loops}. We can avoid this
+   * by having the model tell Objection where to search for models for relationships. In the relationship declaration we
+   * can then just use a string value
+   *
+   * ```
+   *  // ...
+   *  relation: Model.ManyToManyRelation,
+        modelClass: 'authorised_system.model',
+      // ...
+      ```
+
+      We don't want to do this in every model so set it in the `BaseModel` as Objection recommends.
+   */
+  static get modelPaths () {
+    return [__dirname]
+  }
+}
+
+module.exports = BaseModel

--- a/app/models/base.model.js
+++ b/app/models/base.model.js
@@ -3,6 +3,9 @@
 const { db } = require('../../db')
 const { Model, snakeCaseMappers } = require('objection')
 
+// We only have to do this once in the app and then it will be set globally for Objection. As we are not using multiple
+// databases we have no need to pass it into each query we build. And setting it here means all subclasses will inherit
+// it. https://vincit.github.io/objection.js/api/model/static-methods.html#static-knex
 Model.knex(db)
 
 class BaseModel extends Model {

--- a/app/models/index.js
+++ b/app/models/index.js
@@ -1,11 +1,13 @@
 'use strict'
 
 const AuthorisedSystemModel = require('./authorised_system.model')
+const BaseModel = require('./base.model')
 const ChargeModel = require('./charge.model')
 const RegimeModel = require('./regime.model')
 
 module.exports = {
   AuthorisedSystemModel,
+  BaseModel,
   ChargeModel,
   RegimeModel
 }

--- a/app/models/regime.model.js
+++ b/app/models/regime.model.js
@@ -1,9 +1,6 @@
 'use strict'
 
-const { db } = require('../../db')
 const { Model } = require('objection')
-
-Model.knex(db)
 
 class RegimeModel extends Model {
   static get tableName () {

--- a/app/models/regime.model.js
+++ b/app/models/regime.model.js
@@ -1,8 +1,8 @@
 'use strict'
 
-const { Model } = require('objection')
+const BaseModel = require('./base.model')
 
-class RegimeModel extends Model {
+class RegimeModel extends BaseModel {
   static get tableName () {
     return 'regimes'
   }


### PR DESCRIPTION
> Most of the time you want the same configuration for all models and a good pattern is to create a `BaseModel` class and inherit all your models from that. You can then add all shared configuration to `BaseModel`.

[Objection documentation](https://vincit.github.io/objection.js/guide/models.html#models)

This work comes out of the spike we have been doing in [PR #48](https://github.com/DEFRA/sroc-charging-module-api/pull/48) adding authorisation systems and sorting out authorisation in the service.

We know we need to reference other models when creating the Objection relationships. But we also know there is the issue of [require loops](https://vincit.github.io/objection.js/guide/relations.html#require-loops). A base class helps resolve this because we can set the [modelPaths property](https://vincit.github.io/objection.js/api/model/static-properties.html#static-modelpaths) and have that inherited by all sub-classes. This means we no longer have to directly require related models.

Another benefit we've found is with handling the difference in naming conventions. In databases we use snake_case. In code we use camelCase. Objection supports this through [snakeCaseMappers()](https://vincit.github.io/objection.js/recipes/snake-case-to-camel-case-conversion.html#snake-case-to-camel-case-conversion). When you set a model's `columnNameMappers()` property to use `snakeCaseMappers()` it means when you interact with the model you can use camelCase properties. It also means when we dump it to a string, for example in a response, it uses camelCase. This is important to use because it means our response style matches the style we expect in requests.

If we set the `columnNameMappers()` property in a `BaseModel` all sub-classed models will inherit this ability.

Hence this change which helps prepare us for work to come.