### PR TITLE
Add many-to-many rel. for Auth. System and Regime

### DIFF
--- a/app/models/authorised_system.model.js
+++ b/app/models/authorised_system.model.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { Model } = require('objection')
 const BaseModel = require('./base.model')
 
 class AuthorisedSystemModel extends BaseModel {

--- a/app/models/authorised_system.model.js
+++ b/app/models/authorised_system.model.js
@@ -6,6 +6,24 @@ class AuthorisedSystemModel extends BaseModel {
   static get tableName () {
     return 'authorised_systems'
   }
+
+  static get relationMappings () {
+    return {
+      regimes: {
+        relation: Model.ManyToManyRelation,
+        modelClass: 'regime.model',
+        join: {
+          from: 'authorised_systems.id',
+          through: {
+            // authorised_systems_regimes is a join table
+            from: 'authorised_systems_regimes.authorised_system_id',
+            to: 'authorised_systems_regimes.regime_id'
+          },
+          to: 'regimes.id'
+        }
+      }
+    }
+  }
 }
 
 module.exports = AuthorisedSystemModel

--- a/app/models/regime.model.js
+++ b/app/models/regime.model.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { Model } = require('objection')
 const BaseModel = require('./base.model')
 
 class RegimeModel extends BaseModel {

--- a/app/models/regime.model.js
+++ b/app/models/regime.model.js
@@ -6,6 +6,24 @@ class RegimeModel extends BaseModel {
   static get tableName () {
     return 'regimes'
   }
+
+  static get relationMappings () {
+    return {
+      authorisedSystems: {
+        relation: Model.ManyToManyRelation,
+        modelClass: 'authorised_system.model',
+        join: {
+          from: 'regimes.id',
+          through: {
+            // authorised_systems_regimes is a join table
+            from: 'authorised_systems_regimes.regime_id',
+            to: 'authorised_systems_regimes.authorised_system_id'
+          },
+          to: 'authorised_systems.id'
+        }
+      }
+    }
+  }
 }
 
 module.exports = RegimeModel

--- a/db/migrations/20201116103729_create_authorised_systems_regimes.js
+++ b/db/migrations/20201116103729_create_authorised_systems_regimes.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const tableName = 'authorised_systems_regimes'
+
+exports.up = async function (knex) {
+  await knex
+    .schema
+    .createTable(tableName, table => {
+      // Primary Key
+      table.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'))
+
+      // Data
+      table.uuid('authorised_system_id').notNullable()
+      table.uuid('regime_id').notNullable()
+
+      // Automatic timestamps
+      table.timestamps(false, true)
+    })
+
+  await knex.raw(`
+    CREATE TRIGGER update_timestamp
+    BEFORE UPDATE
+    ON ${tableName}
+    FOR EACH ROW
+    EXECUTE PROCEDURE update_timestamp();
+  `)
+}
+
+exports.down = async function (knex) {
+  return knex
+    .schema
+    .dropTableIfExists(tableName)
+}


### PR DESCRIPTION
An authorised system is a user in the context of our service. Any user that is not an admin requires specific authorisations to be granted for access to the different regimes. We hold a list of the available regimes. Each holds details such as their 'slug' (wrls, cfd, pas, and wml), name and Pre-SROC cutoff date.

So we need to create a many-to-many relationship between the two if we want to start properly authorising requests to none admin endpaths. We also need it to support adding new authorised systems (these changes will come in later PR's).