### PR TITLE
Implement regime authorisation fully

### DIFF
--- a/app/models/authorised_system.model.js
+++ b/app/models/authorised_system.model.js
@@ -1,5 +1,9 @@
 'use strict'
 
+/**
+ * @module AuthorisedSystemModel
+ */
+
 const { Model } = require('objection')
 const BaseModel = require('./base.model')
 

--- a/app/models/base.model.js
+++ b/app/models/base.model.js
@@ -1,5 +1,9 @@
 'use strict'
 
+/**
+ * @module BaseModel
+ */
+
 const { db } = require('../../db')
 const { Model, snakeCaseMappers } = require('objection')
 

--- a/app/models/charge.model.js
+++ b/app/models/charge.model.js
@@ -1,5 +1,8 @@
 'use strict'
 
+/**
+ * @module Charge
+ */
 class Charge {
   constructor (data) {
     Object.assign(this, data)

--- a/app/models/regime.model.js
+++ b/app/models/regime.model.js
@@ -1,5 +1,9 @@
 'use strict'
 
+/**
+ * @module RegimeModel
+ */
+
 const { Model } = require('objection')
 const BaseModel = require('./base.model')
 

--- a/app/plugins/authorisation.plugin.js
+++ b/app/plugins/authorisation.plugin.js
@@ -1,8 +1,7 @@
 'use strict'
 
-'use strict'
-
 const Boom = require('@hapi/boom')
+const { AuthorisationService } = require('../services')
 
 /**
  * Checks the client is authorised to access the requested endpoint
@@ -10,35 +9,32 @@ const Boom = require('@hapi/boom')
  * Paths under the `/admin` root are only accessible to requests made with bearer tokens generated using the admin
  * client ID.
  *
- * Paths which have a regime, for example, `/v1/{regimeId}/billruns`are accessible to the admin user plus any request
- * made with a bearer token generated using a recognised client ID.
+ * Paths which have a regime, for example, `/v1/{regimeId}/billruns` are accessible to the admin user plus any request
+ * made with a bearer token generated using a recognised client ID. However, the client ID must also be linked to the
+ * matching regime.
  *
  * If it's not on the `/admin` path and doesn't feature a regime, for example, `/status` then all requests are accepted.
+ *
+ * If the request _is_ for a regime endpoint we take advantage of the fact the `AuthorisationService` returns an
+ * instance of `RegimeModel` and store it in the `request.app`. This means any subsequent need for accessing the regime
+ * record can be served by grabbing it from the request. See
+ * {@link https://hapi.dev/api/?v=20.0.2#-requestapp|request.app} for details.
  */
 const AuthorisationPlugin = {
   name: 'authorisation',
   register: (server, _options) => {
-    server.ext('onCredentials', (request, h) => {
+    server.ext('onCredentials', async (request, h) => {
       const { user } = request.auth.credentials
       const { regimeId } = request.params
 
-      // admin is always authorised to access regimes
-      if (user.admin) {
-        request.log(['INFO'], 'User is an admin')
+      const authorisationResult = await AuthorisationService.go(user, regimeId)
+
+      if (authorisationResult.authorised) {
+        request.app.regime = authorisationResult.regime
         return h.continue
       }
 
-      // No specific authorisation is needed if the endpoint doesn't contain a regime
-      if (!regimeId) {
-        request.log(['INFO'], 'No authorisation needed for this endpoint')
-        return h.continue
-      }
-
-      if (regimeId !== user.name) {
-        return Boom.forbidden(`Unauthorised for regime '${regimeId}'`)
-      }
-
-      return h.continue
+      throw Boom.forbidden(`Unauthorised for regime '${regimeId}'`)
     })
   }
 }

--- a/app/services/authorisation.service.js
+++ b/app/services/authorisation.service.js
@@ -1,0 +1,72 @@
+'use strict'
+
+/**
+ * @module AuthorisationService
+ */
+
+/**
+ * Determine if a request is authorised to proceed
+ *
+ * Used by the `AuthorisationPlugin` to determine if a request can proceed. It has to cover a number of scenarios
+ *
+ * - requests to a public endpoint like `/status`
+ * - requests to 'admin' only endpoints like `/admin/regimes`
+ * - requests to a regime endpoint like `/v1/wrls/billruns`
+ *
+ * You don't need to be authenticated to access a public endpoint. So in those cases it handles both `user` and
+ * `regimeSlug` being `null`.
+ *
+ * Only users where the `admin` flag is set to `true` can access our 'admin' endpoints. And you can only create admins
+ * by directly adding them to the database! However, they can also access any regime endpoint irrespective of what
+ * regime is specified. In these cases it handles `user` being instantiated but the `regimeSlug` being `null`.
+ *
+ * The final scenario is the most common. This is system users who will have authenticated successfully but their
+ * `admin` flag will be false. They will be linked to a regime, but not necessarily the one being requested.
+ *
+ * In all cases it returns an `Object` which callers can use to determine if the request is authorised. It also contains
+ * the matched instance of `RegimeModel` if the slug was specified and matched.
+ *
+ * ```
+ * { authorised: false, regime: MatchedRegime }
+ * ```
+ *
+ * @param {module:AuthorisedSystemModel} [user=null] An instance of `AuthorisedSystemModel` which represents the 'user'
+ *  making the request
+ * @param {string} [regimeSlug=null] The short-code (slug) for the regime the request is for.
+ * @returns {Object} Returns an object which states whether the request is authorised and an instance of `RegimeModel`
+ * if one was specified and matched
+ */
+class AuthorisationService {
+  static async go (user = null, regimeSlug = null) {
+    const result = { authorised: false, regime: null }
+    if (this._endpointHasNoRegime(regimeSlug) || this._userIsAnAdmin(user)) {
+      result.authorised = true
+    } else {
+      const regime = await this._userAuthorisedRegime(user, regimeSlug)
+      if (regime) {
+        result.authorised = true
+        result.regime = regime
+      }
+    }
+
+    return result
+  }
+
+  static _userIsAnAdmin (user) {
+    return user.admin
+  }
+
+  static _endpointHasNoRegime (regimeSlug) {
+    return (!regimeSlug)
+  }
+
+  static async _userAuthorisedRegime (user, regimeSlug) {
+    const result = await user
+      .$relatedQuery('regimes')
+      .findOne({ slug: regimeSlug })
+
+    return result
+  }
+}
+
+module.exports = AuthorisationService

--- a/app/services/authorisation.service.js
+++ b/app/services/authorisation.service.js
@@ -61,11 +61,9 @@ class AuthorisationService {
   }
 
   static async _userAuthorisedRegime (user, regimeSlug) {
-    const result = await user
+    return await user
       .$relatedQuery('regimes')
       .findOne({ slug: regimeSlug })
-
-    return result
   }
 }
 

--- a/app/services/authorisation.service.js
+++ b/app/services/authorisation.service.js
@@ -60,8 +60,8 @@ class AuthorisationService {
     return (!regimeSlug)
   }
 
-  static async _userAuthorisedRegime (user, regimeSlug) {
-    return await user
+  static _userAuthorisedRegime (user, regimeSlug) {
+    return user
       .$relatedQuery('regimes')
       .findOne({ slug: regimeSlug })
   }

--- a/app/services/calculate_charge.service.js
+++ b/app/services/calculate_charge.service.js
@@ -1,6 +1,10 @@
 'use strict'
 
 /**
+ * @module CalculateChargeService
+ */
+
+/**
  * This service handles the presentation of a calculate charge request to the rules
  * service, and the translation of the response.
  */

--- a/app/services/cognito_jwt_to_pem.service.js
+++ b/app/services/cognito_jwt_to_pem.service.js
@@ -1,5 +1,9 @@
 'use strict'
 
+/**
+ * @module CognitoJwtToPemService
+ */
+
 const JwkToPem = require('jwk-to-pem')
 
 class CognitoJwtToPemService {

--- a/app/services/index.js
+++ b/app/services/index.js
@@ -1,11 +1,13 @@
 'use strict'
 
+const AuthorisationService = require('./authorisation.service')
 const CalculateChargeService = require('./calculate_charge.service')
 const CognitoJwtToPemService = require('./cognito_jwt_to_pem.service')
 const ObjectCleaningService = require('./object_cleaning.service')
 const RulesService = require('./rules.service')
 
 module.exports = {
+  AuthorisationService,
   CalculateChargeService,
   CognitoJwtToPemService,
   ObjectCleaningService,

--- a/app/services/object_cleaning.service.js
+++ b/app/services/object_cleaning.service.js
@@ -1,5 +1,9 @@
 'use strict'
 
+/**
+ * @module ObjectCleaningService
+ */
+
 const Sanitizer = require('sanitizer')
 
 /**

--- a/app/services/rules.service.js
+++ b/app/services/rules.service.js
@@ -1,5 +1,9 @@
 'use strict'
 
+/**
+ * @module RulesService
+ */
+
 const Got = require('got')
 const Tunnel = require('tunnel')
 

--- a/test/features/authorisation.test.js
+++ b/test/features/authorisation.test.js
@@ -12,7 +12,13 @@ const { expect } = Code
 const { deployment } = require('../../server')
 
 // Test helpers
-const { AuthorisationHelper, AuthorisedSystemHelper, DatabaseHelper, RouteHelper } = require('../support/helpers')
+const {
+  AuthorisationHelper,
+  AuthorisedSystemHelper,
+  DatabaseHelper,
+  RegimeHelper,
+  RouteHelper
+} = require('../support/helpers')
 
 // Things we need to stub
 const JsonWebToken = require('jsonwebtoken')
@@ -20,12 +26,14 @@ const JsonWebToken = require('jsonwebtoken')
 describe('Authorisation with the API', () => {
   let server
   let authToken
-  const nonAdminClientId = 'k7ehotrs1fqer7hoaslv7ilmr'
+  const nonAdminClientId = '1234546789'
 
   before(async () => {
     await DatabaseHelper.clean()
     await AuthorisedSystemHelper.addAdminSystem()
-    await AuthorisedSystemHelper.addSystem(nonAdminClientId, 'wrls')
+
+    const regime = await RegimeHelper.addRegime('wrls', 'Water')
+    await AuthorisedSystemHelper.addSystem(nonAdminClientId, 'system', [regime])
 
     server = await deployment()
     RouteHelper.addAdminRoute(server)

--- a/test/services/authorisation.service.test.js
+++ b/test/services/authorisation.service.test.js
@@ -1,0 +1,93 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const { AuthorisedSystemHelper, DatabaseHelper, RegimeHelper } = require('../support/helpers')
+
+// Thing under test
+const { AuthorisationService } = require('../../app/services')
+
+describe('Authorisation service', () => {
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+  })
+
+  describe("When there is no regime 'slug'", () => {
+    describe('nor a user', () => {
+      it("returns 'authorised' with no regime", async () => {
+        const result = await AuthorisationService.go()
+
+        expect(result.authorised).to.equal(true)
+        expect(result.regime).to.equal(null)
+      })
+    })
+
+    describe("but an 'admin' user", () => {
+      it("returns 'authorised' with no regime", async () => {
+        const user = await AuthorisedSystemHelper.addAdminSystem()
+        const result = await AuthorisationService.go(user)
+
+        expect(result.authorised).to.equal(true)
+        expect(result.regime).to.equal(null)
+      })
+    })
+
+    describe("but a 'system' user", () => {
+      it("returns 'authorised' with no regime", async () => {
+        const user = await AuthorisedSystemHelper.addSystem('1234546789', 'system')
+        const result = await AuthorisationService.go(user)
+
+        expect(result.authorised).to.equal(true)
+        expect(result.regime).to.equal(null)
+      })
+    })
+  })
+
+  describe("When there is a regime 'slug'", () => {
+    describe('but no user', () => {
+      it('throws an error', async () => {
+        await expect(AuthorisationService.go(null, 'wrls')).to.reject(TypeError)
+      })
+    })
+
+    describe("and an 'admin' user", () => {
+      it("returns 'authorised' with no regime", async () => {
+        const user = await AuthorisedSystemHelper.addAdminSystem()
+        const result = await AuthorisationService.go(user, 'wrls')
+
+        expect(result.authorised).to.equal(true)
+        expect(result.regime).to.equal(null)
+      })
+    })
+
+    describe("and a 'system' user", () => {
+      describe('and the user is authorised for that regime', () => {
+        it("returns 'authorised' and a regime", async () => {
+          const regime = await RegimeHelper.addRegime('wrls', 'water')
+          const user = await AuthorisedSystemHelper.addSystem('1234546789', 'system', [regime])
+          const result = await AuthorisationService.go(user, 'wrls')
+
+          expect(result.authorised).to.equal(true)
+          expect(result.regime).to.contain('id')
+        })
+      })
+
+      describe('and the user is not authorised for that regime', () => {
+        it("returns 'unauthorised' and no regime", async () => {
+          const regime = await RegimeHelper.addRegime('wrls', 'water')
+          const user = await AuthorisedSystemHelper.addSystem('1234546789', 'system', [regime])
+          const result = await AuthorisationService.go(user, 'cfd')
+
+          expect(result.authorised).to.equal(false)
+          expect(result.regime).to.equal(null)
+        })
+      })
+    })
+  })
+})

--- a/test/support/helpers/index.js
+++ b/test/support/helpers/index.js
@@ -3,6 +3,7 @@
 const AuthorisationHelper = require('./authorisation.helper')
 const AuthorisedSystemHelper = require('./authorised_system.helper')
 const DatabaseHelper = require('./database.helper')
+const RegimeHelper = require('./regime.helper')
 const RouteHelper = require('./route.helper')
 const RulesServiceHelper = require('./rules_service.helper')
 
@@ -10,6 +11,7 @@ module.exports = {
   AuthorisationHelper,
   AuthorisedSystemHelper,
   DatabaseHelper,
+  RegimeHelper,
   RouteHelper,
   RulesServiceHelper
 }

--- a/test/support/helpers/regime.helper.js
+++ b/test/support/helpers/regime.helper.js
@@ -1,0 +1,36 @@
+'use strict'
+
+const { RegimeModel } = require('../../../app/models')
+
+/**
+ * Use to help wwith creating 'Regime' records
+ *
+ * The API is intended to support multiple regimes. Each supported regime is recorded in our 'regimes' table and
+ * represented in the code by `RegimeModel`.
+ *
+ * Some endpoints will access the regime to determine how to responded. The most common usage though is checking if a
+ * 'user' (authorised system) is permitted to access endpoints for a specific regime. So as part of being able to test
+ * the API we need to be able to create both regimes and authorised systems.
+ */
+class RegimeHelper {
+  /**
+   * Create a regime
+   *
+   * @param {string} slug Short-code for the regime. Is how we match regime endpoints to regimes in our database
+   * @param {string} name Name for the regiime
+   * @returns {module:RegimeModel} The newly created instance of `RegimeModel`.
+   */
+  static async addRegime (slug, name) {
+    const regime = RegimeModel.query()
+      .insert({
+        slug: slug,
+        name: name,
+        pre_sroc_cutoff_date: '2018-04-01'
+      })
+      .returning('*')
+
+    return regime
+  }
+}
+
+module.exports = RegimeHelper

--- a/test/support/helpers/regime.helper.js
+++ b/test/support/helpers/regime.helper.js
@@ -21,15 +21,13 @@ class RegimeHelper {
    * @returns {module:RegimeModel} The newly created instance of `RegimeModel`.
    */
   static async addRegime (slug, name) {
-    const regime = RegimeModel.query()
+    return await RegimeModel.query()
       .insert({
         slug: slug,
         name: name,
         pre_sroc_cutoff_date: '2018-04-01'
       })
       .returning('*')
-
-    return regime
   }
 }
 

--- a/test/support/helpers/regime.helper.js
+++ b/test/support/helpers/regime.helper.js
@@ -20,8 +20,8 @@ class RegimeHelper {
    * @param {string} name Name for the regiime
    * @returns {module:RegimeModel} The newly created instance of `RegimeModel`.
    */
-  static async addRegime (slug, name) {
-    return await RegimeModel.query()
+  static addRegime (slug, name) {
+    return RegimeModel.query()
       .insert({
         slug: slug,
         name: name,


### PR DESCRIPTION
Currently, our authorisation mimics how authorisation should happen. It handles admin and public requests. But requests to 'regime' endpoints we mimic with a simple check that the username matches the requested regime.

What it should actually be doing is checking the requested regime against the regimes the system user is linked to.

Now we have the `RegimeModel` and `AuthorisedSystemModel` properly linked via [Objection](https://github.com/vincit/objection.js) we can do this.

This change adds a new service to handle the checking. We also needed to add a new regimes test helper to support this.

Another feature is we have to query the database for the regime as part of the checking. To avoid subsequent endpoints needing to do this we stash the `RegimeModel` instance in [request.app](https://hapi.dev/api/?v=20.0.2#-requestapp).