### PR TITLE
Change .call() to .go()

### DIFF
--- a/app/auth/jwt_strategy.auth.js
+++ b/app/auth/jwt_strategy.auth.js
@@ -6,7 +6,7 @@ const { AuthorisedSystemModel } = require('../models')
 
 const authOptions = {
   verifyJWT: true,
-  keychain: CognitoJwtToPemService.call(AuthenticationConfig.environment),
+  keychain: CognitoJwtToPemService.go(AuthenticationConfig.environment),
   verifyOptions: {
     algorithms: ['RS256'],
     ignoreExpiration: AuthenticationConfig.ignoreJwtExpiration

--- a/app/controllers/sroc/calculate_charge.controller.js
+++ b/app/controllers/sroc/calculate_charge.controller.js
@@ -22,12 +22,12 @@ class CalculateChargeController extends BaseCalculateChargeController {
 
   static _presentRequest (charge, regime) {
     const requestPresenter = new RulesServicePresenter({ ...charge, regime })
-    return CalculateChargeService.call(requestPresenter.call(), RulesServiceTranslator)
+    return CalculateChargeService.go(requestPresenter.go(), RulesServiceTranslator)
   }
 
   static _presentResponse (charge) {
     const responsePresenter = new ChargePresenter(charge)
-    return responsePresenter.call()
+    return responsePresenter.go()
   }
 }
 

--- a/app/plugins/payload_cleaner.plugin.js
+++ b/app/plugins/payload_cleaner.plugin.js
@@ -79,7 +79,7 @@ const PayloadCleanerPlugin = {
         return h.continue
       }
 
-      request.payload = ObjectCleaningService.call(request.payload)
+      request.payload = ObjectCleaningService.go(request.payload)
 
       return h.continue
     })

--- a/app/presenters/base.presenter.js
+++ b/app/presenters/base.presenter.js
@@ -5,7 +5,7 @@ class BasePresenter {
     this._data = data
   }
 
-  call () {
+  go () {
     return this._presentation(this._data)
   }
 

--- a/app/services/calculate_charge.service.js
+++ b/app/services/calculate_charge.service.js
@@ -20,8 +20,8 @@ class CalculateChargeService {
    * @param {object} Translator A translator which will contain the response from the rules service
    * @returns {object} An instance of Translator containing the response from the rules service
    */
-  static async call (presenter, Translator) {
-    const response = await RulesService.call(presenter)
+  static async go (presenter, Translator) {
+    const response = await RulesService.go(presenter)
     return new Translator(response.body)
   }
 }

--- a/app/services/cognito_jwt_to_pem.service.js
+++ b/app/services/cognito_jwt_to_pem.service.js
@@ -3,7 +3,7 @@
 const JwkToPem = require('jwk-to-pem')
 
 class CognitoJwtToPemService {
-  static call (environment) {
+  static go (environment) {
     return this._convertJwksToPems(environment)
   }
 

--- a/app/services/object_cleaning.service.js
+++ b/app/services/object_cleaning.service.js
@@ -71,7 +71,7 @@ const Sanitizer = require('sanitizer')
  * * @module ObjectCleaningService
  */
 class ObjectCleaningService {
-  static call (obj) {
+  static go (obj) {
     return this._cleanObject(obj)
   }
 

--- a/app/services/rules.service.js
+++ b/app/services/rules.service.js
@@ -10,7 +10,7 @@ class RulesService {
   // * Regime is the regime in lower case text, eg. wrls
   // * financialYear is the 4-digit year, eg. 2020
   // * chargeParams is an object containing the parameters to be passed to the rules service
-  static call (presenter) {
+  static go (presenter) {
     const { url, username, password, httpProxy } = RulesServiceConfig
     const { regime, financialYear, chargeParams } = presenter
     const path = this._makeRulesPath(regime, financialYear)

--- a/test/presenters/base.presenter.test.js
+++ b/test/presenters/base.presenter.test.js
@@ -24,7 +24,7 @@ describe('Base presenter', () => {
 
     const testData = { before: true }
     const testPresenter = new BasePresenter(testData)
-    const presentation = testPresenter.call()
+    const presentation = testPresenter.go()
 
     expect(presentation.after).to.equal(true)
   })
@@ -33,6 +33,6 @@ describe('Base presenter', () => {
     const testData = { before: true }
     const testPresenter = new BasePresenter(testData)
 
-    expect(() => testPresenter.call()).to.throw('You need to specify _presentation in the child presenter')
+    expect(() => testPresenter.go()).to.throw('You need to specify _presentation in the child presenter')
   })
 })

--- a/test/presenters/charge.presenter.test.js
+++ b/test/presenters/charge.presenter.test.js
@@ -15,7 +15,7 @@ describe('Charge presenter', () => {
     it('negative value when chargeCredit is true', async () => {
       const testData = { chargeValue: 100, chargeCredit: true }
       const testPresenter = new ChargePresenter(testData)
-      const presentation = testPresenter.call()
+      const presentation = testPresenter.go()
 
       expect(presentation.chargeValue).to.equal(-100)
     })
@@ -23,7 +23,7 @@ describe('Charge presenter', () => {
     it('positive value when chargeCredit is false', async () => {
       const testData = { chargeValue: 100, chargeCredit: false }
       const testPresenter = new ChargePresenter(testData)
-      const presentation = testPresenter.call()
+      const presentation = testPresenter.go()
 
       expect(presentation.chargeValue).to.equal(100)
     })

--- a/test/services/calculate_charge.service.test.js
+++ b/test/services/calculate_charge.service.test.js
@@ -20,7 +20,7 @@ describe('Charge service', () => {
   let rulesStub
 
   beforeEach(async () => {
-    rulesStub = Sinon.stub(RulesService, 'call').callsFake(async (data) => { return { body: data } })
+    rulesStub = Sinon.stub(RulesService, 'go').callsFake(async (data) => { return { body: data } })
   })
 
   afterEach(async () => {
@@ -30,7 +30,7 @@ describe('Charge service', () => {
   it('calls the rules service', async () => {
     const translator = { translator: true }
 
-    await CalculateChargeService.call(translator, Presenter)
+    await CalculateChargeService.go(translator, Presenter)
 
     expect(rulesStub.calledOnce).to.be.true()
   })
@@ -38,7 +38,7 @@ describe('Charge service', () => {
   it('returns a presenter containing the rules service response', async () => {
     const translator = { test: true }
 
-    const charge = await CalculateChargeService.call(translator, Presenter)
+    const charge = await CalculateChargeService.go(translator, Presenter)
 
     expect(charge).to.be.an.instanceOf(Presenter)
     expect(charge.response).to.equal(translator)

--- a/test/services/object_cleaning.service.test.js
+++ b/test/services/object_cleaning.service.test.js
@@ -20,7 +20,7 @@ describe('Object cleaning service', () => {
         customerName: 'Bert & Ernie  '
       }
 
-      const cleanedObject = ObjectCleaningService.call(dirtyObject)
+      const cleanedObject = ObjectCleaningService.go(dirtyObject)
       expect(cleanedObject.customerName).to.equal('Bert & Ernie')
     })
 
@@ -33,7 +33,7 @@ describe('Object cleaning service', () => {
         }
       }
 
-      const cleanedObject = ObjectCleaningService.call(dirtyObject)
+      const cleanedObject = ObjectCleaningService.go(dirtyObject)
       expect(cleanedObject.details.firstName).to.equal('Bert')
       expect(cleanedObject.details.lastName).to.equal('Ernie')
     })
@@ -44,7 +44,7 @@ describe('Object cleaning service', () => {
         codes: [' ABD1 ', 'B1 ', ' C2']
       }
 
-      const cleanedObject = ObjectCleaningService.call(dirtyObject)
+      const cleanedObject = ObjectCleaningService.go(dirtyObject)
       expect(cleanedObject.codes).to.equal(['ABD1', 'B1', 'C2'])
     })
 
@@ -57,7 +57,7 @@ describe('Object cleaning service', () => {
         ]
       }
 
-      const cleanedObject = ObjectCleaningService.call(dirtyObject)
+      const cleanedObject = ObjectCleaningService.go(dirtyObject)
       expect(cleanedObject.contacts[0].firstName).to.equal('Bert')
       expect(cleanedObject.contacts[0].lastName).to.equal('Ernie')
     })
@@ -70,7 +70,7 @@ describe('Object cleaning service', () => {
         customerName: ' '
       }
 
-      const cleanedObject = ObjectCleaningService.call(dirtyObject)
+      const cleanedObject = ObjectCleaningService.go(dirtyObject)
       expect(cleanedObject).to.not.contain('customerName')
     })
 
@@ -83,7 +83,7 @@ describe('Object cleaning service', () => {
         }
       }
 
-      const cleanedObject = ObjectCleaningService.call(dirtyObject)
+      const cleanedObject = ObjectCleaningService.go(dirtyObject)
       expect(cleanedObject.details).to.not.contain('firstName')
       expect(cleanedObject.details).to.contain('lastName')
     })
@@ -94,7 +94,7 @@ describe('Object cleaning service', () => {
         codes: [' ABD1 ', ' ', 'C2']
       }
 
-      const cleanedObject = ObjectCleaningService.call(dirtyObject)
+      const cleanedObject = ObjectCleaningService.go(dirtyObject)
       expect(cleanedObject.codes).to.equal(['ABD1', 'C2'])
     })
 
@@ -107,7 +107,7 @@ describe('Object cleaning service', () => {
         ]
       }
 
-      const cleanedObject = ObjectCleaningService.call(dirtyObject)
+      const cleanedObject = ObjectCleaningService.go(dirtyObject)
       expect(cleanedObject.contacts[0]).to.contain('firstName')
       expect(cleanedObject.contacts[0]).to.not.contain('lastName')
     })
@@ -120,7 +120,7 @@ describe('Object cleaning service', () => {
         customerName: ''
       }
 
-      const cleanedObject = ObjectCleaningService.call(dirtyObject)
+      const cleanedObject = ObjectCleaningService.go(dirtyObject)
       expect(cleanedObject).to.not.contain('customerName')
     })
 
@@ -133,7 +133,7 @@ describe('Object cleaning service', () => {
         }
       }
 
-      const cleanedObject = ObjectCleaningService.call(dirtyObject)
+      const cleanedObject = ObjectCleaningService.go(dirtyObject)
       expect(cleanedObject.details).to.not.contain('firstName')
       expect(cleanedObject.details).to.contain('lastName')
     })
@@ -144,7 +144,7 @@ describe('Object cleaning service', () => {
         codes: [' ABD1 ', '', 'C2']
       }
 
-      const cleanedObject = ObjectCleaningService.call(dirtyObject)
+      const cleanedObject = ObjectCleaningService.go(dirtyObject)
       expect(cleanedObject.codes).to.equal(['ABD1', 'C2'])
     })
 
@@ -157,7 +157,7 @@ describe('Object cleaning service', () => {
         ]
       }
 
-      const cleanedObject = ObjectCleaningService.call(dirtyObject)
+      const cleanedObject = ObjectCleaningService.go(dirtyObject)
       expect(cleanedObject.contacts[0]).to.contain('firstName')
       expect(cleanedObject.contacts[0]).to.not.contain('lastName')
     })
@@ -170,7 +170,7 @@ describe('Object cleaning service', () => {
         customerName: null
       }
 
-      const cleanedObject = ObjectCleaningService.call(dirtyObject)
+      const cleanedObject = ObjectCleaningService.go(dirtyObject)
       expect(cleanedObject).to.not.contain('customerName')
     })
 
@@ -183,7 +183,7 @@ describe('Object cleaning service', () => {
         }
       }
 
-      const cleanedObject = ObjectCleaningService.call(dirtyObject)
+      const cleanedObject = ObjectCleaningService.go(dirtyObject)
       expect(cleanedObject.details).to.not.contain('firstName')
       expect(cleanedObject.details).to.contain('lastName')
     })
@@ -194,7 +194,7 @@ describe('Object cleaning service', () => {
         codes: [' ABD1 ', null, 'C2']
       }
 
-      const cleanedObject = ObjectCleaningService.call(dirtyObject)
+      const cleanedObject = ObjectCleaningService.go(dirtyObject)
       expect(cleanedObject.codes).to.equal(['ABD1', 'C2'])
     })
 
@@ -207,7 +207,7 @@ describe('Object cleaning service', () => {
         ]
       }
 
-      const cleanedObject = ObjectCleaningService.call(dirtyObject)
+      const cleanedObject = ObjectCleaningService.go(dirtyObject)
       expect(cleanedObject.contacts[0]).to.contain('firstName')
       expect(cleanedObject.contacts[0]).to.not.contain('lastName')
     })
@@ -221,7 +221,7 @@ describe('Object cleaning service', () => {
         hasOrders: false
       }
 
-      const cleanedObject = ObjectCleaningService.call(dirtyObject)
+      const cleanedObject = ObjectCleaningService.go(dirtyObject)
       expect(cleanedObject).to.equal(dirtyObject)
     })
 
@@ -234,7 +234,7 @@ describe('Object cleaning service', () => {
         }
       }
 
-      const cleanedObject = ObjectCleaningService.call(dirtyObject)
+      const cleanedObject = ObjectCleaningService.go(dirtyObject)
       expect(cleanedObject).to.equal(dirtyObject)
     })
 
@@ -244,7 +244,7 @@ describe('Object cleaning service', () => {
         preferences: [true, false, true]
       }
 
-      const cleanedObject = ObjectCleaningService.call(dirtyObject)
+      const cleanedObject = ObjectCleaningService.go(dirtyObject)
       expect(cleanedObject).to.equal(dirtyObject)
     })
   })
@@ -257,7 +257,7 @@ describe('Object cleaning service', () => {
         lines: 5
       }
 
-      const cleanedObject = ObjectCleaningService.call(dirtyObject)
+      const cleanedObject = ObjectCleaningService.go(dirtyObject)
       expect(cleanedObject).to.equal(dirtyObject)
     })
 
@@ -270,7 +270,7 @@ describe('Object cleaning service', () => {
         }
       }
 
-      const cleanedObject = ObjectCleaningService.call(dirtyObject)
+      const cleanedObject = ObjectCleaningService.go(dirtyObject)
       expect(cleanedObject).to.equal(dirtyObject)
     })
 
@@ -280,7 +280,7 @@ describe('Object cleaning service', () => {
         lineValues: [10.0, 11.54, 2.99]
       }
 
-      const cleanedObject = ObjectCleaningService.call(dirtyObject)
+      const cleanedObject = ObjectCleaningService.go(dirtyObject)
       expect(cleanedObject).to.equal(dirtyObject)
     })
   })
@@ -292,7 +292,7 @@ describe('Object cleaning service', () => {
         customerName: 'Bert< & >Ernie'
       }
 
-      const cleanedObject = ObjectCleaningService.call(dirtyObject)
+      const cleanedObject = ObjectCleaningService.go(dirtyObject)
       expect(cleanedObject).to.equal(dirtyObject)
     })
 
@@ -305,7 +305,7 @@ describe('Object cleaning service', () => {
         }
       }
 
-      const cleanedObject = ObjectCleaningService.call(dirtyObject)
+      const cleanedObject = ObjectCleaningService.go(dirtyObject)
       expect(cleanedObject).to.equal(dirtyObject)
     })
 
@@ -315,7 +315,7 @@ describe('Object cleaning service', () => {
         codes: ['A1&', 'B2<', 'C3>']
       }
 
-      const cleanedObject = ObjectCleaningService.call(dirtyObject)
+      const cleanedObject = ObjectCleaningService.go(dirtyObject)
       expect(cleanedObject).to.equal(dirtyObject)
     })
   })
@@ -327,7 +327,7 @@ describe('Object cleaning service', () => {
         customerName: '<script>alert(1)</script>'
       }
 
-      const cleanedObject = ObjectCleaningService.call(dirtyObject)
+      const cleanedObject = ObjectCleaningService.go(dirtyObject)
       expect(cleanedObject).to.not.contain('customerName')
     })
 
@@ -340,7 +340,7 @@ describe('Object cleaning service', () => {
         }
       }
 
-      const cleanedObject = ObjectCleaningService.call(dirtyObject)
+      const cleanedObject = ObjectCleaningService.go(dirtyObject)
       expect(cleanedObject.details).to.not.contain('firstName')
       expect(cleanedObject.details).to.contain('lastName')
     })
@@ -351,7 +351,7 @@ describe('Object cleaning service', () => {
         codes: ['ABD1', '<script>alert(1)</script>', 'C2']
       }
 
-      const cleanedObject = ObjectCleaningService.call(dirtyObject)
+      const cleanedObject = ObjectCleaningService.go(dirtyObject)
       expect(cleanedObject.codes).to.equal(['ABD1', 'C2'])
     })
   })

--- a/test/services/rules.service.test.js
+++ b/test/services/rules.service.test.js
@@ -29,7 +29,7 @@ describe('Rules service', () => {
       .reply(200, wrls.response)
     const presenter = dummyPresenter('wrls', 2020, wrls.request)
 
-    const result = await RulesService.call(presenter)
+    const result = await RulesService.go(presenter)
 
     expect(result.body).to.equal(wrls.response)
   })
@@ -47,8 +47,8 @@ describe('Rules service', () => {
       const presenterWrls = dummyPresenter('wrls', 2020)
       const presenterCfd = dummyPresenter('cfd', 2020)
 
-      const { requestUrl: requestUrlWrls } = await RulesService.call(presenterWrls)
-      const { requestUrl: requestUrlCfd } = await RulesService.call(presenterCfd)
+      const { requestUrl: requestUrlWrls } = await RulesService.go(presenterWrls)
+      const { requestUrl: requestUrlCfd } = await RulesService.go(presenterCfd)
 
       expect(requestUrlWrls).to.not.equal(requestUrlCfd)
     })
@@ -57,8 +57,8 @@ describe('Rules service', () => {
       const presenter2019 = dummyPresenter('wrls', 2019)
       const presenter2020 = dummyPresenter('wrls', 2020)
 
-      const { requestUrl: requestUrl2019 } = await RulesService.call(presenter2019)
-      const { requestUrl: requestUrl2020 } = await RulesService.call(presenter2020)
+      const { requestUrl: requestUrl2019 } = await RulesService.go(presenter2019)
+      const { requestUrl: requestUrl2020 } = await RulesService.go(presenter2020)
 
       expect(requestUrl2019).to.not.equal(requestUrl2020)
     })


### PR DESCRIPTION
We initially used `call()` as a convention for calling services and presenters. However this name clashes with JavaScript's predefined `call()` method. We are therefore changing the convention to `go()`, which this change implements across the existing services/presenters.