### PR TITLE
Underscores in urls? Oh my!

### DIFF
--- a/app/routes/calculate_charge.routes.js
+++ b/app/routes/calculate_charge.routes.js
@@ -5,12 +5,12 @@ const { PresrocCalculateChargeController, SrocCalculateChargeController } = requ
 const routes = [
   {
     method: 'POST',
-    path: '/v1/{regime}/calculate_charge',
+    path: '/v1/{regime}/calculate-charge',
     handler: PresrocCalculateChargeController.calculate
   },
   {
     method: 'POST',
-    path: '/v2/{regime}/calculate_charge',
+    path: '/v2/{regime}/calculate-charge',
     handler: SrocCalculateChargeController.calculate
   }
 ]

--- a/test/controllers/calculate_charge.controller.test.js
+++ b/test/controllers/calculate_charge.controller.test.js
@@ -20,7 +20,7 @@ const JsonWebToken = require('jsonwebtoken')
 
 const { SimpleFixtures, S127S130Fixtures, S126ProrataCreditFixtures } = require('../support/fixtures/wrls/calculate_charge')
 
-describe('Calculate charge controller: POST /v2/{regime}/calculate_charge', () => {
+describe('Calculate charge controller: POST /v2/{regime}/calculate-charge', () => {
   let server
 
   // Create auth token for stubbing authorisation
@@ -85,7 +85,7 @@ function mockRulesService (request, response) {
 const calculateChargeOptions = (authToken, payload) => {
   return {
     method: 'POST',
-    url: '/v2/srocWrls/calculate_charge',
+    url: '/v2/srocWrls/calculate-charge',
     headers: { authorization: `Bearer ${authToken}` },
     payload
   }


### PR DESCRIPTION
As we have started to migrate functionality from the [charging-module-api](https://github.com/defra/charging-module-api) we have also brought across the odd issue.

One of these is the charging-module's use of underscores in some of its endpoints. We are now [fixing the issue](https://github.com/DEFRA/charging-module-api/pull/164) there, so should it go live before this version we will not be lumbered with these 'unconventional' URL endpoints.

It's perfectly permissible to use underscores. However, it's definitely not the convention for URLs. To quote Google

> Consider using punctuation in your URLs. The URL **http://www.example.com/green-dress.html** is much more useful to us than **http://www.example.com/greendress.html**. We recommend that you use hyphens (-) instead of underscores (_) in your URLs.

There is also the 'blackboard' effect on us as a delivery team. It's for this same reason we added a [`PATCH` version of the bill run `/send` endpoint](https://github.com/DEFRA/charging-module-api/pull/156). 🧑‍🏫 😁

So as we are fixing the charging module this change brings the SROC charging module inline with it.