### PR TITLE
Start using service for regimes index endpoint

### DIFF
--- a/app/controllers/admin/regimes.controller.js
+++ b/app/controllers/admin/regimes.controller.js
@@ -1,11 +1,13 @@
 'use strict'
 
 const { RegimeModel } = require('../../models')
+const { ListRegimesService } = require('../../services')
 
 class RegimesController {
-  static async index (_req, _h) {
-    return RegimeModel
-      .query()
+  static async index (_req, h) {
+    const result = await ListRegimesService.go()
+
+    return h.response(result).code(200)
   }
 
   static async show (req, _h) {

--- a/app/presenters/index.js
+++ b/app/presenters/index.js
@@ -1,11 +1,13 @@
 'use strict'
 
 const BasePresenter = require('./base.presenter')
-const RulesServicePresenter = require('./rules_service.presenter')
 const ChargePresenter = require('./charge.presenter')
+const JsonPresenter = require('./json.presenter')
+const RulesServicePresenter = require('./rules_service.presenter')
 
 module.exports = {
   BasePresenter,
-  RulesServicePresenter,
-  ChargePresenter
+  ChargePresenter,
+  JsonPresenter,
+  RulesServicePresenter
 }

--- a/app/presenters/json.presenter.js
+++ b/app/presenters/json.presenter.js
@@ -1,0 +1,24 @@
+'use strict'
+
+/**
+ * @module JsonPresenter
+ */
+
+const BasePresenter = require('./base.presenter')
+
+/**
+ * Takes the data object and returns a version ready to be used for a JSON response.
+ *
+ * This presenter was created so we could stick to our pattern of
+ *
+ * - `request` -> `translator` -> `model` -> `presenter` -> `response`
+ *
+ * At this time it does nothing to the data passed in and just returns it again.
+ */
+class JsonPresenter extends BasePresenter {
+  _presentation (data) {
+    return data
+  }
+}
+
+module.exports = JsonPresenter

--- a/app/services/index.js
+++ b/app/services/index.js
@@ -3,6 +3,7 @@
 const AuthorisationService = require('./authorisation.service')
 const CalculateChargeService = require('./calculate_charge.service')
 const CognitoJwtToPemService = require('./cognito_jwt_to_pem.service')
+const ListRegimesService = require('./list_regimes.service')
 const ObjectCleaningService = require('./object_cleaning.service')
 const RulesService = require('./rules.service')
 
@@ -10,6 +11,7 @@ module.exports = {
   AuthorisationService,
   CalculateChargeService,
   CognitoJwtToPemService,
+  ListRegimesService,
   ObjectCleaningService,
   RulesService
 }

--- a/app/services/list_regimes.service.js
+++ b/app/services/list_regimes.service.js
@@ -1,0 +1,34 @@
+'use strict'
+
+/**
+ * @module ListRegimesService
+ */
+
+const { RegimeModel } = require('../models')
+const { JsonPresenter } = require('../presenters')
+
+/**
+ * Returns an array of regimes
+ *
+ * @returns {module:RegimeModel[]} an array of `RegimeModel` based on regimes currently in the database
+ */
+class ListRegimesService {
+  static async go () {
+    const regimes = await this._regimes()
+
+    return this._response(regimes)
+  }
+
+  static _regimes () {
+    return RegimeModel
+      .query()
+  }
+
+  static _response (regimes) {
+    const presenter = new JsonPresenter(regimes)
+
+    return presenter.go()
+  }
+}
+
+module.exports = ListRegimesService

--- a/test/controllers/admin/regimes.controller.test.js
+++ b/test/controllers/admin/regimes.controller.test.js
@@ -1,0 +1,78 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, before, beforeEach, after } = exports.lab = Lab.script()
+const { expect } = Code
+
+// For running our service
+const { deployment } = require('../../../server')
+
+// Test helpers
+const { AuthorisationHelper, AuthorisedSystemHelper, DatabaseHelper, RegimeHelper } = require('../../support/helpers')
+
+// Things we need to stub
+const JsonWebToken = require('jsonwebtoken')
+
+const options = token => {
+  return {
+    method: 'GET',
+    url: '/admin/regimes',
+    headers: { authorization: `Bearer ${token}` }
+  }
+}
+
+describe('Regimes controller', () => {
+  let server
+  let authToken
+
+  before(async () => {
+    server = await deployment()
+    authToken = AuthorisationHelper.adminToken()
+
+    Sinon
+      .stub(JsonWebToken, 'verify')
+      .returns(AuthorisationHelper.decodeToken(authToken))
+  })
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+    await AuthorisedSystemHelper.addAdminSystem()
+  })
+
+  after(async () => {
+    Sinon.restore()
+  })
+
+  describe('Listing regimes: GET /admin/regimes', () => {
+    describe('When there are regimes', () => {
+      beforeEach(async () => {
+        await RegimeHelper.addRegime('ice', 'Ice')
+        await RegimeHelper.addRegime('wind', 'Wind')
+        await RegimeHelper.addRegime('fire', 'Fire')
+      })
+
+      it('returns list of regimes', async () => {
+        const response = await server.inject(options(authToken))
+
+        const payload = JSON.parse(response.payload)
+
+        expect(payload.length).to.equal(3)
+        expect(payload[0].slug).to.equal('ice')
+      })
+    })
+
+    describe('When there are no regimes', () => {
+      it('returns an empty list', async () => {
+        const response = await server.inject(options(authToken))
+
+        const payload = JSON.parse(response.payload)
+
+        expect(payload.length).to.equal(0)
+      })
+    })
+  })
+})

--- a/test/presenters/json.presenter.test.js
+++ b/test/presenters/json.presenter.test.js
@@ -1,0 +1,24 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Thing under test
+const { JsonPresenter } = require('../../app/presenters')
+
+describe.only('Json Presenter', () => {
+  it('returns whatever you pass in', () => {
+    const data = {
+      reference: 'BESESAME001',
+      customerName: 'Bert & Ernie Ltd'
+    }
+
+    const presenter = new JsonPresenter(data)
+
+    expect(presenter.go()).to.equal(data)
+  })
+})

--- a/test/presenters/json.presenter.test.js
+++ b/test/presenters/json.presenter.test.js
@@ -10,7 +10,7 @@ const { expect } = Code
 // Thing under test
 const { JsonPresenter } = require('../../app/presenters')
 
-describe.only('Json Presenter', () => {
+describe('Json Presenter', () => {
   it('returns whatever you pass in', () => {
     const data = {
       reference: 'BESESAME001',

--- a/test/services/list_regimes.service.test.js
+++ b/test/services/list_regimes.service.test.js
@@ -1,0 +1,41 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const { DatabaseHelper, RegimeHelper } = require('../support/helpers')
+
+// Thing under test
+const { ListRegimesService } = require('../../app/services')
+
+describe('List Regimes service', () => {
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+  })
+
+  describe('When there are no regimes', () => {
+    it('returns an empty array', async () => {
+      const result = await ListRegimesService.go()
+
+      expect(result).to.equal([])
+    })
+  })
+
+  describe('When there are regimes', () => {
+    it('returns them', async () => {
+      await RegimeHelper.addRegime('ice', 'Ice')
+      await RegimeHelper.addRegime('wind', 'Wind')
+      await RegimeHelper.addRegime('fire', 'Fire')
+
+      const result = await ListRegimesService.go()
+
+      expect(result.length).to.equal(3)
+      expect(result[0].slug).to.equal('ice')
+    })
+  })
+})


### PR DESCRIPTION
We have currently settled on 2 key conventions

- our flow for all requests; `request -> translate -> model -> presenter -> response`
- all work the work of a controller endpoint will be done in a service

This change makes to additions to support this

- we add a `JsonPresenter` so even requests where we'll simply return the database result will flow through a 'presenter'
- we add a `ListRegimesService` to handle the work of querying for all regimes