### PR TITLE
Start using service for regimes show endpoint

### DIFF
--- a/app/controllers/admin/regimes.controller.js
+++ b/app/controllers/admin/regimes.controller.js
@@ -1,7 +1,6 @@
 'use strict'
 
-const { RegimeModel } = require('../../models')
-const { ListRegimesService } = require('../../services')
+const { ListRegimesService, ShowRegimeService } = require('../../services')
 
 class RegimesController {
   static async index (_req, h) {
@@ -10,10 +9,10 @@ class RegimesController {
     return h.response(result).code(200)
   }
 
-  static async show (req, _h) {
-    return RegimeModel
-      .query()
-      .findById(req.params.id)
+  static async show (req, h) {
+    const result = await ShowRegimeService.go(req.params.id)
+
+    return h.response(result).code(200)
   }
 }
 

--- a/app/services/index.js
+++ b/app/services/index.js
@@ -6,6 +6,7 @@ const CognitoJwtToPemService = require('./cognito_jwt_to_pem.service')
 const ListRegimesService = require('./list_regimes.service')
 const ObjectCleaningService = require('./object_cleaning.service')
 const RulesService = require('./rules.service')
+const ShowRegimeService = require('./show_regime.service')
 
 module.exports = {
   AuthorisationService,
@@ -13,5 +14,6 @@ module.exports = {
   CognitoJwtToPemService,
   ListRegimesService,
   ObjectCleaningService,
-  RulesService
+  RulesService,
+  ShowRegimeService
 }

--- a/app/services/show_regime.service.js
+++ b/app/services/show_regime.service.js
@@ -22,7 +22,7 @@ class ShowRegimeService {
     const regime = await this._regime(id)
 
     if (!regime) {
-      throw Boom.notFound('No regime found', id)
+      throw Boom.notFound(`No regime found with id ${id}`)
     }
 
     return this._response(regime)

--- a/app/services/show_regime.service.js
+++ b/app/services/show_regime.service.js
@@ -1,0 +1,44 @@
+'use strict'
+
+/**
+ * @module ShowRegimeService
+ */
+
+const Boom = require('@hapi/boom')
+
+const { RegimeModel } = require('../models')
+const { JsonPresenter } = require('../presenters')
+
+/**
+ * Returns the regime with matching Id
+ *
+ * If no matching regime is found it will throw a `Boom.notFound()` error (404)
+ *
+ * @param {string} id Id of the regime to find
+ * @returns {module:RegimeModel} a `RegimeModel` if found else it will throw a B
+ */
+class ShowRegimeService {
+  static async go (id) {
+    const regime = await this._regime(id)
+
+    if (!regime) {
+      throw Boom.notFound('No regime found', id)
+    }
+
+    return this._response(regime)
+  }
+
+  static _regime (id) {
+    return RegimeModel.query()
+      .findById(id)
+      .withGraphFetched('authorisedSystems')
+  }
+
+  static _response (regime) {
+    const presenter = new JsonPresenter(regime)
+
+    return presenter.go()
+  }
+}
+
+module.exports = ShowRegimeService

--- a/test/controllers/admin/regimes.controller.test.js
+++ b/test/controllers/admin/regimes.controller.test.js
@@ -17,14 +17,6 @@ const { AuthorisationHelper, AuthorisedSystemHelper, DatabaseHelper, RegimeHelpe
 // Things we need to stub
 const JsonWebToken = require('jsonwebtoken')
 
-const options = token => {
-  return {
-    method: 'GET',
-    url: '/admin/regimes',
-    headers: { authorization: `Bearer ${token}` }
-  }
-}
-
 describe('Regimes controller', () => {
   let server
   let authToken
@@ -48,6 +40,14 @@ describe('Regimes controller', () => {
   })
 
   describe('Listing regimes: GET /admin/regimes', () => {
+    const options = token => {
+      return {
+        method: 'GET',
+        url: '/admin/regimes',
+        headers: { authorization: `Bearer ${token}` }
+      }
+    }
+
     describe('When there are regimes', () => {
       beforeEach(async () => {
         await RegimeHelper.addRegime('ice', 'Ice')
@@ -72,6 +72,40 @@ describe('Regimes controller', () => {
         const payload = JSON.parse(response.payload)
 
         expect(payload.length).to.equal(0)
+      })
+    })
+  })
+
+  describe('Show regime: GET /admin/regimes/{id}', () => {
+    const options = (id, token) => {
+      return {
+        method: 'GET',
+        url: `/admin/regimes/${id}`,
+        headers: { authorization: `Bearer ${token}` }
+      }
+    }
+
+    describe('When there the regime exists', () => {
+      it('returns the matching regime', async () => {
+        const regime = await RegimeHelper.addRegime('ice', 'Ice')
+
+        const response = await server.inject(options(regime.id, authToken))
+        const payload = JSON.parse(response.payload)
+
+        expect(response.statusCode).to.equal(200)
+        expect(payload.slug).to.equal('ice')
+      })
+    })
+
+    describe('When the regime does not exist', () => {
+      it("returns a 404 'not found' response", async () => {
+        const id = 'f0d3b4dc-2cae-11eb-adc1-0242ac120002'
+        const response = await server.inject(options(id, authToken))
+
+        const payload = JSON.parse(response.payload)
+
+        expect(response.statusCode).to.equal(404)
+        expect(payload.message).to.equal(`No regime found with id ${id}`)
       })
     })
   })

--- a/test/controllers/admin/regimes.controller.test.js
+++ b/test/controllers/admin/regimes.controller.test.js
@@ -60,6 +60,7 @@ describe('Regimes controller', () => {
 
         const payload = JSON.parse(response.payload)
 
+        expect(response.statusCode).to.equal(200)
         expect(payload.length).to.equal(3)
         expect(payload[0].slug).to.equal('ice')
       })
@@ -71,6 +72,7 @@ describe('Regimes controller', () => {
 
         const payload = JSON.parse(response.payload)
 
+        expect(response.statusCode).to.equal(200)
         expect(payload.length).to.equal(0)
       })
     })

--- a/test/services/show_regime.service.test.js
+++ b/test/services/show_regime.service.test.js
@@ -44,7 +44,8 @@ describe('Show Regime service', () => {
 
   describe('When there is no matching regime', () => {
     it('returns throws an error', async () => {
-      const err = await expect(ShowRegimeService.go('f0d3b4dc-2cae-11eb-adc1-0242ac120002')).to.reject(Error, 'No regime found')
+      const id = 'f0d3b4dc-2cae-11eb-adc1-0242ac120002'
+      const err = await expect(ShowRegimeService.go(id)).to.reject(Error, `No regime found with id ${id}`)
 
       expect(err).to.be.an.error()
     })

--- a/test/services/show_regime.service.test.js
+++ b/test/services/show_regime.service.test.js
@@ -1,0 +1,60 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const { AuthorisedSystemHelper, DatabaseHelper, RegimeHelper } = require('../support/helpers')
+const RegimeModel = require('../../app/models/regime.model')
+const { DataError } = require('objection')
+
+// Thing under test
+const { ShowRegimeService } = require('../../app/services')
+
+describe('Show Regime service', () => {
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+  })
+
+  describe('When there is a matching regime', () => {
+    it('returns a regime', async () => {
+      const regime = await RegimeHelper.addRegime('ice', 'Ice')
+
+      const result = await ShowRegimeService.go(regime.id)
+
+      expect(result instanceof RegimeModel).to.equal(true)
+      expect(result.id).to.equal(regime.id)
+    })
+
+    it('returns a result that includes a list of related authorised systems', async () => {
+      const regime = await RegimeHelper.addRegime('ice', 'water')
+      await AuthorisedSystemHelper.addSystem('1234546789', 'system1', [regime])
+      await AuthorisedSystemHelper.addSystem('987654321', 'system2', [regime])
+
+      const result = await ShowRegimeService.go(regime.id)
+
+      expect(result.authorisedSystems.length).to.equal(2)
+      expect(result.authorisedSystems[0].name).to.equal('system1')
+    })
+  })
+
+  describe('When there is no matching regime', () => {
+    it('returns throws an error', async () => {
+      const err = await expect(ShowRegimeService.go('f0d3b4dc-2cae-11eb-adc1-0242ac120002')).to.reject(Error, 'No regime found')
+
+      expect(err).to.be.an.error()
+    })
+  })
+
+  describe('When an invalid UUID is used', () => {
+    it('returns throws an error', async () => {
+      const err = await expect(ShowRegimeService.go('123456789')).to.reject(DataError)
+
+      expect(err).to.be.an.error()
+    })
+  })
+})


### PR DESCRIPTION
Following on from [Start using service for regimes index endpoint](https://github.com/DEFRA/sroc-charging-module-api/pull/61) this creates a new service to handle querying the db for the requested regime.

Regimes are also linked to authorised systems. Unlike the list endpoint this will include the linked authorised systems in the response.