### PR TITLE
Add authorised systems index endpoint

### DIFF
--- a/app/controllers/admin/authorised_systems.controller.js
+++ b/app/controllers/admin/authorised_systems.controller.js
@@ -1,8 +1,12 @@
 'use strict'
 
+const { ListAuthorisedSystemsService } = require('../../services')
+
 class AuthorisedSystemsController {
   static async index (_req, h) {
-    return h.response('Hello').code(200)
+    const result = await ListAuthorisedSystemsService.go()
+
+    return h.response(result).code(200)
   }
 }
 

--- a/app/controllers/admin/authorised_systems.controller.js
+++ b/app/controllers/admin/authorised_systems.controller.js
@@ -1,0 +1,9 @@
+'use strict'
+
+class AuthorisedSystemsController {
+  static async index (_req, h) {
+    return h.response('Hello').code(200)
+  }
+}
+
+module.exports = AuthorisedSystemsController

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -3,6 +3,7 @@
 const RootController = require('./root.controller')
 
 const RegimesController = require('./admin/regimes.controller')
+const AuthorisedSystemsController = require('./admin/authorised_systems.controller')
 const AirbrakeController = require('./admin/health/airbrake.controller')
 
 const BaseBillRunsController = require('./base_bill_runs.controller')
@@ -20,6 +21,7 @@ module.exports = {
   RootController,
   RegimesController,
   AirbrakeController,
+  AuthorisedSystemsController,
   BaseBillRunsController,
   BaseTransactionsController,
   BaseCalculateChargeController,

--- a/app/plugins/router.plugin.js
+++ b/app/plugins/router.plugin.js
@@ -13,6 +13,7 @@
 
 const {
   AirbrakeRoutes,
+  AuthorisedSystemRoutes,
   BillRunRoutes,
   RegimeRoutes,
   RootRoutes,
@@ -23,6 +24,7 @@ const {
 const routes = [
   ...RootRoutes,
   ...AirbrakeRoutes,
+  ...AuthorisedSystemRoutes,
   ...BillRunRoutes,
   ...TransactionRoutes,
   ...RegimeRoutes,

--- a/app/routes/authorised_system.routes.js
+++ b/app/routes/authorised_system.routes.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const { AuthorisedSystemsController } = require('../controllers')
+
+const routes = [
+  {
+    method: 'GET',
+    path: '/admin/authorised-systems',
+    handler: AuthorisedSystemsController.index,
+    options: {
+      auth: {
+        scope: ['admin']
+      }
+    }
+  }
+]
+
+module.exports = routes

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const AirbrakeRoutes = require('./airbrake.routes')
+const AuthorisedSystemRoutes = require('./authorised_system.routes')
 const BillRunRoutes = require('./bill_run.routes')
 const RegimeRoutes = require('./regime.routes')
 const RootRoutes = require('./root.routes')
@@ -9,6 +10,7 @@ const CalculateChargeRoutes = require('./calculate_charge.routes')
 
 module.exports = {
   AirbrakeRoutes,
+  AuthorisedSystemRoutes,
   BillRunRoutes,
   RegimeRoutes,
   RootRoutes,

--- a/app/services/index.js
+++ b/app/services/index.js
@@ -3,6 +3,7 @@
 const AuthorisationService = require('./authorisation.service')
 const CalculateChargeService = require('./calculate_charge.service')
 const CognitoJwtToPemService = require('./cognito_jwt_to_pem.service')
+const ListAuthorisedSystemsService = require('./list_authorised_systems.service')
 const ListRegimesService = require('./list_regimes.service')
 const ObjectCleaningService = require('./object_cleaning.service')
 const RulesService = require('./rules.service')
@@ -12,6 +13,7 @@ module.exports = {
   AuthorisationService,
   CalculateChargeService,
   CognitoJwtToPemService,
+  ListAuthorisedSystemsService,
   ListRegimesService,
   ObjectCleaningService,
   RulesService,

--- a/app/services/list_authorised_systems.service.js
+++ b/app/services/list_authorised_systems.service.js
@@ -1,0 +1,35 @@
+'use strict'
+
+/**
+ * @module ListAuthorisedSystemsService
+ */
+
+const { AuthorisedSystemModel } = require('../models')
+const { JsonPresenter } = require('../presenters')
+
+/**
+ * Returns an array of authorised systems
+ *
+ * @returns {module:AuthorisedSystemModel[]} an array of `AuthorisedSystemModel` based on authorised systems currently
+ * in the database
+ */
+class ListAuthorisedSystemsService {
+  static async go () {
+    const authorisedSystems = await this._authorisedSystems()
+
+    return this._response(authorisedSystems)
+  }
+
+  static _authorisedSystems () {
+    return AuthorisedSystemModel
+      .query()
+  }
+
+  static _response (authorisedSystems) {
+    const presenter = new JsonPresenter(authorisedSystems)
+
+    return presenter.go()
+  }
+}
+
+module.exports = ListAuthorisedSystemsService

--- a/test/controllers/admin/authorised_systems.controller.test.js
+++ b/test/controllers/admin/authorised_systems.controller.test.js
@@ -1,0 +1,80 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, before, beforeEach, after } = exports.lab = Lab.script()
+const { expect } = Code
+
+// For running our service
+const { deployment } = require('../../../server')
+
+// Test helpers
+const { AuthorisationHelper, AuthorisedSystemHelper, DatabaseHelper } = require('../../support/helpers')
+
+// Things we need to stub
+const JsonWebToken = require('jsonwebtoken')
+
+describe('Authorised systems controller', () => {
+  let server
+  let authToken
+
+  before(async () => {
+    server = await deployment()
+    authToken = AuthorisationHelper.adminToken()
+
+    Sinon
+      .stub(JsonWebToken, 'verify')
+      .returns(AuthorisationHelper.decodeToken(authToken))
+  })
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+    await AuthorisedSystemHelper.addAdminSystem()
+  })
+
+  after(async () => {
+    Sinon.restore()
+  })
+
+  describe('Listing authorised systems: GET /admin/authorised-systems', () => {
+    const options = token => {
+      return {
+        method: 'GET',
+        url: '/admin/authorised-systems',
+        headers: { authorization: `Bearer ${token}` }
+      }
+    }
+
+    describe('When there are authorised systems', () => {
+      beforeEach(async () => {
+        await AuthorisedSystemHelper.addSystem('1234546789', 'system1')
+        await AuthorisedSystemHelper.addSystem('987654321', 'system2')
+        await AuthorisedSystemHelper.addSystem('5432112345', 'system3')
+      })
+
+      it('returns a list of them', async () => {
+        const response = await server.inject(options(authToken))
+
+        const payload = JSON.parse(response.payload)
+
+        expect(response.statusCode).to.equal(200)
+        expect(payload.length).to.equal(3)
+        expect(payload[0].name).to.equal('system1')
+      })
+    })
+
+    describe('When there are no authorised systems', () => {
+      it('returns an empty list', async () => {
+        const response = await server.inject(options(authToken))
+
+        const payload = JSON.parse(response.payload)
+
+        expect(response.statusCode).to.equal(200)
+        expect(payload.length).to.equal(0)
+      })
+    })
+  })
+})

--- a/test/controllers/admin/authorised_systems.controller.test.js
+++ b/test/controllers/admin/authorised_systems.controller.test.js
@@ -61,19 +61,20 @@ describe('Authorised systems controller', () => {
         const payload = JSON.parse(response.payload)
 
         expect(response.statusCode).to.equal(200)
-        expect(payload.length).to.equal(3)
-        expect(payload[0].name).to.equal('system1')
+        expect(payload.length).to.equal(4)
+        expect(payload[1].name).to.equal('system1')
       })
     })
 
-    describe('When there are no authorised systems', () => {
-      it('returns an empty list', async () => {
+    describe("When there is only the 'admin' system", () => {
+      it('returns just it', async () => {
         const response = await server.inject(options(authToken))
 
         const payload = JSON.parse(response.payload)
 
         expect(response.statusCode).to.equal(200)
-        expect(payload.length).to.equal(0)
+        expect(payload.length).to.equal(1)
+        expect(payload[0].name).to.equal('admin')
       })
     })
   })

--- a/test/services/list_authorised_systems.service.test.js
+++ b/test/services/list_authorised_systems.service.test.js
@@ -1,0 +1,41 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const { AuthorisedSystemHelper, DatabaseHelper } = require('../support/helpers')
+
+// Thing under test
+const { ListAuthorisedSystemsService } = require('../../app/services')
+
+describe('List Authorised Systems service', () => {
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+  })
+
+  describe('When there are no authorised systems', () => {
+    it('returns an empty array', async () => {
+      const result = await ListAuthorisedSystemsService.go()
+
+      expect(result).to.equal([])
+    })
+  })
+
+  describe('When there are authorised systems', () => {
+    it('returns them', async () => {
+      await AuthorisedSystemHelper.addSystem('1234546789', 'system1')
+      await AuthorisedSystemHelper.addSystem('987654321', 'system2')
+      await AuthorisedSystemHelper.addSystem('5432112345', 'system3')
+
+      const result = await ListAuthorisedSystemsService.go()
+
+      expect(result.length).to.equal(3)
+      expect(result[0].name).to.equal('system1')
+    })
+  })
+})


### PR DESCRIPTION
We'll need an authorised systems controller to allow us to create new authorised systems records.

So as an initial step this change adds the initial controller along with an index endpoint which lists existing authorised systems.