### PR TITLE
Add authorised systems show endpoint

### DIFF
--- a/app/controllers/admin/authorised_systems.controller.js
+++ b/app/controllers/admin/authorised_systems.controller.js
@@ -8,6 +8,10 @@ class AuthorisedSystemsController {
 
     return h.response(result).code(200)
   }
+
+  static async show (req, h) {
+    return h.response('hello').code(200)
+  }
 }
 
 module.exports = AuthorisedSystemsController

--- a/app/controllers/admin/authorised_systems.controller.js
+++ b/app/controllers/admin/authorised_systems.controller.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { ListAuthorisedSystemsService } = require('../../services')
+const { ListAuthorisedSystemsService, ShowAuthorisedSystemService } = require('../../services')
 
 class AuthorisedSystemsController {
   static async index (_req, h) {
@@ -10,7 +10,9 @@ class AuthorisedSystemsController {
   }
 
   static async show (req, h) {
-    return h.response('hello').code(200)
+    const result = await ShowAuthorisedSystemService.go(req.params.id)
+
+    return h.response(result).code(200)
   }
 }
 

--- a/app/routes/authorised_system.routes.js
+++ b/app/routes/authorised_system.routes.js
@@ -12,6 +12,16 @@ const routes = [
         scope: ['admin']
       }
     }
+  },
+  {
+    method: 'GET',
+    path: '/admin/authorised-systems/{id}',
+    handler: AuthorisedSystemsController.show,
+    options: {
+      auth: {
+        scope: ['admin']
+      }
+    }
   }
 ]
 

--- a/app/services/index.js
+++ b/app/services/index.js
@@ -7,6 +7,7 @@ const ListAuthorisedSystemsService = require('./list_authorised_systems.service'
 const ListRegimesService = require('./list_regimes.service')
 const ObjectCleaningService = require('./object_cleaning.service')
 const RulesService = require('./rules.service')
+const ShowAuthorisedSystemService = require('./show_authorised_system.service')
 const ShowRegimeService = require('./show_regime.service')
 
 module.exports = {
@@ -17,5 +18,6 @@ module.exports = {
   ListRegimesService,
   ObjectCleaningService,
   RulesService,
+  ShowAuthorisedSystemService,
   ShowRegimeService
 }

--- a/app/services/show_authorised_system.service.js
+++ b/app/services/show_authorised_system.service.js
@@ -1,0 +1,44 @@
+'use strict'
+
+/**
+ * @module ShowAuthorisedSystemService
+ */
+
+const Boom = require('@hapi/boom')
+
+const { AuthorisedSystemModel } = require('../models')
+const { JsonPresenter } = require('../presenters')
+
+/**
+ * Returns the authorised system with the matching Id
+ *
+ * If no matching authorised system is found it will throw a `Boom.notFound()` error (404)
+ *
+ * @param {string} id Id of the regime to find
+ * @returns {module:AuthorisedSystemModel} an `AuthorisedSystemModel` if found else it will throw a Boom 404 error
+ */
+class ShowAuthorisedSystemService {
+  static async go (id) {
+    const authorisedSystem = await this._authorisedSystem(id)
+
+    if (!authorisedSystem) {
+      throw Boom.notFound(`No authorised system found with id ${id}`)
+    }
+
+    return this._response(authorisedSystem)
+  }
+
+  static _authorisedSystem (id) {
+    return AuthorisedSystemModel.query()
+      .findById(id)
+      .withGraphFetched('regimes')
+  }
+
+  static _response (authorisedSystem) {
+    const presenter = new JsonPresenter(authorisedSystem)
+
+    return presenter.go()
+  }
+}
+
+module.exports = ShowAuthorisedSystemService

--- a/test/controllers/admin/authorised_systems.controller.test.js
+++ b/test/controllers/admin/authorised_systems.controller.test.js
@@ -78,4 +78,38 @@ describe('Authorised systems controller', () => {
       })
     })
   })
+
+  describe('Show authorised system: GET /admin/authorised-systems/{id}', () => {
+    const options = (id, token) => {
+      return {
+        method: 'GET',
+        url: `/admin/authorised-systems/${id}`,
+        headers: { authorization: `Bearer ${token}` }
+      }
+    }
+
+    describe('When the authorised system exists', () => {
+      it('returns a match', async () => {
+        const authorisedSystem = await AuthorisedSystemHelper.addSystem('1234546789', 'system1')
+
+        const response = await server.inject(options(authorisedSystem.id, authToken))
+        const payload = JSON.parse(response.payload)
+
+        expect(response.statusCode).to.equal(200)
+        expect(payload.name).to.equal('system1')
+      })
+    })
+
+    describe('When the authorised system does not exist', () => {
+      it("returns a 404 'not found' response", async () => {
+        const id = 'f0d3b4dc-2cae-11eb-adc1-0242ac120002'
+        const response = await server.inject(options(id, authToken))
+
+        const payload = JSON.parse(response.payload)
+
+        expect(response.statusCode).to.equal(404)
+        expect(payload.message).to.equal(`No authorised system found with id ${id}`)
+      })
+    })
+  })
 })

--- a/test/services/show_authorised_system.service.test.js
+++ b/test/services/show_authorised_system.service.test.js
@@ -21,6 +21,18 @@ describe('Show Authorised System service', () => {
   })
 
   describe('When there is a matching authorised system', () => {
+    describe("and it's the 'admin'", () => {
+      it('returns a result with no related regimes', async () => {
+        // Add a regime to give assurance the result is not based on the table being empty
+        await RegimeHelper.addRegime('ice', 'Ice')
+        const authorisedSystem = await AuthorisedSystemHelper.addAdminSystem()
+
+        const result = await ShowAuthorisedSystemService.go(authorisedSystem.id)
+
+        expect(result.regimes.length).to.equal(0)
+      })
+    })
+
     it('returns the matching record', async () => {
       const authorisedSystem = await AuthorisedSystemHelper.addSystem('1234546789', 'system1')
 


### PR DESCRIPTION
Now we have an authorised systems controller with support for listing authorised system records we want the ability to view one in more detail. For example, include in the response the regimes the authorised system is authorised for.

This change adds the show endpoint to handle this.