### PR TITLE
Add new create authorised system endpoint

### DIFF
--- a/app/controllers/admin/authorised_systems.controller.js
+++ b/app/controllers/admin/authorised_systems.controller.js
@@ -1,6 +1,10 @@
 'use strict'
 
-const { ListAuthorisedSystemsService, ShowAuthorisedSystemService } = require('../../services')
+const {
+  CreateAuthorisedSystemService,
+  ListAuthorisedSystemsService,
+  ShowAuthorisedSystemService
+} = require('../../services')
 
 class AuthorisedSystemsController {
   static async index (_req, h) {
@@ -13,6 +17,12 @@ class AuthorisedSystemsController {
     const result = await ShowAuthorisedSystemService.go(req.params.id)
 
     return h.response(result).code(200)
+  }
+
+  static async create (req, h) {
+    const result = await CreateAuthorisedSystemService.go(req.payload)
+
+    return h.response(result).code(201)
   }
 }
 

--- a/app/routes/authorised_system.routes.js
+++ b/app/routes/authorised_system.routes.js
@@ -22,6 +22,16 @@ const routes = [
         scope: ['admin']
       }
     }
+  },
+  {
+    method: 'POST',
+    path: '/admin/authorised-systems',
+    handler: AuthorisedSystemsController.create,
+    options: {
+      auth: {
+        scope: ['admin']
+      }
+    }
   }
 ]
 

--- a/app/services/create_authorised_system.service.js
+++ b/app/services/create_authorised_system.service.js
@@ -1,9 +1,23 @@
 'use strict'
 
+/**
+ * @module CreateAuthorisedSystemService
+ */
+
 const { AuthorisedSystemModel, RegimeModel } = require('../models')
 const { AuthorisedSystemTranslator } = require('../translators')
 const { JsonPresenter } = require('../presenters')
 
+/**
+ * Creates a new authorised system record
+ *
+ * The service handles validating and translating the request to the API and then creating a new authorised system. It
+ * returns the new authorised system as the result.
+ *
+ * @param {Object} payload The payload from the API request
+ *
+ * @returns {Object} Details of the newly created authorised system
+ */
 class CreateAuthorisedSystemService {
   static async go (payload) {
     const translator = new AuthorisedSystemTranslator(payload)

--- a/app/services/create_authorised_system.service.js
+++ b/app/services/create_authorised_system.service.js
@@ -1,0 +1,51 @@
+'use strict'
+
+const { AuthorisedSystemModel, RegimeModel } = require('../models')
+const { AuthorisedSystemTranslator } = require('../translators')
+const { JsonPresenter } = require('../presenters')
+
+class CreateAuthorisedSystemService {
+  static async go (payload) {
+    const translator = new AuthorisedSystemTranslator(payload)
+    const regimes = await this._regimes(translator.authorisations)
+    const authorisedSystem = await this._create(translator, regimes)
+
+    return this._response(authorisedSystem)
+  }
+
+  static async _regimes (authorisations) {
+    const regimes = await RegimeModel.query()
+      .select('id')
+      .where('slug', 'in', authorisations)
+
+    return regimes
+  }
+
+  static async _create (translator, regimes) {
+    return AuthorisedSystemModel.transaction(async trx => {
+      const newRecords = await AuthorisedSystemModel.query(trx).insertGraphAndFetch(
+        [
+          {
+            client_id: translator.clientId,
+            name: translator.name,
+            admin: false,
+            status: translator.status,
+            regimes: regimes
+          }
+        ],
+        {
+          relate: true
+        }
+      )
+      return newRecords[0]
+    })
+  }
+
+  static _response (authorisedSystem) {
+    const presenter = new JsonPresenter(authorisedSystem)
+
+    return presenter.go()
+  }
+}
+
+module.exports = CreateAuthorisedSystemService

--- a/app/services/index.js
+++ b/app/services/index.js
@@ -3,6 +3,7 @@
 const AuthorisationService = require('./authorisation.service')
 const CalculateChargeService = require('./calculate_charge.service')
 const CognitoJwtToPemService = require('./cognito_jwt_to_pem.service')
+const CreateAuthorisedSystemService = require('./create_authorised_system.service')
 const ListAuthorisedSystemsService = require('./list_authorised_systems.service')
 const ListRegimesService = require('./list_regimes.service')
 const ObjectCleaningService = require('./object_cleaning.service')
@@ -14,6 +15,7 @@ module.exports = {
   AuthorisationService,
   CalculateChargeService,
   CognitoJwtToPemService,
+  CreateAuthorisedSystemService,
   ListAuthorisedSystemsService,
   ListRegimesService,
   ObjectCleaningService,

--- a/app/translators/authorised_system.translator.js
+++ b/app/translators/authorised_system.translator.js
@@ -1,0 +1,26 @@
+' use strict'
+
+const BaseTranslator = require('./base.translator')
+const Joi = require('joi')
+
+class AuthorisedSystemTranslator extends BaseTranslator {
+  _translations () {
+    return {
+      clientId: 'clientId',
+      name: 'name',
+      status: 'status',
+      authorisations: 'authorisations'
+    }
+  }
+
+  _schema () {
+    return Joi.object({
+      clientId: Joi.string().required(),
+      name: Joi.string().required(),
+      status: Joi.string().default('active'),
+      authorisations: Joi.array().items(Joi.string())
+    })
+  }
+}
+
+module.exports = AuthorisedSystemTranslator

--- a/app/translators/index.js
+++ b/app/translators/index.js
@@ -1,11 +1,13 @@
 'use strict'
 
+const AuthorisedSystemTranslator = require('./authorised_system.translator')
 const BaseTranslator = require('./base.translator')
 const BillRunTranslator = require('./bill_run.translator')
 const RulesServiceTranslator = require('./rules_service.translator')
 const SrocChargeTranslator = require('./sroc_charge.translator')
 
 module.exports = {
+  AuthorisedSystemTranslator,
   BaseTranslator,
   BillRunTranslator,
   RulesServiceTranslator,

--- a/db/migrations/20201127100927_alter_authorised_systems.js
+++ b/db/migrations/20201127100927_alter_authorised_systems.js
@@ -1,0 +1,35 @@
+'use strict'
+
+const tableName = 'authorised_systems'
+
+exports.up = async function (knex) {
+  await knex
+    .schema
+    .alterTable(tableName, table => {
+      // Add client_id unique constraint
+      table.unique('client_id')
+    })
+
+  await knex
+    .schema
+    .alterTable(tableName, table => {
+      // Add name unique constraint
+      table.unique('name')
+    })
+}
+
+exports.down = async function (knex) {
+  await knex
+    .schema
+    .alterTable(tableName, table => {
+      // Drop client_id unique constraint
+      table.unique('client_id')
+    })
+
+  await knex
+    .schema
+    .alterTable(tableName, table => {
+      // Drop name unique constraint
+      table.dropUnique('name')
+    })
+}

--- a/test/controllers/admin/authorised_systems.controller.test.js
+++ b/test/controllers/admin/authorised_systems.controller.test.js
@@ -112,4 +112,44 @@ describe('Authorised systems controller', () => {
       })
     })
   })
+
+  describe('Adding an authorised system: POST /admin/authorised-systems', () => {
+    const options = (token, payload) => {
+      return {
+        method: 'POST',
+        url: '/admin/authorised-systems',
+        headers: { authorization: `Bearer ${token}` },
+        payload: payload
+      }
+    }
+
+    it("adds a new authorised system and returns its details including the 'id'", async () => {
+      const requestPayload = {
+        clientId: 'i7rnixijjrawj7azzhwwxxxxxx',
+        name: 'olmos',
+        status: 'active',
+        authorisations: ['wrls']
+      }
+
+      const response = await server.inject(options(authToken, requestPayload))
+      const responsePayload = JSON.parse(response.payload)
+
+      expect(response.statusCode).to.equal(201)
+      expect(responsePayload.id).to.exist()
+      expect(responsePayload.clientId).to.equal(requestPayload.clientId)
+    })
+
+    it('will not add an authorised system with invalid data', async () => {
+      const requestPayload = {
+        clientId: '',
+        name: 'olmos',
+        status: 'active',
+        authorisations: ['wrls']
+      }
+
+      const response = await server.inject(options(authToken, requestPayload))
+
+      expect(response.statusCode).to.equal(422)
+    })
+  })
 })

--- a/test/services/create_authorised_system.service.test.js
+++ b/test/services/create_authorised_system.service.test.js
@@ -10,6 +10,7 @@ const { expect } = Code
 // Test helpers
 const { AuthorisedSystemHelper, DatabaseHelper, RegimeHelper } = require('../support/helpers')
 const { ValidationError } = require('joi')
+const { UniqueViolationError } = require('db-errors')
 
 // Thing under test
 const { CreateAuthorisedSystemService } = require('../../app/services')
@@ -72,7 +73,7 @@ describe('Create Authorised System service', () => {
     })
   })
 
-  describe.only('When the payload contains an invalid request', () => {
+  describe('When the payload contains an invalid request', () => {
     const invalidPayload = (clientId = 'i7rnixijjrawj7azzhwwxxxxxx', name = 'olmos') => {
       return {
         clientId: clientId,
@@ -97,7 +98,7 @@ describe('Create Authorised System service', () => {
           await AuthorisedSystemHelper.addSystem('1234546789', 'system')
 
           const payload = invalidPayload('1234546789')
-          const err = await expect(CreateAuthorisedSystemService.go(payload)).to.reject(Error)
+          const err = await expect(CreateAuthorisedSystemService.go(payload)).to.reject(UniqueViolationError)
 
           expect(err).to.be.an.error()
         })
@@ -119,7 +120,7 @@ describe('Create Authorised System service', () => {
           await AuthorisedSystemHelper.addSystem('987654321', 'system')
 
           const payload = invalidPayload('1234546789', 'system')
-          const err = await expect(CreateAuthorisedSystemService.go(payload)).to.reject(Error)
+          const err = await expect(CreateAuthorisedSystemService.go(payload)).to.reject(UniqueViolationError)
 
           expect(err).to.be.an.error()
         })

--- a/test/services/create_authorised_system.service.test.js
+++ b/test/services/create_authorised_system.service.test.js
@@ -1,0 +1,129 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const { AuthorisedSystemHelper, DatabaseHelper, RegimeHelper } = require('../support/helpers')
+const { ValidationError } = require('joi')
+
+// Thing under test
+const { CreateAuthorisedSystemService } = require('../../app/services')
+
+describe('Create Authorised System service', () => {
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+  })
+
+  describe('When the payload contains a valid request', () => {
+    const validPayload = (regimes = []) => {
+      return {
+        clientId: 'i7rnixijjrawj7azzhwwxxxxxx',
+        name: 'olmos',
+        status: 'active',
+        authorisations: regimes
+      }
+    }
+
+    describe('that contains authorised regimes', () => {
+      beforeEach(async () => {
+        await RegimeHelper.addRegime('ice', 'Ice')
+        await RegimeHelper.addRegime('wind', 'Wind')
+        await RegimeHelper.addRegime('fire', 'Fire')
+      })
+
+      it('creates a new authorised system', async () => {
+        const payload = validPayload(['ice', 'wind', 'fire'])
+        const result = await CreateAuthorisedSystemService.go(payload)
+
+        expect(result.id).to.exist()
+        expect(result.clientId).to.equal(payload.clientId)
+      })
+
+      it('returns a result that includes the regimes', async () => {
+        const payload = validPayload(['ice', 'wind', 'fire'])
+        const result = await CreateAuthorisedSystemService.go(payload)
+
+        expect(result.id).to.exist()
+        expect(result.regimes.length).to.equal(3)
+      })
+    })
+
+    describe('that contains no authorised', () => {
+      it('creates a new authorised system', async () => {
+        const payload = validPayload()
+        const result = await CreateAuthorisedSystemService.go(payload)
+
+        expect(result.id).to.exist()
+        expect(result.clientId).to.equal(payload.clientId)
+      })
+
+      it('returns a result that includes no regimes', async () => {
+        const payload = validPayload()
+        const result = await CreateAuthorisedSystemService.go(payload)
+
+        expect(result.id).to.exist()
+        expect(result.regimes.length).to.equal(0)
+      })
+    })
+  })
+
+  describe.only('When the payload contains an invalid request', () => {
+    const invalidPayload = (clientId = 'i7rnixijjrawj7azzhwwxxxxxx', name = 'olmos') => {
+      return {
+        clientId: clientId,
+        name: name,
+        status: 'active',
+        authorisations: []
+      }
+    }
+
+    describe("because the 'clientId'", () => {
+      describe('is missing', () => {
+        it('throws an error', async () => {
+          const payload = invalidPayload('')
+          const err = await expect(CreateAuthorisedSystemService.go(payload)).to.reject(ValidationError)
+
+          expect(err).to.be.an.error()
+        })
+      })
+
+      describe('is a duplicate of an existing one', () => {
+        it('throws an error', async () => {
+          await AuthorisedSystemHelper.addSystem('1234546789', 'system')
+
+          const payload = invalidPayload('1234546789')
+          const err = await expect(CreateAuthorisedSystemService.go(payload)).to.reject(Error)
+
+          expect(err).to.be.an.error()
+        })
+      })
+    })
+
+    describe("because the 'name'", () => {
+      describe('is missing', () => {
+        it('throws an error', async () => {
+          const payload = invalidPayload('123456789', '')
+          const err = await expect(CreateAuthorisedSystemService.go(payload)).to.reject(ValidationError)
+
+          expect(err).to.be.an.error()
+        })
+      })
+
+      describe('is a duplicate of an existing one', () => {
+        it('throws an error', async () => {
+          await AuthorisedSystemHelper.addSystem('987654321', 'system')
+
+          const payload = invalidPayload('1234546789', 'system')
+          const err = await expect(CreateAuthorisedSystemService.go(payload)).to.reject(Error)
+
+          expect(err).to.be.an.error()
+        })
+      })
+    })
+  })
+})

--- a/test/services/create_authorised_system.service.test.js
+++ b/test/services/create_authorised_system.service.test.js
@@ -54,7 +54,7 @@ describe('Create Authorised System service', () => {
       })
     })
 
-    describe('that contains no authorised', () => {
+    describe('that contains no authorised regimes', () => {
       it('creates a new authorised system', async () => {
         const payload = validPayload()
         const result = await CreateAuthorisedSystemService.go(payload)

--- a/test/translators/authorised_system.translator.test.js
+++ b/test/translators/authorised_system.translator.test.js
@@ -48,5 +48,21 @@ describe('Authorised system translator', () => {
         expect(() => new AuthorisedSystemTranslator(invalidData(['wrls']))).to.throw(ValidationError)
       })
     })
+
+    describe("When the data contains no 'status'", () => {
+      const validData = () => {
+        return {
+          clientId: 'i7rnixijjrawj7azzhwwxxxxxx',
+          name: 'olmos',
+          authorisations: []
+        }
+      }
+
+      it("defaults it to 'active'", async () => {
+        const translator = new AuthorisedSystemTranslator(validData())
+
+        expect(translator.status).to.equal('active')
+      })
+    })
   })
 })

--- a/test/translators/authorised_system.translator.test.js
+++ b/test/translators/authorised_system.translator.test.js
@@ -1,0 +1,52 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const { ValidationError } = require('joi')
+
+// Thing under test
+const { AuthorisedSystemTranslator } = require('../../app/translators')
+
+describe('Authorised system translator', () => {
+  describe('Validation', () => {
+    describe('when the data is valid', () => {
+      const validData = regimes => {
+        return {
+          clientId: 'i7rnixijjrawj7azzhwwxxxxxx',
+          name: 'olmos',
+          status: 'active',
+          authorisations: regimes
+        }
+      }
+
+      it('does not throw an error', async () => {
+        expect(() => new AuthorisedSystemTranslator(validData(['wrls']))).to.not.throw()
+      })
+
+      it('does not throw an error if authorised regimes is empty', async () => {
+        expect(() => new AuthorisedSystemTranslator(validData([]))).to.not.throw()
+      })
+    })
+
+    describe('when the data is not valid', () => {
+      const invalidData = regimes => {
+        return {
+          clientId: '',
+          name: 'olmos',
+          status: 'active',
+          authorisations: regimes
+        }
+      }
+
+      it('throws an error', async () => {
+        expect(() => new AuthorisedSystemTranslator(invalidData(['wrls']))).to.throw(ValidationError)
+      })
+    })
+  })
+})


### PR DESCRIPTION
To support being able to add new users of the API we need an endpoint that allows us to create one.

This change adds a `POST` create authorised system endpoint to the controller.