### PR TITLE
Add database health check controller

### DIFF
--- a/app/controllers/admin/health/database.controller.js
+++ b/app/controllers/admin/health/database.controller.js
@@ -1,0 +1,13 @@
+'use strict'
+
+const { DatabaseHealthCheckService } = require('../../../services')
+
+class DatabaseController {
+  static async index (_req, h) {
+    const result = await DatabaseHealthCheckService.go()
+
+    return h.response(result).code(200)
+  }
+}
+
+module.exports = DatabaseController

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -5,6 +5,7 @@ const RootController = require('./root.controller')
 const RegimesController = require('./admin/regimes.controller')
 const AuthorisedSystemsController = require('./admin/authorised_systems.controller')
 const AirbrakeController = require('./admin/health/airbrake.controller')
+const DatabaseController = require('./admin/health/database.controller')
 
 const BaseBillRunsController = require('./base_bill_runs.controller')
 const BaseTransactionsController = require('./base_transactions.controller')
@@ -25,6 +26,7 @@ module.exports = {
   BaseBillRunsController,
   BaseTransactionsController,
   BaseCalculateChargeController,
+  DatabaseController,
   PresrocBillRunsController,
   PresrocTransactionsController,
   PresrocCalculateChargeController,

--- a/app/plugins/router.plugin.js
+++ b/app/plugins/router.plugin.js
@@ -15,6 +15,7 @@ const {
   AirbrakeRoutes,
   AuthorisedSystemRoutes,
   BillRunRoutes,
+  DatabaseRoutes,
   RegimeRoutes,
   RootRoutes,
   TransactionRoutes,
@@ -26,6 +27,7 @@ const routes = [
   ...AirbrakeRoutes,
   ...AuthorisedSystemRoutes,
   ...BillRunRoutes,
+  ...DatabaseRoutes,
   ...TransactionRoutes,
   ...RegimeRoutes,
   ...CalculateChargeRoutes

--- a/app/routes/database.routes.js
+++ b/app/routes/database.routes.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const { DatabaseController } = require('../controllers')
+
+const routes = [
+  {
+    method: 'GET',
+    path: '/admin/health/database',
+    handler: DatabaseController.index,
+    options: {
+      description: 'Used by the delivery team to confirm we can connect to the database. It also returns us some ' +
+        'useful stats about each table.',
+      auth: {
+        scope: ['admin']
+      }
+    }
+  }
+]
+
+module.exports = routes

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -3,6 +3,7 @@
 const AirbrakeRoutes = require('./airbrake.routes')
 const AuthorisedSystemRoutes = require('./authorised_system.routes')
 const BillRunRoutes = require('./bill_run.routes')
+const DatabaseRoutes = require('./database.routes')
 const RegimeRoutes = require('./regime.routes')
 const RootRoutes = require('./root.routes')
 const TransactionRoutes = require('./transaction.routes')
@@ -12,6 +13,7 @@ module.exports = {
   AirbrakeRoutes,
   AuthorisedSystemRoutes,
   BillRunRoutes,
+  DatabaseRoutes,
   RegimeRoutes,
   RootRoutes,
   TransactionRoutes,

--- a/app/services/database_health_check.service.js
+++ b/app/services/database_health_check.service.js
@@ -1,0 +1,33 @@
+'use strict'
+
+/**
+ * @module DatabaseHealthCheckService
+ */
+
+const { db } = require('../../db')
+const { JsonPresenter } = require('../presenters')
+
+/**
+ * Generates an array of stats for each table in the database when `go()` is called
+ *
+ * This is a dump of running `SELECT * FROM pg_stat_user_tables` for the database. It's part of the database
+ * healthcheck and we use it for 2 reasons
+ *
+ * - confirm we can connect
+ * - get some basic stats, for example number of records, for each table without needing to connect to the db
+*/
+class DatabaseHealthCheckService {
+  static async go () {
+    const stats = db.select().table('pg_stat_user_tables')
+
+    return this._response(stats)
+  }
+
+  static _response (stats) {
+    const presenter = new JsonPresenter(stats)
+
+    return presenter.go()
+  }
+}
+
+module.exports = DatabaseHealthCheckService

--- a/app/services/index.js
+++ b/app/services/index.js
@@ -3,6 +3,7 @@
 const AuthorisationService = require('./authorisation.service')
 const CalculateChargeService = require('./calculate_charge.service')
 const CognitoJwtToPemService = require('./cognito_jwt_to_pem.service')
+const DatabaseHealthCheckService = require('./database_health_check.service')
 const ListAuthorisedSystemsService = require('./list_authorised_systems.service')
 const ListRegimesService = require('./list_regimes.service')
 const ObjectCleaningService = require('./object_cleaning.service')
@@ -14,6 +15,7 @@ module.exports = {
   AuthorisationService,
   CalculateChargeService,
   CognitoJwtToPemService,
+  DatabaseHealthCheckService,
   ListAuthorisedSystemsService,
   ListRegimesService,
   ObjectCleaningService,

--- a/test/controllers/admin/health/database.controller.test.js
+++ b/test/controllers/admin/health/database.controller.test.js
@@ -55,12 +55,7 @@ describe('Database controller', () => {
 
       expect(response.statusCode).to.equal(200)
 
-      // We expect at least the following tables to exist
-      // - authorised_systems
-      // - authorised_systems_regimes
-      // - knex_migrations
-      // - knex_migrations_lock
-      // - regimes
+      // We expect at least 5 tables to exist and be returned in the results
       expect(payload.length).to.be.at.least(5)
       expect(payload[0].relname).to.exist()
     })

--- a/test/controllers/admin/health/database.controller.test.js
+++ b/test/controllers/admin/health/database.controller.test.js
@@ -1,0 +1,68 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, before, beforeEach, after } = exports.lab = Lab.script()
+const { expect } = Code
+
+// For running our service
+const { deployment } = require('../../../../server')
+
+// Test helpers
+const { AuthorisationHelper, AuthorisedSystemHelper, DatabaseHelper } = require('../../../support/helpers')
+
+// Things we need to stub
+const JsonWebToken = require('jsonwebtoken')
+
+describe('Database controller', () => {
+  let server
+  let authToken
+
+  before(async () => {
+    server = await deployment()
+    authToken = AuthorisationHelper.adminToken()
+
+    Sinon
+      .stub(JsonWebToken, 'verify')
+      .returns(AuthorisationHelper.decodeToken(authToken))
+  })
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+    await AuthorisedSystemHelper.addAdminSystem()
+  })
+
+  after(async () => {
+    Sinon.restore()
+  })
+
+  describe('Listing table stats: GET /admin/health/database', () => {
+    const options = token => {
+      return {
+        method: 'GET',
+        url: '/admin/health/database',
+        headers: { authorization: `Bearer ${token}` }
+      }
+    }
+
+    it('returns stats about each table', async () => {
+      const response = await server.inject(options(authToken))
+
+      const payload = JSON.parse(response.payload)
+
+      expect(response.statusCode).to.equal(200)
+
+      // We expect at least the following tables to exist
+      // - authorised_systems
+      // - authorised_systems_regimes
+      // - knex_migrations
+      // - knex_migrations_lock
+      // - regimes
+      expect(payload.length).to.be.at.least(5)
+      expect(payload[0].relname).to.exist()
+    })
+  })
+})

--- a/test/services/database_health_check.service.test.js
+++ b/test/services/database_health_check.service.test.js
@@ -13,7 +13,7 @@ const { DatabaseHelper } = require('../support/helpers')
 // Thing under test
 const { DatabaseHealthCheckService } = require('../../app/services')
 
-describe.only('Database Health Check service', () => {
+describe('Database Health Check service', () => {
   beforeEach(async () => {
     await DatabaseHelper.clean()
   })

--- a/test/services/database_health_check.service.test.js
+++ b/test/services/database_health_check.service.test.js
@@ -1,0 +1,37 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const { DatabaseHelper } = require('../support/helpers')
+
+// Thing under test
+const { DatabaseHealthCheckService } = require('../../app/services')
+
+describe.only('Database Health Check service', () => {
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+  })
+
+  it('confirms connection to the db by not throwing an error', async () => {
+    await expect(DatabaseHealthCheckService.go()).to.not.reject()
+  })
+
+  it('returns stats about each table', async () => {
+    const result = await DatabaseHealthCheckService.go()
+
+    // We expect at least the following tables to exist
+    // - authorised_systems
+    // - authorised_systems_regimes
+    // - knex_migrations
+    // - knex_migrations_lock
+    // - regimes
+    expect(result.length).to.be.at.least(5)
+    expect(result[0].relname).to.exist()
+  })
+})

--- a/test/services/database_health_check.service.test.js
+++ b/test/services/database_health_check.service.test.js
@@ -25,12 +25,7 @@ describe('Database Health Check service', () => {
   it('returns stats about each table', async () => {
     const result = await DatabaseHealthCheckService.go()
 
-    // We expect at least the following tables to exist
-    // - authorised_systems
-    // - authorised_systems_regimes
-    // - knex_migrations
-    // - knex_migrations_lock
-    // - regimes
+    // We expect at least 5 tables to exist and be returned in the results
     expect(result.length).to.be.at.least(5)
     expect(result[0].relname).to.exist()
   })


### PR DESCRIPTION
This controller is more about confirming we can connect to a database in a given environment. But it will also allow us to access stats about each table, for example row counts and number of sequential scans. This information will be useful to monitor when the service goes live.