### PR TITLE
Use knex config to handle multiple environments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,9 +13,10 @@ IGNORE_JWT_EXPIRATION=false
 # Database config
 POSTGRES_USER=myuser
 POSTGRES_PASSWORD=password12345
-POSTGRES_DB=sroc_charge
 POSTGRES_HOST=db
 POSTGRES_PORT=5432
+POSTGRES_DB=sroc_charge
+POSTGRES_DB_TEST=sroc_charge_test
 
 # Server config
 PORT=3000

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
       POSTGRES_HOST: localhost
       POSTGRES_PORT: 5432
       POSTGRES_DB: sroc_charge_test
+      POSTGRES_DB_TEST: sroc_charge_test
       ENVIRONMENT: dev
       RULES_SERVICE_URL: http://example.com
       RULES_SERVICE_USER: admin

--- a/config/database.config.js
+++ b/config/database.config.js
@@ -6,8 +6,9 @@ const config = {
   host: process.env.POSTGRES_HOST,
   user: process.env.POSTGRES_USER,
   password: process.env.POSTGRES_PASSWORD,
+  port: process.env.POSTGRES_PORT,
   database: process.env.POSTGRES_DB,
-  port: process.env.POSTGRES_PORT
+  testDatabase: process.env.POSTGRES_DB_TEST
 }
 
 module.exports = config

--- a/db/create_database.js
+++ b/db/create_database.js
@@ -1,20 +1,22 @@
 'use strict'
 
-const DatabaseConfig = require('../config/database.config')
+const environment = process.env.NODE_ENV || 'development'
 
-// If the script has been run using the package.json scripts the database name
-// will be set as `sroc_charge` or `sroc_charge_test`. This is done by
-// overriding the PGDATABASE env var set in .env (or the current environment).
-const databaseName = DatabaseConfig.database
+const dbConfig = require('../knexfile')[environment]
 
-// connect to maintenance database
+const databaseName = dbConfig.connection.database
+
+// Connect to maintenance database. We can't use `knexfile.js` and require it as we would in other places because it
+// will already have instantiated using the actual db.
+// So we have to grab our config and instantiate it ourselves here so we can connect against the default 'postgres' db.
+// https://stackoverflow.com/a/31428260/6117745
 const knex = require('knex')({
   client: 'pg',
   connection: {
-    host: DatabaseConfig.host,
-    port: DatabaseConfig.port,
-    user: DatabaseConfig.user,
-    password: DatabaseConfig.password,
+    host: dbConfig.connection.host,
+    port: dbConfig.connection.port,
+    user: dbConfig.connection.user,
+    password: dbConfig.connection.password,
     database: 'postgres',
     charset: 'utf8'
   }

--- a/db/index.js
+++ b/db/index.js
@@ -1,6 +1,8 @@
 'use strict'
 
-const dbConfig = require('../knexfile')
+const environment = process.env.NODE_ENV || 'development'
+
+const dbConfig = require('../knexfile')[environment]
 
 const db = require('knex')(dbConfig)
 

--- a/knexfile.js
+++ b/knexfile.js
@@ -2,16 +2,8 @@
 
 const DatabaseConfig = require('./config/database.config')
 
-module.exports = {
+const defaultConfig = {
   client: 'postgres',
-  connection: {
-    host: DatabaseConfig.host,
-    user: DatabaseConfig.user,
-    password: DatabaseConfig.password,
-    database: DatabaseConfig.database,
-    port: DatabaseConfig.port,
-    charset: 'utf8'
-  },
   useNullAsDefault: true,
   migrations: {
     tableName: 'knex_migrations',
@@ -21,3 +13,41 @@ module.exports = {
     directory: './db/seeds'
   }
 }
+
+const development = {
+  connection: {
+    host: DatabaseConfig.host,
+    user: DatabaseConfig.user,
+    password: DatabaseConfig.password,
+    database: DatabaseConfig.database,
+    port: DatabaseConfig.port,
+    charset: 'utf8'
+  },
+  ...defaultConfig
+}
+
+const test = {
+  connection: {
+    host: DatabaseConfig.host,
+    user: DatabaseConfig.user,
+    password: DatabaseConfig.password,
+    database: DatabaseConfig.testDatabase,
+    port: DatabaseConfig.port,
+    charset: 'utf8'
+  },
+  ...defaultConfig
+}
+
+const production = {
+  connection: {
+    host: DatabaseConfig.host,
+    user: DatabaseConfig.user,
+    password: DatabaseConfig.password,
+    database: DatabaseConfig.database,
+    port: DatabaseConfig.port,
+    charset: 'utf8'
+  },
+  ...defaultConfig
+}
+
+module.exports = { development, test, production }

--- a/knexfile.js
+++ b/knexfile.js
@@ -14,40 +14,35 @@ const defaultConfig = {
   }
 }
 
+const defaultConnection = {
+  host: DatabaseConfig.host,
+  user: DatabaseConfig.user,
+  password: DatabaseConfig.password,
+  database: DatabaseConfig.database,
+  port: DatabaseConfig.port,
+  charset: 'utf8'
+}
+
 const development = {
+  ...defaultConfig,
   connection: {
-    host: DatabaseConfig.host,
-    user: DatabaseConfig.user,
-    password: DatabaseConfig.password,
-    database: DatabaseConfig.database,
-    port: DatabaseConfig.port,
-    charset: 'utf8'
-  },
-  ...defaultConfig
+    ...defaultConnection
+  }
 }
 
 const test = {
+  ...defaultConfig,
   connection: {
-    host: DatabaseConfig.host,
-    user: DatabaseConfig.user,
-    password: DatabaseConfig.password,
-    database: DatabaseConfig.testDatabase,
-    port: DatabaseConfig.port,
-    charset: 'utf8'
-  },
-  ...defaultConfig
+    ...defaultConnection,
+    database: DatabaseConfig.testDatabase
+  }
 }
 
 const production = {
+  ...defaultConfig,
   connection: {
-    host: DatabaseConfig.host,
-    user: DatabaseConfig.user,
-    password: DatabaseConfig.password,
-    database: DatabaseConfig.database,
-    port: DatabaseConfig.port,
-    charset: 'utf8'
-  },
-  ...defaultConfig
+    ...defaultConnection
+  }
 }
 
 module.exports = { development, test, production }

--- a/knexfile.js
+++ b/knexfile.js
@@ -25,9 +25,7 @@ const defaultConnection = {
 
 const development = {
   ...defaultConfig,
-  connection: {
-    ...defaultConnection
-  }
+  connection: defaultConnection
 }
 
 const test = {
@@ -40,9 +38,7 @@ const test = {
 
 const production = {
   ...defaultConfig,
-  connection: {
-    ...defaultConnection
-  }
+  connection: defaultConnection
 }
 
 module.exports = { development, test, production }

--- a/package.json
+++ b/package.json
@@ -9,11 +9,11 @@
     "watch": "./node_modules/nodemon/bin/nodemon.js --watch ./app --watch server.js -x node server.js",
     "lint": "standard",
     "test": "npm run lint && npm run migratedbtest && npm run unit-test",
-    "createdb": "PGDATABASE=sroc_charge node db/create_database.js",
-    "createdbtest": "PGDATABASE=sroc_charge_test node db/create_database.js",
-    "migratedb": "PGDATABASE=sroc_charge knex migrate:latest",
-    "migratedbtest": "PGDATABASE=sroc_charge_test knex migrate:latest",
-    "unit-test": "PGDATABASE=sroc_charge_test lab --silent-skips"
+    "createdb": "node db/create_database.js",
+    "createdbtest": "NODE_ENV=test node db/create_database.js",
+    "migratedb": "knex migrate:latest",
+    "migratedbtest": "NODE_ENV=test knex migrate:latest",
+    "unit-test": "lab --silent-skips"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -13,9 +13,7 @@
     "createdbtest": "PGDATABASE=sroc_charge_test node db/create_database.js",
     "migratedb": "PGDATABASE=sroc_charge knex migrate:latest",
     "migratedbtest": "PGDATABASE=sroc_charge_test knex migrate:latest",
-    "unit-test": "PGDATABASE=sroc_charge_test lab --silent-skips",
-    "dropdb": "dropdb sroc_charge",
-    "dropdbtest": "dropdb sroc_charge_test"
+    "unit-test": "PGDATABASE=sroc_charge_test lab --silent-skips"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
When we created this project as a replacement for the [charging-module-api](https://github.com/defra/charging-module-api) we followed some of its existing practises as we were just getting started. One of them was to hardcode which database to use into the some of the npm scripts.

Knex and specifically its config file `knexfile.js` has the ability to maintain a number of different configurations. Which is used is determined by what `NODE_ENV` is set to.

By switching to use the `knexfile.js` properly we are not only being more consistent with our knex usage, we are also enabling more flexibility by not having to hardcode database names into the project.