### PR TITLE
Add pre-sroc bill run translator

### DIFF
--- a/app/translators/bill_run.translator.js
+++ b/app/translators/bill_run.translator.js
@@ -1,0 +1,24 @@
+' use strict'
+
+const BaseTranslator = require('./base.translator')
+const Joi = require('joi')
+
+class BillRunTranslator extends BaseTranslator {
+  _translations () {
+    return {
+      region: 'region'
+    }
+  }
+
+  _schema () {
+    return Joi.object({
+      region: Joi.string().uppercase().valid(...this._validRegions())
+    })
+  }
+
+  _validRegions () {
+    return ['A', 'B', 'E', 'N', 'S', 'T', 'W', 'Y']
+  }
+}
+
+module.exports = BillRunTranslator

--- a/app/translators/index.js
+++ b/app/translators/index.js
@@ -1,11 +1,13 @@
 'use strict'
 
 const BaseTranslator = require('./base.translator')
+const BillRunTranslator = require('./bill_run.translator')
 const ChargeTranslator = require('./charge.translator')
 const RulesServiceTranslator = require('./rules_service.translator')
 
 module.exports = {
   BaseTranslator,
+  BillRunTranslator,
   ChargeTranslator,
   RulesServiceTranslator
 }

--- a/test/translators/bill_run.translator.test.js
+++ b/test/translators/bill_run.translator.test.js
@@ -13,7 +13,7 @@ const { ValidationError } = require('joi')
 // Thing under test
 const { BillRunTranslator } = require('../../app/translators')
 
-describe.only('Bill Run translator', () => {
+describe('Bill Run translator', () => {
   const data = region => {
     return {
       region: region

--- a/test/translators/bill_run.translator.test.js
+++ b/test/translators/bill_run.translator.test.js
@@ -1,0 +1,56 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const { ValidationError } = require('joi')
+
+// Thing under test
+const { BillRunTranslator } = require('../../app/translators')
+
+describe.only('Bill Run translator', () => {
+  const data = region => {
+    return {
+      region: region
+    }
+  }
+
+  describe('Validation', () => {
+    describe('when the data is valid', () => {
+      it('does not throw an error', async () => {
+        const region = 'A'
+
+        expect(() => new BillRunTranslator(data(region))).to.not.throw()
+      })
+
+      it("does not throw an error if the 'region' is lowercase", async () => {
+        const region = 'a'
+
+        expect(() => new BillRunTranslator(data(region))).to.not.throw()
+      })
+    })
+
+    describe('when the data is not valid', () => {
+      describe("because the 'region' is missing", () => {
+        it('throws an error', async () => {
+          const region = ''
+
+          expect(() => new BillRunTranslator(data(region))).to.throw(ValidationError)
+        })
+      })
+
+      describe("because the 'region' is unrecognised", () => {
+        it('throws an error', async () => {
+          const region = 'Z'
+
+          expect(() => new BillRunTranslator(data(region))).to.throw(ValidationError)
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
This is the first step in being able to support a create bill run translator. When we have a request come in we'll need to be ale to validate it and map it to a model.

Adding a translator is the first step in being able to do this.