### PR TITLE
Add not-supported controller to project

### DIFF
--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -10,6 +10,8 @@ const DatabaseController = require('./admin/health/database.controller')
 const BaseTransactionsController = require('./base_transactions.controller')
 const BaseCalculateChargeController = require('./base_calculate_charge.controller')
 
+const NotSupportedController = require('./not_supported.controller')
+
 const PresrocBillRunsController = require('./presroc/bill_runs.controller')
 const PresrocTransactionsController = require('./presroc/transactions.controller')
 const PresrocCalculateChargeController = require('./presroc/calculate_charge.controller')
@@ -28,6 +30,7 @@ module.exports = {
   PresrocBillRunsController,
   PresrocTransactionsController,
   PresrocCalculateChargeController,
+  NotSupportedController,
   SrocTransactionsController,
   SrocCalculateChargeController
 }

--- a/app/controllers/not_supported.controller.js
+++ b/app/controllers/not_supported.controller.js
@@ -1,0 +1,11 @@
+'use strict'
+
+const Boom = require('@hapi/boom')
+
+class NotSupportedController {
+  static async index (_req, _h) {
+    throw Boom.resourceGone('This version of the resource is no longer available. There may be an updated version.')
+  }
+}
+
+module.exports = NotSupportedController

--- a/app/routes/bill_run.routes.js
+++ b/app/routes/bill_run.routes.js
@@ -1,12 +1,12 @@
 'use strict'
 
-const { PresrocBillRunsController } = require('../controllers')
+const { NotSupportedController, PresrocBillRunsController } = require('../controllers')
 
 const routes = [
   {
     method: 'POST',
     path: '/v1/{regimeId}/billruns',
-    handler: PresrocBillRunsController.create
+    handler: NotSupportedController.index
   },
   {
     method: 'POST',

--- a/test/controllers/not_supported.controller.test.js
+++ b/test/controllers/not_supported.controller.test.js
@@ -1,0 +1,35 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, before } = exports.lab = Lab.script()
+const { expect } = Code
+
+// For running our service
+const { deployment } = require('../../server')
+
+// Test helpers
+const { RouteHelper } = require('../support/helpers')
+
+describe('Not Supported controller', () => {
+  let server
+
+  // Create server before each test
+  before(async () => {
+    server = await deployment()
+    RouteHelper.addNotSupportedRoute(server)
+  })
+
+  it('returns a 410 error', async () => {
+    const options = {
+      method: 'GET',
+      url: '/test/not-supported'
+    }
+
+    const response = await server.inject(options)
+
+    expect(response.statusCode).to.equal(410)
+  })
+})

--- a/test/support/helpers/route.helper.js
+++ b/test/support/helpers/route.helper.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { NotSupportedController } = require('../../../app/controllers')
+
 /**
  * A helper that provides test routes.
  *
@@ -89,6 +91,23 @@ class RouteHelper {
         auth: {
           scope: ['system']
         }
+      }
+    })
+  }
+
+  /**
+   * Adds a route to a Hapi server instance which replicates an unsupported route.
+   *
+   * This supports testing that when we flag a route as 'unsupported' it behaves as we expect. For example, we are
+   * flagging that the /v1 versions of a number of endpoints are not supported in this project.
+   */
+  static addNotSupportedRoute (server) {
+    server.route({
+      method: 'GET',
+      path: '/test/not-supported',
+      handler: NotSupportedController.index,
+      options: {
+        auth: false
       }
     })
   }


### PR DESCRIPTION
This project is a replacement for the [charging-module-api](https://github.com/defra/chartging-module-api). It was originally intended as the means of implementing a new version of the charging rules and the requirements that go with it (SROC). But that has been postponed till 2022.

In the meantime, there are improvements to be made to the existing functionality, especially around the performance of generating the bill run. Plus we believe the design of this project is the only way we can support adding new regimes without duplicating all existing code. Duplication seems to be the only solution to adding regimes in the charging-module-api.

As these are large scale changes to the functionality we are doing them here so we at least have a 'working' version of the API for our first regime WRLS in the charging-module.

`/v2/` endpoints were going to represent SROC versions. Now we'll use them to represent updated versions of the existing endpoints. And as these are direct replacements there is no need to re-engineer the `/v1` endpoints as part of this project.

So to make it clear where we are not supporting a `/v1` version of an endpoint this change adds a new `NotSupportedController`.