### PR TITLE
Make docker dev environment more distinct

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   db:
     image: postgres:10-alpine
     volumes:
-      - db_volume:/var/lib/postgresql/data
+      - cma_db_volume:/var/lib/postgresql/data
     ports:
       - "54320:5432"
     env_file:
@@ -37,7 +37,7 @@ services:
       - ./package-lock.json:/home/node/package-lock.json
       # This is a workaround to prevent the host node_modules from accidently getting mounted in the container in case
       # you want to use either `node` or `npm` outside it, for example, to run linting.
-      - notused:/home/node/app/node_modules
+      - cma_notused:/home/node/app/node_modules
     env_file:
       - .env
     # Run these services first before you run this one. Note, it does not wait or check to ensure the service is fully
@@ -46,5 +46,5 @@ services:
       - db
 
 volumes:
-  db_volume:
-  notused:
+  cma_db_volume:
+  cma_notused:


### PR DESCRIPTION
When working on the [charging-module-api Docker dev environment](https://github.com/DEFRA/charging-module-api/pull/175) we realised that the volume names used in the Docker compose were pretty generic. So resolved this in the charging-module by prefixing `cha_` to the names.

This change is just about solving the same issue in this project and ensuring we don't inadvertently overwrite or remove another service's volumes.