### PR TITLE
Fix sonarcloud smell - return regimes directly

### DIFF
--- a/app/services/create_authorised_system.service.js
+++ b/app/services/create_authorised_system.service.js
@@ -28,11 +28,9 @@ class CreateAuthorisedSystemService {
   }
 
   static async _regimes (authorisations) {
-    const regimes = await RegimeModel.query()
+    return RegimeModel.query()
       .select('id')
       .where('slug', 'in', authorisations)
-
-    return regimes
   }
 
   static async _create (translator, regimes) {


### PR DESCRIPTION
> Immediately return this expression instead of assigning it to the temporary variable "regimes".

SonarCloud tagged some code as a code smell. Currently we assign a return value to a temporary variable then return it. We should be returning it directly.

This changes fixes the issue.