### PR TITLE
Fix not handling unknown client id

### DIFF
--- a/app/auth/jwt_strategy.auth.js
+++ b/app/auth/jwt_strategy.auth.js
@@ -3,6 +3,7 @@
 const { AuthenticationConfig } = require('../../config')
 const { CognitoJwtToPemService } = require('../services')
 const { AuthorisedSystemModel } = require('../models')
+const Boom = require('@hapi/boom')
 
 const authOptions = {
   verifyJWT: true,
@@ -19,6 +20,13 @@ const authOptions = {
     // Find the authorised system with a matching client ID
     const authorisedSystem = await AuthorisedSystemModel.query()
       .findOne({ client_id: clientId })
+
+    // No matching authorised system found
+    if (!authorisedSystem) {
+      // We throw a Boom error rather than returning `isValid: false` as it allows us to control the error message. If
+      // we didn't the client would just get the message 'Bad token'
+      throw Boom.unauthorized(`The client ID '${clientId}' is not recognised`)
+    }
 
     // We use the `options.auth.scope` property on our routes to manage authorisation and what endpoints a client can
     // access. Public endpoints have a scope of `system`. Admin can access these as well as those with only a scope of

--- a/test/features/authentication.test.js
+++ b/test/features/authentication.test.js
@@ -88,11 +88,13 @@ describe('Authenticating with the API', () => {
         })
       })
 
-      describe.only("but it contains an unrecognised 'client_id'", () => {
+      describe("but it contains an unrecognised 'client_id'", () => {
+        const unknownClientId = 'notfromroundhere'
+
         before(async () => {
           authToken = AuthorisationHelper.adminToken()
           const decodedTokenWithUnknownId = AuthorisationHelper.decodeToken(authToken)
-          decodedTokenWithUnknownId.client_id = 'notfromroundhere'
+          decodedTokenWithUnknownId.client_id = unknownClientId
 
           Sinon
             .stub(JsonWebToken, 'verify')
@@ -107,8 +109,10 @@ describe('Authenticating with the API', () => {
           }
 
           const response = await server.inject(options)
+          const payload = JSON.parse(response.payload)
 
           expect(response.statusCode).to.equal(401)
+          expect(payload.message).to.equal(`The client ID '${unknownClientId}' is not recognised`)
         })
       })
     })


### PR DESCRIPTION
https://trello.com/c/DWZta7a6

In preparation for a thorough test of our authentication and authorisation functionality we did some exploratory testing ourselves. We found an issue where the service errors and returns a 500 when it should be returning a `401 - Unauthorized`.

If the token is valid (it is properly signed and not expired) but contains an unrecognised `client_id` we currently error.

This change fixes the issue. In this scenario we now will return a `401 - Unauthorized`.