### PR TITLE
Only allow 'active' authorised systems

### DIFF
--- a/app/auth/jwt_strategy.auth.js
+++ b/app/auth/jwt_strategy.auth.js
@@ -28,6 +28,12 @@ const authOptions = {
       throw Boom.unauthorized(`The client ID '${clientId}' is not recognised`)
     }
 
+    if (!authorisedSystem.$active()) {
+      // We return a 403 rather than a 401 because the credentials are for a valid user (so they are authenticated) but
+      // because the user is not 'active' they are forbidden from accessing any functionality (not authorized)
+      throw Boom.forbidden(`Client ID '${clientId}' is no longer active`)
+    }
+
     // We use the `options.auth.scope` property on our routes to manage authorisation and what endpoints a client can
     // access. Public endpoints have a scope of `system`. Admin can access these as well as those with only a scope of
     // `admin`.

--- a/app/models/authorised_system.model.js
+++ b/app/models/authorised_system.model.js
@@ -37,6 +37,18 @@ class AuthorisedSystemModel extends BaseModel {
       }
     }
   }
+
+  /**
+   * Returns whether the authorised system is 'active' or not
+   *
+   * Checks the value of `status` on the instance and if 'active' it returns `true` else it returns `false`. We use this
+   * as part of authorisation to determine if the client is permitted to use the service or not.
+   *
+   * @returns {boolean} whether this instance is 'active'
+   */
+  $active () {
+    return (this.status.toLowerCase() === 'active')
+  }
 }
 
 module.exports = AuthorisedSystemModel

--- a/test/models/authorised_system.model.test.js
+++ b/test/models/authorised_system.model.test.js
@@ -1,0 +1,27 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Thing under test
+const { AuthorisedSystemModel } = require('../../app/models')
+
+describe('Authorised System Model', () => {
+  describe('the $active() method', () => {
+    it("returns 'true' when the status is 'active'", async () => {
+      const instance = AuthorisedSystemModel.fromJson({ status: 'active' })
+
+      expect(instance.$active()).to.be.true()
+    })
+
+    it("returns 'false' when the status is not 'active'", async () => {
+      const instance = AuthorisedSystemModel.fromJson({ status: 'inactive' })
+
+      expect(instance.$active()).to.be.false()
+    })
+  })
+})

--- a/test/support/helpers/authorised_system.helper.js
+++ b/test/support/helpers/authorised_system.helper.js
@@ -17,12 +17,15 @@ class AuthorisedSystemHelper {
    * Create an admin system record
    *
    * @param {string} [clientId] If not set will default to the configured admin client ID.
+   * @param {string} [name='active'] Name to be set for the new user
+   * @param {string} [status='active'] Status to be set for the new user
+   *
    * @returns {module:AuthorisedSystemModel} The result of the db insertion for your reference
    */
-  static async addAdminSystem (clientId) {
+  static async addAdminSystem (clientId, name = 'admin', status = 'active') {
     const systemId = clientId || AuthenticationConfig.adminClientId
 
-    return this._insertSystem(systemId, 'admin', true, 'active')
+    return this._insertSystem(systemId, name, true, status)
   }
 
   /**
@@ -31,10 +34,12 @@ class AuthorisedSystemHelper {
    * @param {string} clientId Client ID you want set for the system
    * @param {string} name Name you want to set for the system
    * @param {module:RegimeModel[]} [regimes={}] An array of `RegimeModel` to be related to the new system user
+   * @param {string} [status='active'] Status to be set for the new user
+   *
    * @returns {module:AuthorisedSystemModel} The result of the db insertion for your reference
    */
-  static async addSystem (clientId, name, regimes = []) {
-    return this._insertSystem(clientId, name, false, 'active', regimes)
+  static async addSystem (clientId, name, regimes = [], status = 'active') {
+    return this._insertSystem(clientId, name, false, status, regimes)
   }
 
   static async _insertSystem (clientId, name, isAdmin, status, regimes) {


### PR DESCRIPTION
https://trello.com/c/mjGotliI

When we migrated the authorised system functionality over we added a status column. The intent is we can use this to control an authorised systems access without having to remove the record.

As yet we don't know what the different statuses will be. What we do know is that only authorised systems with a status of 'active' should be able to access the service.