### PR TITLE
Update PostgreSQl dependence to v12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       # Label used to access the service container
       postgres:
         # Docker Hub image
-        image: postgres:10-alpine
+        image: postgres:12-alpine
         # Provide the password for postgres
         env:
           POSTGRES_USER: charge

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This API provides an interface for calculating charges, queuing transactions and
 Make sure you already have:
 
 - [Node.js v12.*](https://nodejs.org/en/)
-- [PostgreSQL v10](https://www.postgresql.org/)
+- [PostgreSQL v12](https://www.postgresql.org/)
 
 ## Installation
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   db:
-    image: postgres:10-alpine
+    image: postgres:12-alpine
     volumes:
       - cma_db_volume:/var/lib/postgresql/data
     ports:


### PR DESCRIPTION
Currently the [charging-module-api](http://github.com/defra/charging-module-api) depends on version 10.6 of PostgreSQL. Our AWS environments are currently running that version and our original intent was to drop this version of the API in alongside until we are ready to switch.

Now we are working through so many changes as part of the performance rework with the intent of simply swapping out the old version we don't have that concern. So to take advantage of performance improvements in the latest version AWS RDS supports and to 'future-proof' the service for as long as possible we're going straight to PostgreSQL v12 when we deploy.

We won't have to change our Postgres related packages are they are on the latest already. But this change does update our development docker environment and CI to confirm we can work with v12.