### PR TITLE
Fix reliance on dev-only dependencies in prod.

### DIFF
--- a/config/server.config.js
+++ b/config/server.config.js
@@ -3,13 +3,16 @@
 require('dotenv').config()
 
 const config = {
-  port: process.env.PORT,
-  // The routes section is used to set default configuration for every route
-  // in the app. In our case we want to Hapi to set a bunch of common security
-  // heades. See https://hapi.dev/api/?v=20.0.0#-routeoptionssecurity for
-  // details of what gets enabled
-  routes: {
-    security: true
+  environment: process.env.NODE_ENV || 'development',
+  hapi: {
+    port: process.env.PORT,
+    // The routes section is used to set default configuration for every route
+    // in the app. In our case we want to Hapi to set a bunch of common security
+    // heades. See https://hapi.dev/api/?v=20.0.0#-routeoptionssecurity for
+    // details of what gets enabled
+    routes: {
+      security: true
+    }
   }
 }
 

--- a/server.js
+++ b/server.js
@@ -18,7 +18,7 @@ const {
 
 exports.deployment = async start => {
   // Create the hapi server
-  const server = Hapi.server(ServerConfig)
+  const server = Hapi.server(ServerConfig.hapi)
 
   // Register our auth plugin and then the strategies (needs to be done in this
   // order)
@@ -34,8 +34,12 @@ exports.deployment = async start => {
   await server.register(InvalidCharactersPlugin)
   await server.register(PayloadCleanerPlugin)
   await server.register(HapiPinoPlugin(TestConfig.logInTest))
-  await server.register(BlippPlugin)
-  await server.register(HpalDebugPlugin)
+
+  // Register non-production plugins
+  if (ServerConfig.environment === 'development') {
+    await server.register(BlippPlugin)
+    await server.register(HpalDebugPlugin)
+  }
 
   await server.initialize()
 


### PR DESCRIPTION
Spotted when we built a Docker image for production and then tried to run it. We keep seeing this error

```
uncaught exception Error: Cannot find module 'hpal-debug'
Require stack:
- /home/node/app/app/plugins/hpal_debug.plugin.js
- /home/node/app/app/plugins/index.js
- /home/node/app/server.js
at Function.Module._resolveFilename (internal/modules/cjs/loader.js:831:15)
at Function.Module._load (internal/modules/cjs/loader.js:687:27)
at Module.require (internal/modules/cjs/loader.js:903:19)
at require (internal/modules/cjs/helpers.js:74:18)
at Object.<anonymous> (/home/node/app/app/plugins/hpal_debug.plugin.js:23:19)
at Module._compile (internal/modules/cjs/loader.js:1015:30)
at Object.Module._extensions..js (internal/modules/cjs/loader.js:1035:10)
at Module.load (internal/modules/cjs/loader.js:879:32)
at Function.Module._load (internal/modules/cjs/loader.js:724:14)
at Module.require (internal/modules/cjs/loader.js:903:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/home/node/app/app/plugins/hpal_debug.plugin.js',
    '/home/node/app/app/plugins/index.js',
    '/home/node/app/server.js'
  ]
}
```

[hpal_debug](https://github.com/hapipal/hpal-debug) is something we use in development only so list as a dev dependency. But because it's a plugin we are currently always trying to register it even when the app is run with `NODE_ENV` set to `production`.

When the docker image was built, it didn't include any of the dev dependencies. That's because of the behaviour of `npm install`

> With the `--production` flag (or when the `NODE_ENV` environment variable is set to `production`), npm will not install modules listed in `devDependencies`.
>
> https://docs.npmjs.com/cli/v6/commands/npm-install

We shouldn't be loading dev only plugins so this change fixes the issue by adding a check in `server.js` for whether production mode is enabled. If so it won't register any dev only dependencies.