### PR TITLE
Create Bill Run presenter

### DIFF
--- a/app/presenters/create_bill_run.presenter.js
+++ b/app/presenters/create_bill_run.presenter.js
@@ -1,0 +1,23 @@
+'use strict'
+
+/**
+ * @module CreateBillRunPresenter
+ */
+
+const BasePresenter = require('./base.presenter')
+
+/**
+ * Handles formatting the data into the response we send to clients after a create bill run request.
+ */
+class CreateBillRunPresenter extends BasePresenter {
+  _presentation (data) {
+    return {
+      billRun: {
+        id: data.id,
+        billRunNumber: data.billRunNumber
+      }
+    }
+  }
+}
+
+module.exports = CreateBillRunPresenter

--- a/app/presenters/index.js
+++ b/app/presenters/index.js
@@ -2,12 +2,14 @@
 
 const BasePresenter = require('./base.presenter')
 const CalculateChargePresenter = require('./calculate_charge.presenter')
+const CreateBillRunPresenter = require('./create_bill_run.presenter')
 const JsonPresenter = require('./json.presenter')
 const RulesServicePresenter = require('./rules_service.presenter')
 
 module.exports = {
   BasePresenter,
   CalculateChargePresenter,
+  CreateBillRunPresenter,
   JsonPresenter,
   RulesServicePresenter
 }

--- a/app/services/create_bill_run.service.js
+++ b/app/services/create_bill_run.service.js
@@ -6,7 +6,7 @@
 
 const { BillRunModel } = require('../models')
 const { BillRunTranslator } = require('../translators')
-const { JsonPresenter } = require('../presenters')
+const { CreateBillRunPresenter } = require('../presenters')
 
 // Files in the same folder cannot be destructured from index.js so have to be required directly
 const NextBillRunNumberService = require('./next_bill_run_number.service')
@@ -48,7 +48,7 @@ class CreateBillRunService {
   }
 
   static async _response (billRun) {
-    const presenter = new JsonPresenter(billRun)
+    const presenter = new CreateBillRunPresenter(billRun)
 
     return presenter.go()
   }

--- a/test/controllers/presroc/bill_runs.controller.test.js
+++ b/test/controllers/presroc/bill_runs.controller.test.js
@@ -62,10 +62,12 @@ describe('Presroc Bill Runs controller', () => {
 
       const response = await server.inject(options(authToken, requestPayload))
       const responsePayload = JSON.parse(response.payload)
+      const { billRun } = responsePayload
 
       expect(response.statusCode).to.equal(201)
-      expect(responsePayload.id).to.exist()
-      expect(responsePayload.region).to.equal(requestPayload.region)
+      expect(billRun.id).to.exist()
+      expect(billRun.billRunNumber).to.exist()
+      expect(billRun).to.have.length(2)
     })
 
     it('will not add an bill run with invalid data', async () => {

--- a/test/presenters/create_bill_run.presenter.test.js
+++ b/test/presenters/create_bill_run.presenter.test.js
@@ -1,0 +1,32 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Thing under test
+const { CreateBillRunPresenter } = require('../../app/presenters')
+
+describe('Create Bill Run presenter', () => {
+  it('correctly presents the data', () => {
+    const data = {
+      billRunNumber: 10001,
+      region: 'A',
+      regimeId: 'ff75f82d-d56f-4807-9cad-12f23d6b29a8',
+      createdBy: 'e46b816a-3fe8-438a-a3f9-7a1a8eb525ce',
+      status: 'initialised',
+      id: 'e2a28efc-09eb-439e-95bc-e64c68ab1ea5'
+    }
+
+    const testPresenter = new CreateBillRunPresenter(data)
+    const result = testPresenter.go()
+    const { billRun } = result
+
+    expect(billRun.id).to.equal(data.id)
+    expect(billRun.billRunNumber).to.equal(data.billRunNumber)
+    expect(billRun).to.have.length(2)
+  })
+})

--- a/test/services/create_bill_run.service.test.js
+++ b/test/services/create_bill_run.service.test.js
@@ -31,34 +31,30 @@ describe('Create Bill Run service', () => {
   })
 
   describe('When the data is valid', () => {
-    it('creates a bill', async () => {
-      const result = await CreateBillRunService.go(payload, authorisedSystem, regime)
+    let result
 
-      expect(result instanceof BillRunModel).to.equal(true)
+    beforeEach(async () => {
+      const billRun = await CreateBillRunService.go(payload, authorisedSystem, regime)
+      result = await BillRunModel.query().findById(billRun.billRun.id)
+    })
+
+    it('creates a bill', async () => {
       expect(result.id).to.exist()
     })
 
     it("records the 'regime' it's for", async () => {
-      const result = await CreateBillRunService.go(payload, authorisedSystem, regime)
-
       expect(result.regimeId).to.equal(regime.id)
     })
 
     it("records who it was 'created_by'", async () => {
-      const result = await CreateBillRunService.go(payload, authorisedSystem, regime)
-
       expect(result.createdBy).to.equal(authorisedSystem.id)
     })
 
     it("defaults 'status' to 'initialised", async () => {
-      const result = await CreateBillRunService.go(payload, authorisedSystem, regime)
-
       expect(result.status).to.equal('initialised')
     })
 
     it('records the bill run number', async () => {
-      const result = await CreateBillRunService.go(payload, authorisedSystem, regime)
-
       // Bill run number column defaults to 10000 so the first number retrieved will be 10001
       expect(result.billRunNumber).to.equal(10001)
     })


### PR DESCRIPTION
The last part of adding bill run numbers to the create bill run endpoint is to define `create_bill_run.presenter` which we use to return to the end user the bill run id and number.

This change implements this and updates existing tests:

- `bill_runs.controller` now only tests for the info returned;
- `create_bill_run.service` now pulls the bill run from the database and tests its properties, rather than relying on all the properties being returned.