### PR TITLE
Override default hapi router options

### DIFF
--- a/config/server.config.js
+++ b/config/server.config.js
@@ -6,12 +6,18 @@ const config = {
   environment: process.env.NODE_ENV || 'development',
   hapi: {
     port: process.env.PORT,
-    // The routes section is used to set default configuration for every route
-    // in the app. In our case we want to Hapi to set a bunch of common security
-    // heades. See https://hapi.dev/api/?v=20.0.0#-routeoptionssecurity for
-    // details of what gets enabled
+    // The routes section is used to set default configuration for every route in the app. In our case we want to Hapi
+    // to set a bunch of common security headers. See https://hapi.dev/api/?v=20.0.0#-routeoptionssecurity for details
+    // of what gets enabled.
     routes: {
       security: true
+    },
+    // The router section controls how incoming request URIs are matched against the routing table. In our AWS
+    // environments we see trailing slashes added to the end of paths so this deals with that issue. We also don't want
+    // client systems having to worry about what case they use for the endpoint when making a request.
+    router: {
+      isCaseSensitive: false,
+      stripTrailingSlash: true
     }
   }
 }

--- a/test/features/routing.test.js
+++ b/test/features/routing.test.js
@@ -20,13 +20,13 @@ const options = (url) => {
   }
 }
 
-describe('Routing requests to the API', () => {
+describe.only('Routing requests to the API', () => {
   let server
 
   // Create server before each test
   before(async () => {
     server = await deployment()
-    RouteHelper.addPublicPostRoute(server)
+    RouteHelper.addPublicRoute(server)
   })
 
   describe('When a request path has a trailing slash', () => {

--- a/test/features/routing.test.js
+++ b/test/features/routing.test.js
@@ -1,0 +1,47 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, before } = exports.lab = Lab.script()
+const { expect } = Code
+
+// For running our service
+const { deployment } = require('../../server')
+
+// Test helpers
+const { RouteHelper } = require('../support/helpers')
+
+const options = (url) => {
+  return {
+    method: 'GET',
+    url: url
+  }
+}
+
+describe('Routing requests to the API', () => {
+  let server
+
+  // Create server before each test
+  before(async () => {
+    server = await deployment()
+    RouteHelper.addPublicPostRoute(server)
+  })
+
+  describe('When a request path has a trailing slash', () => {
+    it('still matches the route', async () => {
+      const response = await server.inject(options('/test/public/'))
+
+      expect(response.statusCode).to.equal(200)
+    })
+  })
+
+  describe('When a request path uses a different case', () => {
+    it('still matches the route', async () => {
+      const response = await server.inject(options('/test/PUBLIC'))
+
+      expect(response.statusCode).to.equal(200)
+    })
+  })
+})

--- a/test/features/routing.test.js
+++ b/test/features/routing.test.js
@@ -20,7 +20,7 @@ const options = (url) => {
   }
 }
 
-describe.only('Routing requests to the API', () => {
+describe('Routing requests to the API', () => {
   let server
 
   // Create server before each test


### PR DESCRIPTION
This fixes an issue found after deploying the app to our AWS environments. Any requests to the service were returning a 404. When we checked the logs we found all the requests were being received with a trailing slash. For example, `GET https://myenv.cloud/status` was being recorded in the logs as `https://myenv.cloud/status/`.

This won't match to any of our routes hence the app returns a 404.

Some digging in the existing [charging-module-api](https://github.com/DEFRA/charging-module-api/blob/main/config/config.js#L27) confirmed it had made config changes to Hapi to deal with this situation. Our suspicion is that in the AWS API Gateway config for the environment something has inadvertently been set to add a trailing slash to the request before forwarding it to the app.

So the first change is to tell Hapi to automatically strip any trailing slashes on incoming paths.

After discovering this router option we also spotted that Hapi is case sensitive by default. We want our app to respond to `/StAtuS` exactly the same way it responds to `/status`; a user shouldn't have to worry about case when making a request.

So the second change is we tell Hapi to not be case sensitive with incoming paths.