### PR TITLE
Add --shuffle parameter to lab

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "createdbtest": "NODE_ENV=test node db/create_database.js",
     "migratedb": "knex migrate:latest",
     "migratedbtest": "NODE_ENV=test knex migrate:latest",
-    "unit-test": "lab --silent-skips"
+    "unit-test": "lab --silent-skips --shuffle"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
It is best practice to randomise the order that tests are run in to help ensure that they're truly running in isolation and aren't just passing because of previous tests. This change adds the `--shuffle` parameter to `lab` to enable this.