### PR TITLE
Fix issue with authorised system migration scripts

### DIFF
--- a/db/migrations/20201127100927_alter_authorised_systems.js
+++ b/db/migrations/20201127100927_alter_authorised_systems.js
@@ -23,7 +23,7 @@ exports.down = async function (knex) {
     .schema
     .alterTable(tableName, table => {
       // Drop client_id unique constraint
-      table.unique('client_id')
+      table.dropUnique('client_id')
     })
 
   await knex

--- a/db/migrations/20201218153444_alter_authorised_systems.js
+++ b/db/migrations/20201218153444_alter_authorised_systems.js
@@ -1,0 +1,23 @@
+'use strict'
+
+const tableName = 'authorised_systems'
+
+exports.up = async function (knex) {
+  await knex
+    .schema
+    .alterTable(tableName, table => {
+      // Alter existing columns
+      // alter() requires you list everything, not just the thing you are changing. This is why existing constraints
+      // like notNullable() are listed as well. If we didn't, they would be dropped.
+      table.boolean('admin').defaultTo(false).notNullable().alter()
+    })
+}
+
+exports.down = async function (knex) {
+  await knex
+    .schema
+    .alterTable(tableName, table => {
+      // Revert alterations
+      table.boolean('admin').defaultTo(false).alter()
+    })
+}


### PR DESCRIPTION
We have found an issue with `db/migrations/20201127100927_alter_authorised_systems.js`. In it's drop it's trying to add the column again, not drop it. This change fixes the issue.

We also have realised we are not marking a boolean field as `notNullable()`. Ideally, all boolean fields should be defaulted and never contain a null so we never have to worry about whether a value is `true, false, or null`. So this also adds an alter script for the `authorised_systems` 'admin' field.