### PR TITLE
Transaction translator

### DIFF
--- a/app/translators/base.translator.js
+++ b/app/translators/base.translator.js
@@ -20,7 +20,7 @@ class BaseTranslator {
   }
 
   _validate (data) {
-    return this._schema().validate(data, { abortEarly: false })
+    return this._schema().validate(data, { abortEarly: false, allowUnknown: true })
   }
 
   _translate (data, translations) {

--- a/app/translators/transaction.translator.js
+++ b/app/translators/transaction.translator.js
@@ -9,46 +9,10 @@ class TransactionTranslator extends BaseTranslator {
     super(data)
 
     this.lineAttr3 = this._prorataDays()
-    this.chargeFinancialYear = this._financialYear(this.chargePeriodStart)
+    this.financialYear = this._financialYear(this.periodStart)
 
     // Additional post-getter validation to ensure periodStart and periodEnd are in the same financial year
     this._validateFinancialYear()
-  }
-
-  _translations () {
-    return {
-      region: 'region',
-      customerReference: 'customerReference',
-      batchNumber: 'regimeValue1',
-      licenceNumber: 'lineAttr1',
-      chargePeriod: 'lineAttr2',
-      chargeElementId: 'regimeValue3',
-      areaCode: 'lineAreaCode',
-      lineDescription: 'lineDescription',
-      newLicence: 'newLicence',
-      clientId: 'clientId',
-      ruleset: 'ruleset',
-      periodStart: 'chargePeriodStart',
-      periodEnd: 'chargePeriodEnd',
-      credit: 'chargeCredit',
-      billableDays: 'regimeValue4',
-      authorisedDays: 'regimeValue5',
-      volume: 'lineAttr5',
-      source: 'regimeValue6',
-      season: 'regimeValue7',
-      loss: 'regimeValue8',
-      section130Agreement: 'regimeValue9',
-      section126Agreement: 'regimeValue10',
-      section126Factor: 'regimeValue11',
-      section127Agreement: 'regimeValue12',
-      twoPartTariff: 'regimeValue16',
-      compensationCharge: 'regimeValue17',
-      eiucSource: 'regimeValue13',
-      waterUndertaker: 'regimeValue14',
-      regionalChargingArea: 'regimeValue15',
-      prorataDays: 'lineAttr3',
-      chargeFinancialYear: 'chargeFinancialYear'
-    }
   }
 
   _schema () {
@@ -63,7 +27,6 @@ class TransactionTranslator extends BaseTranslator {
       lineDescription: Joi.string().max(240).required(),
       newLicence: Joi.boolean().default(false),
       clientId: Joi.string().allow('', null),
-      // Set a new field called ruleset. This will be used to determine which ruleset to query in the rules service
       ruleset: Joi.string().default('presroc'),
       periodStart: Joi.date().less(Joi.ref('periodEnd')).min('01-APR-2014').required(),
       periodEnd: Joi.date().required(),
@@ -85,13 +48,49 @@ class TransactionTranslator extends BaseTranslator {
     })
   }
 
+  _translations () {
+    return {
+      ruleset: 'ruleset',
+      region: 'region',
+      customerReference: 'customerReference',
+      periodStart: 'periodStart',
+      periodEnd: 'periodEnd',
+      financialYear: 'financialYear',
+      newLicence: 'newLicence',
+      clientId: 'clientId',
+      credit: 'credit',
+      areaCode: 'lineAreaCode',
+      lineDescription: 'lineDescription',
+      licenceNumber: 'lineAttr1',
+      chargePeriod: 'lineAttr2',
+      prorataDays: 'lineAttr3',
+      volume: 'lineAttr5',
+      batchNumber: 'regimeValue1',
+      chargeElementId: 'regimeValue3',
+      billableDays: 'regimeValue4',
+      authorisedDays: 'regimeValue5',
+      source: 'regimeValue6',
+      season: 'regimeValue7',
+      loss: 'regimeValue8',
+      section130Agreement: 'regimeValue9',
+      section126Agreement: 'regimeValue10',
+      section126Factor: 'regimeValue11',
+      section127Agreement: 'regimeValue12',
+      eiucSource: 'regimeValue13',
+      waterUndertaker: 'regimeValue14',
+      regionalChargingArea: 'regimeValue15',
+      twoPartTariff: 'regimeValue16',
+      compensationCharge: 'regimeValue17'
+    }
+  }
+
   _validateFinancialYear () {
     const schema = Joi.object({
-      chargePeriodEndFinancialYear: Joi.number().equal(this.chargeFinancialYear)
+      periodEndFinancialYear: Joi.number().equal(this.financialYear)
     })
 
     const data = {
-      chargePeriodEndFinancialYear: this._financialYear(this.chargePeriodEnd)
+      periodEndFinancialYear: this._financialYear(this.periodEnd)
     }
 
     const { error } = schema.validate(data)
@@ -114,9 +113,9 @@ class TransactionTranslator extends BaseTranslator {
    * @returns {Number} The calculated financial year
   */
   _financialYear (date) {
-    const chargePeriodDate = new Date(date)
-    const month = chargePeriodDate.getMonth()
-    const year = chargePeriodDate.getFullYear()
+    const periodDate = new Date(date)
+    const month = periodDate.getMonth()
+    const year = periodDate.getFullYear()
 
     return (month <= 2 ? year - 1 : year)
   }

--- a/app/translators/transaction.translator.js
+++ b/app/translators/transaction.translator.js
@@ -2,19 +2,8 @@
 
 const BaseTranslator = require('./base.translator')
 const Joi = require('joi')
-const Boom = require('@hapi/boom')
 
 class TransactionTranslator extends BaseTranslator {
-  constructor (data) {
-    super(data)
-
-    this.lineAttr3 = this._prorataDays()
-    this.financialYear = this._financialYear(this.periodStart)
-
-    // Additional post-getter validation to ensure periodStart and periodEnd are in the same financial year
-    this._validateFinancialYear()
-  }
-
   _schema () {
     return Joi.object({
       region: Joi.string().uppercase().valid(...this._validRegions()),
@@ -26,25 +15,7 @@ class TransactionTranslator extends BaseTranslator {
       areaCode: Joi.string().uppercase().valid(...this._validAreas()),
       lineDescription: Joi.string().max(240).required(),
       newLicence: Joi.boolean().default(false),
-      clientId: Joi.string().allow('', null),
-      ruleset: Joi.string().default('presroc'),
-      periodStart: Joi.date().less(Joi.ref('periodEnd')).min('01-APR-2014').required(),
-      periodEnd: Joi.date().required(),
-      credit: Joi.boolean().required(),
-      billableDays: Joi.number().integer().min(0).max(366).required(),
-      authorisedDays: Joi.number().integer().min(0).max(366).required(),
-      volume: Joi.number().min(0),
-      source: Joi.string().required(), // validated in rules service
-      season: Joi.string().required(), // validated in rules service
-      loss: Joi.string().required(), // validated in rules service
-      section130Agreement: Joi.boolean().required(),
-      section126Factor: Joi.number().allow(null).empty(null).default(1.0),
-      section127Agreement: Joi.boolean().required(),
-      twoPartTariff: Joi.boolean().required(),
-      compensationCharge: Joi.boolean().required(),
-      eiucSource: Joi.when('compensationCharge', { is: true, then: Joi.string().required() }), // validated in the rules service
-      waterUndertaker: Joi.boolean().required(),
-      regionalChargingArea: Joi.string().required() // validated in the rules service
+      clientId: Joi.string().allow('', null)
     })
   }
 
@@ -84,66 +55,8 @@ class TransactionTranslator extends BaseTranslator {
     }
   }
 
-  _validateFinancialYear () {
-    const schema = Joi.object({
-      periodEndFinancialYear: Joi.number().equal(this.financialYear)
-    })
-
-    const data = {
-      periodEndFinancialYear: this._financialYear(this.periodEnd)
-    }
-
-    const { error } = schema.validate(data)
-
-    if (error) {
-      throw Boom.badData(error)
-    }
-  }
-
-  /**
-   * Returns the calculated financial year for a given date
-   *
-   * If the date is January to March then the financial year is the previous year. Otherwise, the financial year is the
-   * current year.
-   *
-   * For example, if the date is 01-MAR-2022 then the financial year will be 2021. If the it's 01-MAY-2022 then the
-   * financial year will be 2022.
-   *
-   * @param {String} date
-   * @returns {Number} The calculated financial year
-  */
-  _financialYear (date) {
-    const periodDate = new Date(date)
-    const month = periodDate.getMonth()
-    const year = periodDate.getFullYear()
-
-    return (month <= 2 ? year - 1 : year)
-  }
-
-  /**
-   * Returns billable and authorised day values as a specially formatted string.
-   *
-   * For example, if billable days is 12 and authorised days is 6 it will return `012/006`.
-   *
-   * @returns {String} Billable days and authorised days as a formatted string
-   */
-  _prorataDays () {
-    return `${this._padNumber(this.regimeValue4)}/${this._padNumber(this.regimeValue5)}`
-  }
-
   _validRegions () {
     return ['A', 'B', 'E', 'N', 'S', 'T', 'W', 'Y']
-  }
-
-  /**
-   * Return a number as a string, padded to 3 digits with leading zeroes
-   *
-   * For example, `_padNumber(3)` will return `003`.
-   *
-   * @returns {Number} the number padded with leading zeroes
-   */
-  _padNumber (number) {
-    return number.toString().padStart(3, '0')
   }
 
   _validAreas () {

--- a/test/translators/base.translator.test.js
+++ b/test/translators/base.translator.test.js
@@ -45,6 +45,12 @@ describe('Base translator', () => {
 
       expect(() => new BaseTranslator(testData)).to.throw()
     })
+
+    it('allows data to be passed that is not part of the validation', async () => {
+      const testData = { before: true, test: true }
+
+      expect(() => new BaseTranslator(testData)).to.not.throw()
+    })
   })
 
   describe('translation', () => {
@@ -61,6 +67,16 @@ describe('Base translator', () => {
       const testData = { before: true }
 
       expect(() => new BaseTranslator(testData)).to.throw()
+    })
+
+    it('translates data that is not part of the valdation', async () => {
+      translationsStub.restore()
+      translationsStub = Sinon.stub(BaseTranslator.prototype, '_translations').returns({ test: 'passed' })
+      const testData = { test: true }
+
+      const testTranslator = new BaseTranslator(testData)
+
+      expect(testTranslator.passed).to.equal(true)
     })
   })
 })

--- a/test/translators/transaction.translator.test.js
+++ b/test/translators/transaction.translator.test.js
@@ -41,61 +41,11 @@ describe('Transaction translator', () => {
     areaCode: 'ARCA'
   }
 
-  describe('calculating prorataDays', () => {
-    it('correctly calculates the format', async () => {
-      const testTranslator = new TransactionTranslator({
-        ...data,
-        billableDays: 128,
-        authorisedDays: 256
-      })
-
-      expect(testTranslator.lineAttr3).to.equal('128/256')
-    })
-
-    it('correctly pads values to 3 digits', async () => {
-      const testTranslator = new TransactionTranslator({
-        ...data,
-        billableDays: 8,
-        authorisedDays: 16
-      })
-
-      expect(testTranslator.lineAttr3).to.equal('008/016')
-    })
-  })
-
-  describe('calculating the financial year', () => {
-    it("correctly determines the previous year for 'period' dates in March or earlier", async () => {
-      const testTranslator = new TransactionTranslator({
-        ...data,
-        periodStart: '01-MAR-2022',
-        periodEnd: '30-MAR-2022'
-      })
-
-      expect(testTranslator.financialYear).to.equal(2021)
-    })
-
-    it("correctly determines the current year for 'period' dates in April onwards", async () => {
-      const testTranslator = new TransactionTranslator({
-        ...data,
-        periodStart: '01-APR-2021',
-        periodEnd: '01-MAY-2021'
-      })
-
-      expect(testTranslator.financialYear).to.equal(2021)
-    })
-  })
-
   describe('Default values', () => {
     it("defaults 'newLicence' to 'false'", async () => {
       const testTranslator = new TransactionTranslator(data)
 
       expect(testTranslator.newLicence).to.be.a.boolean().and.equal(false)
-    })
-
-    it("defaults 'regimeValue11' to '1.0' when 'section126Factor' is not provided", async () => {
-      const testTranslator = new TransactionTranslator(data)
-
-      expect(testTranslator.regimeValue11).to.be.a.number().and.equal(1.0)
     })
   })
 
@@ -107,47 +57,22 @@ describe('Transaction translator', () => {
     })
 
     describe('when the data is not valid', () => {
-      describe("because the 'periodStart' is greater than the 'periodEnd'", () => {
+      describe("because 'region' is not a valid region", () => {
         it('throws an error', async () => {
           const invalidData = {
             ...data,
-            periodStart: '01-APR-2021'
+            region: 'INVALID_REGION'
           }
 
           expect(() => new TransactionTranslator(invalidData)).to.throw(ValidationError)
         })
       })
 
-      describe("because the 'periodEnd' is less than 01-APR-2014", () => {
+      describe("because 'areaCode' is not a valid area", () => {
         it('throws an error', async () => {
           const invalidData = {
             ...data,
-            periodStart: '01-FEB-2014',
-            periodEnd: '01-MAR-2014'
-          }
-
-          expect(() => new TransactionTranslator(invalidData)).to.throw(ValidationError)
-        })
-      })
-
-      describe("because 'eiucSource' is empty when 'compensationCharge' is true", () => {
-        it('throws an error', async () => {
-          const invalidData = {
-            ...data,
-            compensationCharge: true,
-            eiucSource: ''
-          }
-
-          expect(() => new TransactionTranslator(invalidData)).to.throw(ValidationError)
-        })
-      })
-
-      describe("because 'periodStart' and 'periodEnd' are not in the same financial year", () => {
-        it('throws an error', async () => {
-          const invalidData = {
-            ...data,
-            periodStart: '01-APR-2021',
-            periodEnd: '01-APR-2022'
+            areaCode: 'INVALID_AREA'
           }
 
           expect(() => new TransactionTranslator(invalidData)).to.throw(ValidationError)

--- a/test/translators/transaction.translator.test.js
+++ b/test/translators/transaction.translator.test.js
@@ -71,7 +71,7 @@ describe('Transaction translator', () => {
         periodEnd: '30-MAR-2022'
       })
 
-      expect(testTranslator.chargeFinancialYear).to.equal(2021)
+      expect(testTranslator.financialYear).to.equal(2021)
     })
 
     it("correctly determines the current year for 'period' dates in April onwards", async () => {
@@ -81,7 +81,7 @@ describe('Transaction translator', () => {
         periodEnd: '01-MAY-2021'
       })
 
-      expect(testTranslator.chargeFinancialYear).to.equal(2021)
+      expect(testTranslator.financialYear).to.equal(2021)
     })
   })
 


### PR DESCRIPTION
This change updates `transaction.translator` to remove validation duplicated in `create_charge.translator`. As part of this it amends `base.translator` to not error if data is passed in that isn't validated.