### PR TITLE
Add stop (SIGTERM) plugin

### DIFF
--- a/app/plugins/index.js
+++ b/app/plugins/index.js
@@ -10,6 +10,7 @@ const InvalidCharactersPlugin = require('./invalid_characters.plugin')
 const MissingPayloadPlugin = require('./missing_payload.plugin')
 const PayloadCleanerPlugin = require('./payload_cleaner.plugin')
 const RouterPlugin = require('./router.plugin')
+const StopPlugin = require('./stop.plugin')
 
 // These plugins are only used when the app is running in NODE_ENV=development. This means we don't want them or their
 // dependencies available in production. The problem is when we build the image any dev dependencies won't be installed.
@@ -35,5 +36,6 @@ module.exports = {
   InvalidCharactersPlugin,
   MissingPayloadPlugin,
   PayloadCleanerPlugin,
-  RouterPlugin
+  RouterPlugin,
+  StopPlugin
 }

--- a/app/plugins/stop.plugin.js
+++ b/app/plugins/stop.plugin.js
@@ -23,8 +23,6 @@
  * @module StopPlugin
  */
 
-// const logger = require('pino')()
-
 const StopPlugin = {
   name: 'stop',
   register: (server, _options) => {

--- a/app/plugins/stop.plugin.js
+++ b/app/plugins/stop.plugin.js
@@ -1,0 +1,58 @@
+'use strict'
+
+/**
+ * Handle `SIGTERM` and `SIGINT` calls to the app
+ *
+ * `SIGINT` is the signal sent when a user presses 'CTRL+C' in the terminal. `SIGTERM` is the generic version often sent
+ * by a host or managing system process.
+ *
+ * They are both requests to an app to terminate. Without this plugin the app would immediately stop when the signal
+ * is received. Our issue is this means any in-flight requests will be dropped and not allowed to complete and return a
+ * response.
+ *
+ * We want to avoid dropping any existing requests whilst also not accepting new ones. By handling the terminate
+ * signals we can call {@link https://hapi.dev/api/?v=20.0.3#-await-serverstopoptions|Hapi's server.stop()} which does
+ * exactly that.
+ *
+ * It rejects new requests whilst allowing a period of time for existing ones to complete.
+ *
+ * *Based on* {@link https://github.com/visualjeff/hapi-graceful-shutdown-plugin}
+ *
+ * @see {@link https://www.gnu.org/software/libc/manual/html_node/Termination-Signals.html|Termination Signals} for further details about `SIGTERM` and `SIGINT`.
+ *
+ * @module StopPlugin
+ */
+
+// const logger = require('pino')()
+
+const StopPlugin = {
+  name: 'stop',
+  register: (server, _options) => {
+    // The timeout is set to 25 seconds (it has to be passed to Hapi in milliseconds) based on AWS ECS. When it sends a
+    // stop request it allows an container 30 seconds before it sends a `SIGKILL`
+    const options = {
+      timeout: 25 * 1000
+    }
+
+    const stop = async () => {
+      try {
+        // If there are no in-flight requests Hapi will immediately stop. If there are they get 25 seconds to finish
+        // before Hapi terminates them
+        await server.stop(options)
+
+        // Log we're shut down using the same log format as the rest of our log output
+        server.logger.info('Thats all folks!')
+        process.exit(0)
+      } catch (err) {
+        // Ensure we exit with a non-zero code so it can be picked up by whatever requested the termination that
+        // something went wrong
+        process.exit(1)
+      }
+    }
+
+    process.on('SIGTERM', stop)
+    process.on('SIGINT', stop)
+  }
+}
+
+module.exports = StopPlugin

--- a/server.js
+++ b/server.js
@@ -13,7 +13,8 @@ const {
   InvalidCharactersPlugin,
   MissingPayloadPlugin,
   PayloadCleanerPlugin,
-  RouterPlugin
+  RouterPlugin,
+  StopPlugin
 } = require('./app/plugins')
 
 exports.deployment = async start => {
@@ -27,6 +28,7 @@ exports.deployment = async start => {
   server.auth.default('jwt-strategy')
 
   // Register the remaining plugins
+  await server.register(StopPlugin)
   await server.register(AuthorisationPlugin)
   await server.register(RouterPlugin)
   await server.register(AirbrakePlugin)

--- a/test/features/graceful_shutdown.test.js
+++ b/test/features/graceful_shutdown.test.js
@@ -15,7 +15,7 @@ const { deployment } = require('../../server')
 // However, the server module it is written against exposes its methods in such a way they are easy to stub/spy on.
 // We've had no such luck with Hapi. So though we can't get our expectations to work we can see with well placed
 // console logs that when these tests are run the behaviour we expect to see does happen.
-describe.only('Gracefully shuts down when asked to terminate', () => {
+describe('Gracefully shuts down when asked to terminate', () => {
   let server
 
   before(async () => {

--- a/test/features/graceful_shutdown.test.js
+++ b/test/features/graceful_shutdown.test.js
@@ -1,0 +1,57 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, before, afterEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// For running our service
+const { deployment } = require('../../server')
+
+// The main inspiration for these tests was taken from https://stackoverflow.com/a/40909092/6117745
+// However, the server module it is written against exposes its methods in such a way they are easy to stub/spy on.
+// We've had no such luck with Hapi. So though we can't get our expectations to work we can see with well placed
+// console logs that when these tests are run the behaviour we expect to see does happen.
+describe.only('Gracefully shuts down when asked to terminate', () => {
+  let server
+
+  before(async () => {
+    server = await deployment()
+
+    Sinon.stub(process, 'exit')
+
+    // See comments above tests for reason why these are commented out
+    // Sinon.spy(server, 'stop')
+    // Sinon.spy(server.logger, 'info')
+  })
+
+  afterEach(async () => {
+    Sinon.resetHistory()
+    Sinon.restore()
+  })
+
+  describe("When a 'SIGTERM' signal is sent", () => {
+    // We have to admit defeat on this one. We currently cannot figure out how to attach a spy to the server.close()
+    // method in Hapi. We've left the test here for documentation purposes and in case we have inspiration at a later
+    // date.
+    it.skip("calls 'server.stop()' to allow existing requests time to finish", async () => {
+      process.once('SIGTERM', () => {
+        expect(server.stop.calledOnce).to.be.true()
+      })
+      process.kill(process.pid, 'SIGTERM')
+    })
+
+    // We also have to admit defeat on this one. We currently cannot figure out how to attach a spy to the
+    // server.logger instance hapi-pino attaches. We've left the test here for documentation purposes and in case we
+    // have inspiration at a later date.
+    it.skip("uses 'server.logger' to log the service is finished", async () => {
+      process.once('SIGTERM', () => {
+        expect(server.logger.info.calledOnce).to.be.true()
+      })
+      process.kill(process.pid, 'SIGTERM')
+    })
+  })
+})


### PR DESCRIPTION
Our deployment is based on Docker and [AWS ECS](https://aws.amazon.com/ecs/). When ECS needs to stop a container it will send a [SIGTERM](https://www.gnu.org/software/libc/manual/html_node/Termination-Signals.html) and allow it 30 seconds to stop.

> When UpdateService stops a task during a deployment, the equivalent of docker stop is issued to the containers running in the task. This results in a `SIGTERM` and a 30-second timeout, after which `SIGKILL` is sent and the containers are forcibly stopped. If the container handles the SIGTERM gracefully and exits within 30 seconds from receiving it, no `SIGKILL` is sent.
>
> https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ecs/update-service.html

`SIGTERM` is a 'polite request' to stop. Typically it's caught by apps so they can do any clean up needed before shutting down. In the case of Hapi, it is often combined with [server.stop()](https://hapi.dev/api/?v=20.0.3#-await-serverstopoptions) to ensure no requests are dropped. When the signal is received an app will call `server.stop()` which tells hapi to reject any new connections but allow any existing ones to complete. Without it the app would be stopped immediately and any inflight requests would be dropped.

We want to avoid dropping requests if at all possible, so this change adds a new custom plugin to handle `SIGTERM` requests.

Note. The solution is heavily based on [hapi-graceful-shutdown-plugin](https://github.com/visualjeff/hapi-graceful-shutdown-plugin). We've decided to 'do it ourselves' because

- the solution is relatively simple
- hapi-graceful-shutdown-plugin does not appear to be maintained. There are many outstanding depdendabot requests
- we continue to try to strike a balance of only bringing in dependencies when we need them, whilst also not rewriting everything