### PR TITLE
Add create transaction presenter

### DIFF
--- a/app/presenters/create_transaction.presenter.js
+++ b/app/presenters/create_transaction.presenter.js
@@ -1,0 +1,22 @@
+'use strict'
+
+/**
+ * @module CreateTransactionPresenter
+ */
+
+const BasePresenter = require('./base.presenter')
+
+/**
+ * Handles formatting the data into the response we send to clients after a create transaction request.
+ */
+class CreateTransactionPresenter extends BasePresenter {
+  _presentation (data) {
+    return {
+      transaction: {
+        id: data.id
+      }
+    }
+  }
+}
+
+module.exports = CreateTransactionPresenter

--- a/app/presenters/index.js
+++ b/app/presenters/index.js
@@ -3,6 +3,7 @@
 const BasePresenter = require('./base.presenter')
 const CalculateChargePresenter = require('./calculate_charge.presenter')
 const CreateBillRunPresenter = require('./create_bill_run.presenter')
+const CreateTransactionPresenter = require('./create_transaction.presenter')
 const JsonPresenter = require('./json.presenter')
 const RulesServicePresenter = require('./rules_service.presenter')
 
@@ -10,6 +11,7 @@ module.exports = {
   BasePresenter,
   CalculateChargePresenter,
   CreateBillRunPresenter,
+  CreateTransactionPresenter,
   JsonPresenter,
   RulesServicePresenter
 }

--- a/test/presenters/create_transaction.presenter.test.js
+++ b/test/presenters/create_transaction.presenter.test.js
@@ -10,7 +10,7 @@ const { expect } = Code
 // Thing under test
 const { CreateTransactionPresenter } = require('../../app/presenters')
 
-describe.only('Create Transaction presenter', () => {
+describe('Create Transaction presenter', () => {
   it('correctly presents the data', () => {
     // Format and content of the test data does not have to accurately reflect a transaction. The key thing is the
     // presenter can pull what it needs from it

--- a/test/presenters/create_transaction.presenter.test.js
+++ b/test/presenters/create_transaction.presenter.test.js
@@ -1,0 +1,31 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Thing under test
+const { CreateTransactionPresenter } = require('../../app/presenters')
+
+describe.only('Create Transaction presenter', () => {
+  it('correctly presents the data', () => {
+    // Format and content of the test data does not have to accurately reflect a transaction. The key thing is the
+    // presenter can pull what it needs from it
+    const data = {
+      region: 'A',
+      regimeId: 'ff75f82d-d56f-4807-9cad-12f23d6b29a8',
+      createdBy: 'e46b816a-3fe8-438a-a3f9-7a1a8eb525ce',
+      status: 'initialised',
+      id: 'e2a28efc-09eb-439e-95bc-e64c68ab1ea5'
+    }
+
+    const presenter = new CreateTransactionPresenter(data)
+    const result = presenter.go()
+
+    expect(result.transaction.id).to.equal(data.id)
+    expect(result.transaction).to.have.length(1)
+  })
+})


### PR DESCRIPTION
https://trello.com/c/gTcQmR8M

This change adds a create transaction presenter to the app. The presenter will specifically handle ensuring the result we return from a `POST - bill run transaction` matches what clients see when doing the same in the [charging-module-api](https://github.com/defra/charging-module-api).