### PR TITLE
Allow access to validatedData in translators

### DIFF
--- a/app/translators/base.translator.js
+++ b/app/translators/base.translator.js
@@ -14,9 +14,8 @@ class BaseTranslator {
     const translatedData = this._translate(validatedData, this._translations())
     Object.assign(this, translatedData)
 
-    // Assign validated data to _data and set it to be non-enumerable so it isn't visible outside of the translator
+    // Assign validated data to _data
     Object.assign(this, { _data: validatedData })
-    Object.defineProperty(this, '_data', { enumerable: false })
   }
 
   _validate (data) {

--- a/app/translators/base.translator.js
+++ b/app/translators/base.translator.js
@@ -18,6 +18,19 @@ class BaseTranslator {
     Object.assign(this, { _data: validatedData })
   }
 
+  /**
+   * The validated data untranslated
+   *
+   * This was originally added to support needing to pass a validated transaction create request to the
+   * `CalculateChargeService` but with its original property names/. Doing it this way avoids needing another translator
+   * to sit between the 2.
+   *
+   * @return {Object} The validated data passed into the translator but untranslated.
+   */
+  get validatedData () {
+    return this._data
+  }
+
   _validate (data) {
     return this._schema().validate(data, { abortEarly: false, allowUnknown: true })
   }

--- a/test/translators/base.translator.test.js
+++ b/test/translators/base.translator.test.js
@@ -51,6 +51,15 @@ describe('Base translator', () => {
 
       expect(() => new BaseTranslator(testData)).to.not.throw()
     })
+
+    it('allows access to the untranslated validated data', async () => {
+      const testData = { before: true, test: true }
+
+      const testTranslator = new BaseTranslator(testData)
+
+      expect(testTranslator.validatedData).to.equal(testData)
+      expect(testTranslator.after).to.equal(true)
+    })
   })
 
   describe('translation', () => {


### PR DESCRIPTION
https://trello.com/c/gTcQmR8M

When a `POST Transaction` request comes in we first pass it to the transaction translator. It has 2 jobs to do

- validate the transaction properties
- translate the properties to those that match our db and model

Because of confusion on our part we thought we could pass the translator directly to the `CalculateCharge` service, which would then treat the object as if it was the payload to the calculate charge endpoint. Not only would this keep things simple it would also mean we would not need to duplicate the validation done for the charge properties.

We overlooked that the transaction translator is converting something like `waterUndertaker` to `regimeValue14`. The first thing the calculate charge service does is pass in the payload to `CalculateChargeTranslator` which is expecting to see `waterUndertaker`. So everything blows up.

A simple solution to this which avoids the need for even more translators is to allow access to the validated data in the `TransactionTranslator`. If we can access that we can pass it as the payload to `CalculateChargeService` and then everything should work as expected.