### PR TITLE
Update transaction model relations

### DIFF
--- a/app/models/authorised_system.model.js
+++ b/app/models/authorised_system.model.js
@@ -14,6 +14,14 @@ class AuthorisedSystemModel extends BaseModel {
 
   static get relationMappings () {
     return {
+      billRuns: {
+        relation: Model.HasManyRelation,
+        modelClass: 'bill_run.model',
+        join: {
+          from: 'authorised_systems.id',
+          to: 'bill_runs.created_by'
+        }
+      },
       regimes: {
         relation: Model.ManyToManyRelation,
         modelClass: 'regime.model',
@@ -25,14 +33,6 @@ class AuthorisedSystemModel extends BaseModel {
             to: 'authorised_systems_regimes.regime_id'
           },
           to: 'regimes.id'
-        }
-      },
-      billRuns: {
-        relation: Model.HasManyRelation,
-        modelClass: 'bill_run.model',
-        join: {
-          from: 'authorised_systems.id',
-          to: 'bill_runs.created_by'
         }
       },
       transactions: {

--- a/app/models/authorised_system.model.js
+++ b/app/models/authorised_system.model.js
@@ -34,6 +34,14 @@ class AuthorisedSystemModel extends BaseModel {
           from: 'authorised_systems.id',
           to: 'bill_runs.created_by'
         }
+      },
+      transactions: {
+        relation: Model.HasManyRelation,
+        modelClass: 'transaction.model',
+        join: {
+          from: 'authorised_systems.id',
+          to: 'transactions.created_by'
+        }
       }
     }
   }

--- a/app/models/index.js
+++ b/app/models/index.js
@@ -5,11 +5,13 @@ const BaseModel = require('./base.model')
 const BillRunModel = require('./bill_run.model')
 const RegimeModel = require('./regime.model')
 const SequenceCounterModel = require('./sequence_counter.model')
+const TransactionModel = require('./transaction.model')
 
 module.exports = {
   AuthorisedSystemModel,
   BaseModel,
   BillRunModel,
   RegimeModel,
-  SequenceCounterModel
+  SequenceCounterModel,
+  TransactionModel
 }

--- a/app/models/regime.model.js
+++ b/app/models/regime.model.js
@@ -42,6 +42,14 @@ class RegimeModel extends BaseModel {
           from: 'regimes.id',
           to: 'sequence_counters.regime_id'
         }
+      },
+      transactions: {
+        relation: Model.HasManyRelation,
+        modelClass: 'transaction.model',
+        join: {
+          from: 'regimes.id',
+          to: 'transactions.regime_id'
+        }
       }
     }
   }

--- a/app/models/transaction.model.js
+++ b/app/models/transaction.model.js
@@ -14,6 +14,14 @@ class TransactionModel extends BaseModel {
 
   static get relationMappings () {
     return {
+      authorisedSystem: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: 'authorised_system.model',
+        join: {
+          from: 'transactions.created_by',
+          to: 'authorised_systems.id'
+        }
+      },
       billRun: {
         relation: Model.BelongsToOneRelation,
         modelClass: 'bill_run.model',

--- a/app/models/transaction.model.js
+++ b/app/models/transaction.model.js
@@ -21,6 +21,14 @@ class TransactionModel extends BaseModel {
           from: 'transactions.bill_run_id',
           to: 'bill_runs.id'
         }
+      },
+      regime: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: 'regime.model',
+        join: {
+          from: 'transactions.regime_id',
+          to: 'regimes.id'
+        }
       }
     }
   }


### PR DESCRIPTION
Spotted that the model for transactions was missing relationships we know it will now support. Plus its not listed by the `index.js` in the `app/models`. This change resolves those issues.