### PR TITLE
Fix charge credit vs credit in transaction

### DIFF
--- a/app/presenters/calculate_charge.presenter.js
+++ b/app/presenters/calculate_charge.presenter.js
@@ -28,7 +28,7 @@ class CalculateChargePresenter extends BasePresenter {
 
   // Returns a negative or positive value for chargeValue dependent on whether credit is true or false
   _calculateChargeValue (data) {
-    return data.credit ? -data.chargeValue : data.chargeValue
+    return data.chargeCredit ? -data.chargeValue : data.chargeValue
   }
 }
 

--- a/app/translators/calculate_charge.translator.js
+++ b/app/translators/calculate_charge.translator.js
@@ -65,7 +65,7 @@ class CalculateChargeTranslator extends BaseTranslator {
       authorisedDays: 'regimeValue5',
       billableDays: 'regimeValue4',
       compensationCharge: 'regimeValue17',
-      credit: 'credit',
+      credit: 'chargeCredit',
       loss: 'regimeValue8',
       periodEnd: 'periodEnd',
       periodStart: 'periodStart',

--- a/app/translators/transaction.translator.js
+++ b/app/translators/transaction.translator.js
@@ -29,7 +29,7 @@ class TransactionTranslator extends BaseTranslator {
       financialYear: 'financialYear',
       newLicence: 'newLicence',
       clientId: 'clientId',
-      credit: 'credit',
+      credit: 'chargeCredit',
       areaCode: 'lineAreaCode',
       lineDescription: 'lineDescription',
       licenceNumber: 'lineAttr1',

--- a/test/presenters/calculate_charge.presenter.test.js
+++ b/test/presenters/calculate_charge.presenter.test.js
@@ -14,7 +14,7 @@ describe('Charge presenter', () => {
   describe("when the request was marked as a 'credit'", () => {
     const data = {
       chargeValue: 100,
-      credit: true
+      chargeCredit: true
     }
 
     it("returns a negative 'chargeValue'", async () => {
@@ -28,7 +28,7 @@ describe('Charge presenter', () => {
   describe("when the request was not marked as a 'credit'", () => {
     const data = {
       chargeValue: 100,
-      credit: false
+      chargeCredit: false
     }
 
     it("returns a postive 'chargeValue'", async () => {


### PR DESCRIPTION
When we were working on the spike in [PR #81](https://github.com/DEFRA/sroc-charging-module-api/pull/81) we had the intent of fixing some of the transaction field names to make them simpler and remove unnecessary prefixes.

We've decided to hold off on those changes and focus on ensuring we have things behaving as they currently do first. One of those changes that have managed to be implemented is referring to the `chargeCredit` field as `credit`.

To make things consistent with how the table has now been set up this small change rolls back the use of `credit` instead of `chargeCredit`.