### PR TITLE
Fix chargeFinancialYear vs financialYear in trans.

### DIFF
--- a/app/presenters/rules_service.presenter.js
+++ b/app/presenters/rules_service.presenter.js
@@ -14,7 +14,7 @@ class RulesServicePresenter extends BasePresenter {
     return {
       ruleset: data.ruleset,
       regime: data.regime,
-      financialYear: data.financialYear,
+      financialYear: data.chargeFinancialYear,
       chargeParams: {
         WRLSChargingRequest: {
           billableDays: data.regimeValue4,

--- a/app/translators/calculate_charge.translator.js
+++ b/app/translators/calculate_charge.translator.js
@@ -13,7 +13,7 @@ class CalculateChargeTranslator extends BaseTranslator {
     super(data)
 
     this.lineAttr3 = this._prorataDays()
-    this.financialYear = this._financialYear(this.periodStart)
+    this.chargeFinancialYear = this._financialYear(this.periodStart)
 
     // Additional post-getter validation to ensure periodStart and periodEnd are in the same financial year
     this._validateFinancialYear()
@@ -21,7 +21,7 @@ class CalculateChargeTranslator extends BaseTranslator {
 
   _validateFinancialYear () {
     const schema = Joi.object({
-      periodEndFinancialYear: Joi.number().equal(this.financialYear)
+      periodEndFinancialYear: Joi.number().equal(this.chargeFinancialYear)
     })
 
     const data = {

--- a/app/translators/transaction.translator.js
+++ b/app/translators/transaction.translator.js
@@ -26,7 +26,6 @@ class TransactionTranslator extends BaseTranslator {
       customerReference: 'customerReference',
       periodStart: 'periodStart',
       periodEnd: 'periodEnd',
-      financialYear: 'financialYear',
       newLicence: 'newLicence',
       clientId: 'clientId',
       credit: 'chargeCredit',

--- a/test/translators/calculate_charge.translator.test.js
+++ b/test/translators/calculate_charge.translator.test.js
@@ -62,7 +62,7 @@ describe('Calculate Charge translator', () => {
         periodEnd: '30-MAR-2022'
       })
 
-      expect(testTranslator.financialYear).to.equal(2021)
+      expect(testTranslator.chargeFinancialYear).to.equal(2021)
     })
 
     it("correctly determines the current year for 'period' dates in April onwards", async () => {
@@ -72,7 +72,7 @@ describe('Calculate Charge translator', () => {
         periodEnd: '01-MAY-2021'
       })
 
-      expect(testTranslator.financialYear).to.equal(2021)
+      expect(testTranslator.chargeFinancialYear).to.equal(2021)
     })
   })
 


### PR DESCRIPTION
When we were working on the spike in [PR #81](https://github.com/DEFRA/sroc-charging-module-api/pull/81) we had the intent of fixing some of the transaction field names to make them simpler and remove unnecessary prefixes.

We've decided to hold off on those changes and focus on ensuring we have things behaving as they currently do first. One of those changes that have managed to be implemented is referring to the `chargeFinancialYear` field as `financialYear`.

To make things consistent with how the table has now been set up this small change rolls back the use of `financialYear` instead of `chargeFinancialYear`.