### PR TITLE
Fix chargePeriodStart vs periodStart in trans.

### DIFF
--- a/app/translators/calculate_charge.translator.js
+++ b/app/translators/calculate_charge.translator.js
@@ -13,7 +13,7 @@ class CalculateChargeTranslator extends BaseTranslator {
     super(data)
 
     this.lineAttr3 = this._prorataDays()
-    this.chargeFinancialYear = this._financialYear(this.periodStart)
+    this.chargeFinancialYear = this._financialYear(this.chargePeriodStart)
 
     // Additional post-getter validation to ensure periodStart and periodEnd are in the same financial year
     this._validateFinancialYear()
@@ -68,7 +68,7 @@ class CalculateChargeTranslator extends BaseTranslator {
       credit: 'chargeCredit',
       loss: 'regimeValue8',
       periodEnd: 'periodEnd',
-      periodStart: 'periodStart',
+      periodStart: 'chargePeriodStart',
       regionalChargingArea: 'regimeValue15',
       ruleset: 'ruleset',
       season: 'regimeValue7',

--- a/app/translators/transaction.translator.js
+++ b/app/translators/transaction.translator.js
@@ -24,7 +24,7 @@ class TransactionTranslator extends BaseTranslator {
       ruleset: 'ruleset',
       region: 'region',
       customerReference: 'customerReference',
-      periodStart: 'periodStart',
+      periodStart: 'chargePeriodStart',
       periodEnd: 'periodEnd',
       newLicence: 'newLicence',
       clientId: 'clientId',


### PR DESCRIPTION
When we were working on the spike in [PR #81](https://github.com/DEFRA/sroc-charging-module-api/pull/81) we had the intent of fixing some of the transaction field names to make them simpler and remove unnecessary prefixes.

We've decided to hold off on those changes and focus on ensuring we have things behaving as they currently do first. One of those changes that have managed to be implemented is referring to the `chargePeriodStart` field as `periodStart`.

To make things consistent with how the table has now been set up this small change rolls back the use of `periodStart` instead of `chargePeriodStart`.