### PR TITLE
Fix chargePeriodEnd vs periodEnd in trans.

### DIFF
--- a/app/translators/calculate_charge.translator.js
+++ b/app/translators/calculate_charge.translator.js
@@ -25,7 +25,7 @@ class CalculateChargeTranslator extends BaseTranslator {
     })
 
     const data = {
-      periodEndFinancialYear: this._financialYear(this.periodEnd)
+      periodEndFinancialYear: this._financialYear(this.chargePeriodEnd)
     }
 
     const { error } = schema.validate(data)
@@ -67,7 +67,7 @@ class CalculateChargeTranslator extends BaseTranslator {
       compensationCharge: 'regimeValue17',
       credit: 'chargeCredit',
       loss: 'regimeValue8',
-      periodEnd: 'periodEnd',
+      periodEnd: 'chargePeriodEnd',
       periodStart: 'chargePeriodStart',
       regionalChargingArea: 'regimeValue15',
       ruleset: 'ruleset',

--- a/app/translators/transaction.translator.js
+++ b/app/translators/transaction.translator.js
@@ -25,7 +25,7 @@ class TransactionTranslator extends BaseTranslator {
       region: 'region',
       customerReference: 'customerReference',
       periodStart: 'chargePeriodStart',
-      periodEnd: 'periodEnd',
+      periodEnd: 'chargePeriodEnd',
       newLicence: 'newLicence',
       clientId: 'clientId',
       credit: 'chargeCredit',


### PR DESCRIPTION
When we were working on the spike in [PR #81](https://github.com/DEFRA/sroc-charging-module-api/pull/81) we had the intent of fixing some of the transaction field names to make them simpler and remove unnecessary prefixes.

We've decided to hold off on those changes and focus on ensuring we have things behaving as they currently do first. One of those changes that have managed to be implemented is referring to the `chargePeriodEnd` field as `periodEnd`.

To make things consistent with how the table has now been set up this small change rolls back the use of `periodEnd` instead of `chargePeriodEnd`.