### PR TITLE
Retain rules service response in translator

### DIFF
--- a/app/translators/rules_service.translator.js
+++ b/app/translators/rules_service.translator.js
@@ -12,6 +12,9 @@ class RulesServiceTranslator extends BaseTranslator {
     // The rules service returns the data we need in a WRLSChargingResponse object within the response object
     super(data.WRLSChargingResponse)
 
+    // We retain a copy of the actual response for audit purposes
+    this.chargeCalculation = JSON.stringify(data)
+
     this.chargeValue = this._convertToPence(this._data.chargeValue)
     this.sucFactor = this._convertToPence(this._data.sucFactor)
 

--- a/test/translators/rules_service.translator.test.js
+++ b/test/translators/rules_service.translator.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it } = exports.lab = Lab.script()
+const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
@@ -15,9 +15,14 @@ const rulesServiceFixture = require('../support/fixtures/calculate_charge/presro
 const { RulesServiceTranslator } = require('../../app/translators')
 
 describe('Rules Service translator', () => {
+  let data
+
+  beforeEach(async () => {
+    data = GeneralHelper.cloneObject(rulesServiceFixture)
+  })
+
   describe("the 'chargeValue' property", () => {
     it('is translated to pence instead of pounds and pence', async () => {
-      const data = GeneralHelper.cloneObject(rulesServiceFixture)
       data.WRLSChargingResponse.chargeValue = 123.45
 
       const testTranslator = new RulesServiceTranslator(data)
@@ -28,7 +33,6 @@ describe('Rules Service translator', () => {
 
   describe("the 'lineAttr10' property", () => {
     it('returns S127 value if present', async () => {
-      const data = GeneralHelper.cloneObject(rulesServiceFixture)
       data.WRLSChargingResponse.abatementAdjustment = 'S126 x 0.5'
       data.WRLSChargingResponse.s127Agreement = 'S127 x 0.5'
 
@@ -38,7 +42,6 @@ describe('Rules Service translator', () => {
     })
 
     it('returns S126 value if it indicates adjustment', async () => {
-      const data = GeneralHelper.cloneObject(rulesServiceFixture)
       data.WRLSChargingResponse.abatementAdjustment = 'S126 x 0.5'
 
       const testTranslator = new RulesServiceTranslator(data)
@@ -47,7 +50,6 @@ describe('Rules Service translator', () => {
     })
 
     it("returns null if S126 value doesn't indicate adjustment", async () => {
-      const data = GeneralHelper.cloneObject(rulesServiceFixture)
       data.WRLSChargingResponse.abatementAdjustment = 'S126 x 1.0'
 
       const testTranslator = new RulesServiceTranslator(data)
@@ -57,9 +59,7 @@ describe('Rules Service translator', () => {
   })
 
   describe("the 'chargeCalculation' property", () => {
-    it.only('returns an exact copy of the response received from the rules service', async => {
-      const data = GeneralHelper.cloneObject(rulesServiceFixture)
-
+    it('returns an exact copy of the response received from the rules service', async => {
       const testTranslator = new RulesServiceTranslator(data)
 
       expect(testTranslator.chargeCalculation).to.equal(JSON.stringify(data))

--- a/test/translators/rules_service.translator.test.js
+++ b/test/translators/rules_service.translator.test.js
@@ -55,4 +55,14 @@ describe('Rules Service translator', () => {
       expect(testTranslator.lineAttr10).to.equal(null)
     })
   })
+
+  describe("the 'chargeCalculation' property", () => {
+    it.only('returns an exact copy of the response received from the rules service', async => {
+      const data = GeneralHelper.cloneObject(rulesServiceFixture)
+
+      const testTranslator = new RulesServiceTranslator(data)
+
+      expect(testTranslator.chargeCalculation).to.equal(JSON.stringify(data))
+    })
+  })
 })


### PR DESCRIPTION
Currently, the [charging-module-api](https://github.com/defra/charging-module-api) retains a formatted form of the response received from the charging module. This makes a lot of sense from an auditing context. Being able to show the calculation response if questioned about the charge value assigned is handy.

We want to do the same in this project so this change adds support for it. We do this by updating the `RulesServiceTranslator` to add it as a property. We know the properties of the translator will be assigned to a `TransactionTranslator` instance. That instance will then form the basis of what gets persisted to the db.

The one change we're making to the CHA is we are not doing any reformatting of the response. If the intent is to hold this for auditing purposes then we really should record exactly what we received, not an altered version of it.