### PR TITLE
Add default ruleset property to Trans. translator

### DIFF
--- a/app/translators/calculate_charge.translator.js
+++ b/app/translators/calculate_charge.translator.js
@@ -47,7 +47,9 @@ class CalculateChargeTranslator extends BaseTranslator {
       periodStart: Joi.date().less(Joi.ref('periodEnd')).min('01-APR-2014').required(),
       periodEnd: Joi.date().required(),
       regionalChargingArea: Joi.string().required(), // validated in the rules service
-      // Set a new field called ruleset. This will be used to determine which ruleset to query in the rules service
+      // Set a new field called ruleset. This will be used to determine which ruleset to query in the rules service. If
+      // the data comes from a calculate charge request we deafult it. If the data comes from a create transaction
+      // request it will already be populated
       ruleset: Joi.string().default('presroc'),
       season: Joi.string().required(), // validated in rules service
       section126Factor: Joi.number().allow(null).empty(null).default(1.0),

--- a/app/translators/transaction.translator.js
+++ b/app/translators/transaction.translator.js
@@ -15,7 +15,9 @@ class TransactionTranslator extends BaseTranslator {
       areaCode: Joi.string().uppercase().valid(...this._validAreas()),
       lineDescription: Joi.string().max(240).required(),
       newLicence: Joi.boolean().default(false),
-      clientId: Joi.string().allow('', null)
+      clientId: Joi.string().allow('', null),
+      // Set a new field called ruleset. This will identify which ruleset the transaction and it's charge relates to
+      ruleset: Joi.string().default('presroc')
     })
   }
 

--- a/test/translators/calculate_charge.translator.test.js
+++ b/test/translators/calculate_charge.translator.test.js
@@ -32,6 +32,23 @@ describe('Calculate Charge translator', () => {
     section130Agreement: false
   }
 
+  describe('Default values', () => {
+    it("defaults 'section126Factor' to '1.0'", async () => {
+      const testTranslator = new CalculateChargeTranslator({
+        ...data,
+        section126Factor: null
+      })
+
+      expect(testTranslator.regimeValue11).to.be.a.number().and.equal(1.0)
+    })
+
+    it("defaults 'ruleset' to 'presroc'", async () => {
+      const testTranslator = new CalculateChargeTranslator(data)
+
+      expect(testTranslator.ruleset).to.be.a.string().and.equal('presroc')
+    })
+  })
+
   describe('calculating prorataDays', () => {
     it('correctly calculates the format', async () => {
       const testTranslator = new CalculateChargeTranslator({

--- a/test/translators/transaction.translator.test.js
+++ b/test/translators/transaction.translator.test.js
@@ -47,6 +47,12 @@ describe('Transaction translator', () => {
 
       expect(testTranslator.newLicence).to.be.a.boolean().and.equal(false)
     })
+
+    it("defaults 'ruleset' to 'presroc'", async () => {
+      const testTranslator = new TransactionTranslator(data)
+
+      expect(testTranslator.ruleset).to.be.a.string().and.equal('presroc')
+    })
   })
 
   describe('Validation', () => {


### PR DESCRIPTION
One of the changes we have made from the [charging-module-api](https://github.com/defra/charging-module-api) is that instead of using a boolean field to tell us whether something is related to `presroc` or not, we instead hold the ruleset name.

We believe this will give us much more flexibility going forward whilst still being able to tell us clearly which ruleset a transaction is related to. It also means we can use this value directly, for example, when trying to determine which rules service endpoints to hit.

As we only have `presroc` at the moment, this change adds it as a field to the `TransactionTranslator` and handles defaulting the value.