### PR TITLE
Update Trans. Translator to expect bill run id

### DIFF
--- a/app/translators/transaction.translator.js
+++ b/app/translators/transaction.translator.js
@@ -6,6 +6,7 @@ const Joi = require('joi')
 class TransactionTranslator extends BaseTranslator {
   _schema () {
     return Joi.object({
+      billRunId: Joi.string().required(),
       region: Joi.string().uppercase().valid(...this._validRegions()),
       customerReference: Joi.string().uppercase().max(12).required(),
       batchNumber: Joi.string().allow('', null),
@@ -23,6 +24,7 @@ class TransactionTranslator extends BaseTranslator {
 
   _translations () {
     return {
+      billRunId: 'billRunId',
       ruleset: 'ruleset',
       region: 'region',
       customerReference: 'customerReference',

--- a/test/translators/transaction.translator.test.js
+++ b/test/translators/transaction.translator.test.js
@@ -14,7 +14,7 @@ const { ValidationError } = require('joi')
 const { TransactionTranslator } = require('../../app/translators')
 
 describe('Transaction translator', () => {
-  const data = {
+  const payload = {
     periodStart: '01-APR-2019',
     periodEnd: '31-MAR-2020',
     credit: false,
@@ -41,15 +41,22 @@ describe('Transaction translator', () => {
     areaCode: 'ARCA'
   }
 
+  const data = (payload, billRunId = 'e2a28efc-09eb-439e-95bc-e64c68ab1ea5') => {
+    return {
+      billRunId,
+      ...payload
+    }
+  }
+
   describe('Default values', () => {
     it("defaults 'newLicence' to 'false'", async () => {
-      const testTranslator = new TransactionTranslator(data)
+      const testTranslator = new TransactionTranslator(data(payload))
 
       expect(testTranslator.newLicence).to.be.a.boolean().and.equal(false)
     })
 
     it("defaults 'ruleset' to 'presroc'", async () => {
-      const testTranslator = new TransactionTranslator(data)
+      const testTranslator = new TransactionTranslator(data(payload))
 
       expect(testTranslator.ruleset).to.be.a.string().and.equal('presroc')
     })
@@ -58,7 +65,7 @@ describe('Transaction translator', () => {
   describe('Validation', () => {
     describe('when the data is valid', () => {
       it('does not throw an error', async () => {
-        const result = new TransactionTranslator(data)
+        const result = new TransactionTranslator(data(payload))
 
         expect(result).to.not.be.an.error()
       })
@@ -67,23 +74,23 @@ describe('Transaction translator', () => {
     describe('when the data is not valid', () => {
       describe("because 'region' is not a valid region", () => {
         it('throws an error', async () => {
-          const invalidData = {
-            ...data,
+          const invalidPayload = {
+            ...payload,
             region: 'INVALID_REGION'
           }
 
-          expect(() => new TransactionTranslator(invalidData)).to.throw(ValidationError)
+          expect(() => new TransactionTranslator(data(invalidPayload))).to.throw(ValidationError)
         })
       })
 
       describe("because 'areaCode' is not a valid area", () => {
         it('throws an error', async () => {
-          const invalidData = {
-            ...data,
+          const invalidPayload = {
+            ...payload,
             areaCode: 'INVALID_AREA'
           }
 
-          expect(() => new TransactionTranslator(invalidData)).to.throw(ValidationError)
+          expect(() => new TransactionTranslator(data(invalidPayload))).to.throw(ValidationError)
         })
       })
     })

--- a/test/translators/transaction.translator.test.js
+++ b/test/translators/transaction.translator.test.js
@@ -58,7 +58,9 @@ describe('Transaction translator', () => {
   describe('Validation', () => {
     describe('when the data is valid', () => {
       it('does not throw an error', async () => {
-        expect(() => new TransactionTranslator(data).to.not.throw())
+        const result = new TransactionTranslator(data)
+
+        expect(result).to.not.be.an.error()
       })
     })
 


### PR DESCRIPTION
We know we'll have a bill run ID because requests to create a transaction will come via `POST /v2/bill-runs/{id}/transactions`. We also will be persisting this to the `transactions` table when we create the transaction.

But the current design does not inject the bill run ID into the translator. Instead, it assumes this will be added separately when the transaction is persisted.

The issue is this forces us to generate an ad-hoc object to persist made up of the transaction translator, bill run ID, regime ID etc. It's not a significant problem but we believe a cleaner, clearer design is to think of a request not just as the body received. Instead, it should consider all information sent as being part of the request.

- the request body
- the regime it is for
- the authorised system making the request
- the bill run it's related too (if relevant)
- etc

So this change is the first step in implementing this concept. That translators receive and interpret _all_ request data, not just the body.