### PR TITLE
Update Trans. Translator to expect Regime Id

### DIFF
--- a/app/translators/transaction.translator.js
+++ b/app/translators/transaction.translator.js
@@ -7,6 +7,7 @@ class TransactionTranslator extends BaseTranslator {
   _schema () {
     return Joi.object({
       billRunId: Joi.string().required(),
+      regimeId: Joi.string().required(),
       region: Joi.string().uppercase().valid(...this._validRegions()),
       customerReference: Joi.string().uppercase().max(12).required(),
       batchNumber: Joi.string().allow('', null),
@@ -25,6 +26,7 @@ class TransactionTranslator extends BaseTranslator {
   _translations () {
     return {
       billRunId: 'billRunId',
+      regimeId: 'regimeId',
       ruleset: 'ruleset',
       region: 'region',
       customerReference: 'customerReference',

--- a/test/translators/transaction.translator.test.js
+++ b/test/translators/transaction.translator.test.js
@@ -41,9 +41,13 @@ describe('Transaction translator', () => {
     areaCode: 'ARCA'
   }
 
-  const data = (payload, billRunId = 'e2a28efc-09eb-439e-95bc-e64c68ab1ea5') => {
+  const data = (
+    payload,
+    billRunId = 'e2a28efc-09eb-439e-95bc-e64c68ab1ea5',
+    regimeId = 'ff75f82d-d56f-4807-9cad-12f23d6b29a8') => {
     return {
       billRunId,
+      regimeId,
       ...payload
     }
   }


### PR DESCRIPTION
> Part of the translator 'request' concept update kicked off by [PR #116](https://github.com/DEFRA/sroc-charging-module-api/pull/116)

This change updates the transaction translator to expect a regime Id as part of the data passed to it.

**Concept update**

Prior to this change, the purpose of translators was to 'translate' just the request body into properties our models and services would understand.

The update expands the concept of translators to 'translate' everything in the request. So this includes regime, authorised system, and bill run, for example. They are *not* included in the body. But they are part of the request.