### PR TITLE
Manage values to persist in bill run translator

### DIFF
--- a/app/services/create_bill_run.service.js
+++ b/app/services/create_bill_run.service.js
@@ -45,7 +45,7 @@ class CreateBillRunService {
           region: translator.region,
           regimeId: translator.regimeId,
           createdBy: translator.createdBy,
-          status: 'initialised'
+          status: translator.status
         })
         .returning('*')
     })

--- a/app/services/create_bill_run.service.js
+++ b/app/services/create_bill_run.service.js
@@ -26,14 +26,18 @@ const NextBillRunNumberService = require('./next_bill_run_number.service')
  */
 class CreateBillRunService {
   static async go (payload, authorisedSystem, regime) {
-    const translator = new BillRunTranslator({
+    const translator = this._translateRequest(payload, authorisedSystem, regime)
+    const billRun = await this._create(translator)
+
+    return this._response(billRun)
+  }
+
+  static _translateRequest (payload, authorisedSystem, regime) {
+    return new BillRunTranslator({
       ...payload,
       regimeId: regime.id,
       authorisedSystemId: authorisedSystem.id
     })
-    const billRun = await this._create(translator)
-
-    return this._response(billRun)
   }
 
   static async _create (translator) {

--- a/app/services/create_bill_run.service.js
+++ b/app/services/create_bill_run.service.js
@@ -15,7 +15,7 @@ const NextBillRunNumberService = require('./next_bill_run_number.service')
  * Creates a new bill run record
  *
  * The service handles validating and translating the request to the API and then creating a new bill run for the
- * selected regime. It then returns the new bill run as the result.
+ * selected regime. It then returns a representation of the new bill run to be used in the response.
  *
  * @param {Object} payload The payload from the API request
  * @param {module:AuthorisedSystemModel} authorisedSystem Instance of `AuthorisedSystemModel' representing the

--- a/app/services/create_bill_run.service.js
+++ b/app/services/create_bill_run.service.js
@@ -41,11 +41,8 @@ class CreateBillRunService {
       const billRunNumber = await NextBillRunNumberService.go(translator.regimeId, translator.region)
       return BillRunModel.query()
         .insert({
-          billRunNumber,
-          region: translator.region,
-          regimeId: translator.regimeId,
-          createdBy: translator.createdBy,
-          status: translator.status
+          ...translator,
+          billRunNumber
         })
         .returning('*')
     })

--- a/app/translators/bill_run.translator.js
+++ b/app/translators/bill_run.translator.js
@@ -8,7 +8,8 @@ class BillRunTranslator extends BaseTranslator {
     return {
       authorisedSystemId: 'createdBy',
       regimeId: 'regimeId',
-      region: 'region'
+      region: 'region',
+      status: 'status'
     }
   }
 
@@ -16,7 +17,8 @@ class BillRunTranslator extends BaseTranslator {
     return Joi.object({
       authorisedSystemId: Joi.string().required(),
       regimeId: Joi.string().required(),
-      region: Joi.string().uppercase().valid(...this._validRegions())
+      region: Joi.string().uppercase().valid(...this._validRegions()),
+      status: Joi.string().default('initialised')
     })
   }
 

--- a/test/translators/bill_run.translator.test.js
+++ b/test/translators/bill_run.translator.test.js
@@ -41,7 +41,9 @@ describe('Bill Run translator', () => {
   describe('Validation', () => {
     describe('when the data is valid', () => {
       it('does not throw an error', async () => {
-        expect(() => new BillRunTranslator(data(payload))).to.not.throw()
+        const result = new BillRunTranslator(data(payload))
+
+        expect(result).to.not.be.an.error()
       })
 
       it("does not throw an error if the 'region' is lowercase", async () => {

--- a/test/translators/bill_run.translator.test.js
+++ b/test/translators/bill_run.translator.test.js
@@ -30,6 +30,14 @@ describe('Bill Run translator', () => {
     }
   }
 
+  describe('Default values', () => {
+    it("defaults 'status' to 'initialised'", async () => {
+      const testTranslator = new BillRunTranslator(data(payload))
+
+      expect(testTranslator.status).to.be.a.string().and.equal('initialised')
+    })
+  })
+
   describe('Validation', () => {
     describe('when the data is valid', () => {
       it('does not throw an error', async () => {


### PR DESCRIPTION
We're trying to simplify and be consistent with the creation process for our records. In support of this, we're trying to have all values that are to be persisted determined in the translator. We then can pass the translator as is to the [Objection insert query](https://vincit.github.io/objection.js/guide/query-examples.html#insert-queries).

This change updates the BillRun translator and the create bill run service to follow this pattern.