### PR TITLE
Update Bill Run Translator to expect Regime Id

### DIFF
--- a/app/services/create_bill_run.service.js
+++ b/app/services/create_bill_run.service.js
@@ -26,20 +26,20 @@ const NextBillRunNumberService = require('./next_bill_run_number.service')
  */
 class CreateBillRunService {
   static async go (payload, authorisedSystem, regime) {
-    const translator = new BillRunTranslator(payload)
-    const billRun = await this._create(translator, authorisedSystem, regime)
+    const translator = new BillRunTranslator({ ...payload, regimeId: regime.id })
+    const billRun = await this._create(translator, authorisedSystem)
 
     return this._response(billRun)
   }
 
-  static async _create (translator, authorisedSystem, regime) {
+  static async _create (translator, authorisedSystem) {
     return BillRunModel.transaction(async () => {
-      const billRunNumber = await NextBillRunNumberService.go(regime.id, translator.region)
+      const billRunNumber = await NextBillRunNumberService.go(translator.regimeId, translator.region)
       return BillRunModel.query()
         .insert({
           billRunNumber,
           region: translator.region,
-          regimeId: regime.id,
+          regimeId: translator.regimeId,
           createdBy: authorisedSystem.id,
           status: 'initialised'
         })

--- a/app/translators/bill_run.translator.js
+++ b/app/translators/bill_run.translator.js
@@ -6,12 +6,14 @@ const Joi = require('joi')
 class BillRunTranslator extends BaseTranslator {
   _translations () {
     return {
+      regimeId: 'regimeId',
       region: 'region'
     }
   }
 
   _schema () {
     return Joi.object({
+      regimeId: Joi.string().required(),
       region: Joi.string().uppercase().valid(...this._validRegions())
     })
   }

--- a/test/translators/bill_run.translator.test.js
+++ b/test/translators/bill_run.translator.test.js
@@ -14,41 +14,53 @@ const { ValidationError } = require('joi')
 const { BillRunTranslator } = require('../../app/translators')
 
 describe('Bill Run translator', () => {
-  const data = region => {
+  const payload = {
+    region: 'A'
+  }
+
+  const data = (payload, regimeId = 'ff75f82d-d56f-4807-9cad-12f23d6b29a8') => {
     return {
-      region: region
+      regimeId,
+      ...payload
     }
   }
 
   describe('Validation', () => {
     describe('when the data is valid', () => {
       it('does not throw an error', async () => {
-        const region = 'A'
-
-        expect(() => new BillRunTranslator(data(region))).to.not.throw()
+        expect(() => new BillRunTranslator(data(payload))).to.not.throw()
       })
 
       it("does not throw an error if the 'region' is lowercase", async () => {
-        const region = 'a'
+        const lowercasePayload = {
+          ...payload,
+          region: 'a'
+        }
 
-        expect(() => new BillRunTranslator(data(region))).to.not.throw()
+        expect(() => new BillRunTranslator(data(lowercasePayload))).to.not.throw()
       })
     })
 
     describe('when the data is not valid', () => {
       describe("because the 'region' is missing", () => {
         it('throws an error', async () => {
-          const region = ''
+          const invalidPayload = {
+            ...payload,
+            region: ''
+          }
 
-          expect(() => new BillRunTranslator(data(region))).to.throw(ValidationError)
+          expect(() => new BillRunTranslator(data(invalidPayload))).to.throw(ValidationError)
         })
       })
 
       describe("because the 'region' is unrecognised", () => {
         it('throws an error', async () => {
-          const region = 'Z'
+          const invalidPayload = {
+            ...payload,
+            region: 'Z'
+          }
 
-          expect(() => new BillRunTranslator(data(region))).to.throw(ValidationError)
+          expect(() => new BillRunTranslator(data(invalidPayload))).to.throw(ValidationError)
         })
       })
     })


### PR DESCRIPTION
> Part of the translator 'request' concept update kicked off by [PR #116](https://github.com/DEFRA/sroc-charging-module-api/pull/116)

This change updates the bill run translator to expect a regime Id as part of the data passed to it.

**Concept update**

Prior to this change, the purpose of translators was to 'translate' just the request body into properties our models and services would understand.

The update expands the concept of translators to 'translate' everything in the request. So this includes regime, authorised system, and bill run, for example. They are *not* included in the body. But they are part of the request.