### PR TITLE
Update Bill Run Translator expect Auth. System Id

### DIFF
--- a/app/translators/bill_run.translator.js
+++ b/app/translators/bill_run.translator.js
@@ -6,6 +6,7 @@ const Joi = require('joi')
 class BillRunTranslator extends BaseTranslator {
   _translations () {
     return {
+      authorisedSystemId: 'createdBy',
       regimeId: 'regimeId',
       region: 'region'
     }
@@ -13,6 +14,7 @@ class BillRunTranslator extends BaseTranslator {
 
   _schema () {
     return Joi.object({
+      authorisedSystemId: Joi.string().required(),
       regimeId: Joi.string().required(),
       region: Joi.string().uppercase().valid(...this._validRegions())
     })

--- a/test/translators/bill_run.translator.test.js
+++ b/test/translators/bill_run.translator.test.js
@@ -18,9 +18,14 @@ describe('Bill Run translator', () => {
     region: 'A'
   }
 
-  const data = (payload, regimeId = 'ff75f82d-d56f-4807-9cad-12f23d6b29a8') => {
+  const data = (
+    payload,
+    regimeId = 'ff75f82d-d56f-4807-9cad-12f23d6b29a8',
+    authorisedSystemId = 'e46b816a-3fe8-438a-a3f9-7a1a8eb525ce'
+  ) => {
     return {
       regimeId,
+      authorisedSystemId,
       ...payload
     }
   }


### PR DESCRIPTION
> Part of the translator 'request' concept update kicked off by [PR #116](https://github.com/DEFRA/sroc-charging-module-api/pull/116)

This change updates the bill run translator to expect an authorised system Id as part of the data passed to it.

**Concept update**

Prior to this change, the purpose of translators was to 'translate' just the request body into properties our models and services would understand.

The update expands the concept of translators to 'translate' everything in the request. So this includes regime, authorised system, and bill run, for example. They are *not* included in the body. But they are part of the request.