### PR TITLE
Revert making _data enumerable in base translator

### DIFF
--- a/app/translators/base.translator.js
+++ b/app/translators/base.translator.js
@@ -14,8 +14,12 @@ class BaseTranslator {
     const translatedData = this._translate(validatedData, this._translations())
     Object.assign(this, translatedData)
 
-    // Assign validated data to _data
+    // Assign validated data to _data and set it to be non-enumerable so it isn't visible outside of the translator.
+    // For example, this allows us to pass a translator instance to Objection's `query().insert()` method as is rather
+    // than defining each property to update. Without this Objection would see `_data` and try and include it in the
+    // insert query
     Object.assign(this, { _data: validatedData })
+    Object.defineProperty(this, '_data', { enumerable: false })
   }
 
   /**


### PR DESCRIPTION
We removed the logic which hid `_data` in the base translator in [PR #108](https://github.com/DEFRA/sroc-charging-module-api/pull/108). At the time we felt it was unnecessary as we had a convention of marking private members with an underscore.

However, in initial attempts to just pass the translator instances directly into [Objection insert queries](https://vincit.github.io/objection.js/guide/query-examples.html#insert-queries) we got errors. We are trying to avoid having to specify each field to insert or update and instead just rely on the translator instance and its properties. This failed though because `_data` was being seen and read by Objection. As our tables and models don't have a `_data` field the attempt failed. It works though if we hide `_data`.

So, this change reverts that previous misguided attempt to simplify the code!