### PR TITLE
Simplify auth. system creation in service

### DIFF
--- a/app/services/create_authorised_system.service.js
+++ b/app/services/create_authorised_system.service.js
@@ -21,7 +21,7 @@ const { JsonPresenter } = require('../presenters')
 class CreateAuthorisedSystemService {
   static async go (payload) {
     const translator = new AuthorisedSystemTranslator(payload)
-    const regimes = await this._regimes(translator.authorisations)
+    const regimes = await this._regimes(translator.validatedData.authorisations)
     const authorisedSystem = await this._create(translator, regimes)
 
     return this._response(authorisedSystem)
@@ -38,10 +38,7 @@ class CreateAuthorisedSystemService {
       const newRecords = await AuthorisedSystemModel.query(trx).insertGraphAndFetch(
         [
           {
-            client_id: translator.clientId,
-            name: translator.name,
-            admin: false,
-            status: translator.status,
+            ...translator,
             regimes: regimes
           }
         ],

--- a/app/translators/authorised_system.translator.js
+++ b/app/translators/authorised_system.translator.js
@@ -9,8 +9,7 @@ class AuthorisedSystemTranslator extends BaseTranslator {
       clientId: 'clientId',
       name: 'name',
       admin: 'admin',
-      status: 'status',
-      authorisations: 'authorisations'
+      status: 'status'
     }
   }
 

--- a/app/translators/authorised_system.translator.js
+++ b/app/translators/authorised_system.translator.js
@@ -8,6 +8,7 @@ class AuthorisedSystemTranslator extends BaseTranslator {
     return {
       clientId: 'clientId',
       name: 'name',
+      admin: 'admin',
       status: 'status',
       authorisations: 'authorisations'
     }
@@ -17,6 +18,7 @@ class AuthorisedSystemTranslator extends BaseTranslator {
     return Joi.object({
       clientId: Joi.string().required(),
       name: Joi.string().required(),
+      admin: Joi.boolean().default(false),
       status: Joi.string().default('active'),
       authorisations: Joi.array().items(Joi.string())
     })

--- a/test/translators/authorised_system.translator.test.js
+++ b/test/translators/authorised_system.translator.test.js
@@ -32,6 +32,12 @@ describe('Authorised system translator', () => {
 
       expect(testTranslator.status).to.be.a.string().and.equal('active')
     })
+
+    it("defaults 'admin' to 'false'", async () => {
+      const testTranslator = new AuthorisedSystemTranslator(data(payload, ['wrls']))
+
+      expect(testTranslator.admin).to.be.a.boolean().and.equal(false)
+    })
   })
 
   describe('Validation', () => {

--- a/test/translators/authorised_system.translator.test.js
+++ b/test/translators/authorised_system.translator.test.js
@@ -14,54 +14,62 @@ const { ValidationError } = require('joi')
 const { AuthorisedSystemTranslator } = require('../../app/translators')
 
 describe('Authorised system translator', () => {
+  const payload = {
+    clientId: 'i7rnixijjrawj7azzhwwxxxxxx',
+    name: 'olmos'
+  }
+
+  const data = (payload, regimes) => {
+    return {
+      ...payload,
+      authorisations: regimes
+    }
+  }
+
+  describe('Default values', () => {
+    it("defaults 'status' to 'active'", async () => {
+      const testTranslator = new AuthorisedSystemTranslator(data(payload))
+
+      expect(testTranslator.status).to.be.a.string().and.equal('active')
+    })
+  })
+
   describe('Validation', () => {
     describe('when the data is valid', () => {
-      const validData = regimes => {
-        return {
-          clientId: 'i7rnixijjrawj7azzhwwxxxxxx',
-          name: 'olmos',
-          status: 'active',
-          authorisations: regimes
-        }
-      }
-
       it('does not throw an error', async () => {
-        expect(() => new AuthorisedSystemTranslator(validData(['wrls']))).to.not.throw()
+        const result = new AuthorisedSystemTranslator(data(payload, ['wrls']))
+
+        expect(result).to.not.be.an.error()
       })
 
       it('does not throw an error if authorised regimes is empty', async () => {
-        expect(() => new AuthorisedSystemTranslator(validData([]))).to.not.throw()
+        const result = new AuthorisedSystemTranslator(data(payload, []))
+
+        expect(result).to.not.be.an.error()
       })
     })
 
     describe('when the data is not valid', () => {
-      const invalidData = regimes => {
-        return {
-          clientId: '',
-          name: 'olmos',
-          status: 'active',
-          authorisations: regimes
-        }
-      }
+      describe("because 'clientId' is missing", () => {
+        it('throws an error', async () => {
+          const invalidPayload = {
+            ...payload,
+            clientId: ''
+          }
 
-      it('throws an error', async () => {
-        expect(() => new AuthorisedSystemTranslator(invalidData(['wrls']))).to.throw(ValidationError)
+          expect(() => new AuthorisedSystemTranslator(data(invalidPayload, ['wrls']))).to.throw(ValidationError)
+        })
       })
-    })
 
-    describe("When the data contains no 'status'", () => {
-      const validData = () => {
-        return {
-          clientId: 'i7rnixijjrawj7azzhwwxxxxxx',
-          name: 'olmos',
-          authorisations: []
-        }
-      }
+      describe("because 'name' is missing", () => {
+        it('throws an error', async () => {
+          const invalidPayload = {
+            ...payload,
+            name: ''
+          }
 
-      it("defaults it to 'active'", async () => {
-        const translator = new AuthorisedSystemTranslator(validData())
-
-        expect(translator.status).to.equal('active')
+          expect(() => new AuthorisedSystemTranslator(data(invalidPayload, ['wrls']))).to.throw(ValidationError)
+        })
       })
     })
   })


### PR DESCRIPTION
Similar to the changes made in [Manage values to persist in bill run translator](https://github.com/DEFRA/sroc-charging-module-api/pull/119) we are trying to simplify and be consistent with the creation process of records. We want to be able to pass in translator instances to [Objection insert queries](https://vincit.github.io/objection.js/guide/query-examples.html#insert-queries) rather than spell out each field that needs updating.

We've made the change for when creating bill runs. At the moment the only other `create` is for authorised systems. This updates the `CreateAuthorisedSystemService` and associated `AuthorisedSystemTranslator` to support this new convention.