### PR TITLE
Update Calculate Charge Translator expect Regime slug

### DIFF
--- a/app/services/calculate_charge.service.js
+++ b/app/services/calculate_charge.service.js
@@ -26,16 +26,23 @@ class CalculateChargeService {
    * @returns {Object} The calculated charge
    */
   static async go (payload, regime) {
-    const translator = new CalculateChargeTranslator(payload)
-    const calculatedCharge = await this._calculateCharge(translator, regime.slug)
+    const translator = this._translateRequest(payload, regime)
+    const calculatedCharge = await this._calculateCharge(translator)
 
     this._applyCalculatedCharge(translator, calculatedCharge)
 
     return this._response(translator)
   }
 
-  static async _calculateCharge (translator, regimeSlug) {
-    const presenter = new RulesServicePresenter({ ...translator, regime: regimeSlug })
+  static _translateRequest (payload, regime) {
+    return new CalculateChargeTranslator({
+      ...payload,
+      regime: regime.slug
+    })
+  }
+
+  static async _calculateCharge (translator) {
+    const presenter = new RulesServicePresenter(translator)
     const result = await RulesService.go(presenter.go())
 
     return new RulesServiceTranslator(result)

--- a/app/translators/calculate_charge.translator.js
+++ b/app/translators/calculate_charge.translator.js
@@ -58,7 +58,8 @@ class CalculateChargeTranslator extends BaseTranslator {
       source: Joi.string().required(), // validated in rules service
       twoPartTariff: Joi.boolean().required(),
       volume: Joi.number().min(0),
-      waterUndertaker: Joi.boolean().required()
+      waterUndertaker: Joi.boolean().required(),
+      regime: Joi.string().required() // needed to determine which endpoints to call in the rules service
     })
   }
 

--- a/app/translators/calculate_charge.translator.js
+++ b/app/translators/calculate_charge.translator.js
@@ -81,7 +81,8 @@ class CalculateChargeTranslator extends BaseTranslator {
       source: 'regimeValue6',
       twoPartTariff: 'regimeValue16',
       volume: 'lineAttr5',
-      waterUndertaker: 'regimeValue14'
+      waterUndertaker: 'regimeValue14',
+      regime: 'regime'
     }
   }
 

--- a/test/translators/calculate_charge.translator.test.js
+++ b/test/translators/calculate_charge.translator.test.js
@@ -96,7 +96,9 @@ describe('Calculate Charge translator', () => {
   describe('Validation', () => {
     describe('when the data is valid', () => {
       it('does not throw an error', async () => {
-        expect(() => new CalculateChargeTranslator(data).to.not.throw())
+        const result = new CalculateChargeTranslator(data)
+
+        expect(result).to.not.be.an.error()
       })
     })
 


### PR DESCRIPTION
> Part of the translator 'request' concept update kicked off by [PR #116](https://github.com/DEFRA/sroc-charging-module-api/pull/116)

This change updates the calculate charge translator to expect a regime 'slug' as part of the data passed to it.

**Concept update**

Prior to this change, the purpose of translators was to 'translate' just the request body into properties our models and services would understand.

The update expands the concept of translators to 'translate' everything in the request. So this includes regime, authorised system, and bill run, for example. They are *not* included in the body. But they are part of the request.