### PR TITLE
Access rules service result from charge service

### DIFF
--- a/app/services/calculate_charge.service.js
+++ b/app/services/calculate_charge.service.js
@@ -22,13 +22,24 @@ class CalculateChargeService {
    * @param {Object} payload The payload from the API request
    * @param {module:RegimeModel} regime Instance of `RegimeModel` representing the regime we are calculating the charge
    * for
+   * @param {boolean} [presenterResponse] Whether to return the result ready for responding to a client (the default) or
+   * to return the rules service result directly
    *
-   * @returns {Object} The calculated charge
+   * @returns {Object} The calculated charge, either formatted ready for responding to the client or as translated from
+   * the rules service response
    */
-  static async go (payload, regime) {
+  static async go (payload, regime, presenterResponse = true) {
     const translator = this._translateRequest(payload, regime)
     const calculatedCharge = await this._calculateCharge(translator)
 
+    // When creating a transaction we'll want the response from rules service directly. We need all the values
+    // translated to things we understand. So we use this option to allow us to return early with that result
+    if (!presenterResponse) {
+      return calculatedCharge
+    }
+
+    // When responding to a calculate charge request we need to present the response in a format the client will
+    // understand. So we merge the translator and the rules service result and then prepare the response
     this._applyCalculatedCharge(translator, calculatedCharge)
 
     return this._response(translator)

--- a/test/services/calculate_charge.service.test.js
+++ b/test/services/calculate_charge.service.test.js
@@ -25,11 +25,11 @@ describe('Calculate Charge service', () => {
     slug: 'wrls'
   }
 
-  describe('When the data is valid', () => {
-    afterEach(async () => {
-      Sinon.restore()
-    })
+  afterEach(async () => {
+    Sinon.restore()
+  })
 
+  describe('When the data is valid', () => {
     describe("and is a 'simple' request", () => {
       beforeEach(async () => {
         Sinon.stub(RulesService, 'go').returns(fixtures.simple.rulesService)
@@ -78,6 +78,19 @@ describe('Calculate Charge service', () => {
       const err = await expect(CalculateChargeService.go(invalidPaylod, regime)).to.reject(ValidationError)
 
       expect(err).to.be.an.error()
+    })
+  })
+
+  describe("When I don't want a 'presenter response'", () => {
+    beforeEach(async () => {
+      Sinon.stub(RulesService, 'go').returns(fixtures.simple.rulesService)
+    })
+
+    it("returns the 'rule service response'", async () => {
+      const result = await CalculateChargeService.go(fixtures.simple.request, regime, false)
+
+      expect(result.calculation).to.not.exist()
+      expect(result.chargeCalculation).to.exist()
     })
   })
 })


### PR DESCRIPTION
We're endeavouring to keep things simple, clean and avoid duplication. There are 2 places we need to acept a request, forward the details to the rules service, and return a response

- standalone calculate charge endpoint
- create a transaction endpoint

For both the flow is pretty similar right up to the point we get the result back from the rules service and translate it into something we understand.

- The standalone calculate charge then passes it to a presenter ready for returning to the client
- The create transaction needs the result in a format it understands for persisting to the database

We have experimented with changes to the presenters and translators, and even breaking up the charge service. However, we realised we were making the solution much more complicated simply to stick to a pattern of 'one input - one output'. By providing an override flag to the `CalculateChargeService` we can have it return the result needed for each scenario.

So this change updates the service to allow the caller to determine what format of result is needed.