### PR TITLE
Fix sucFactor from rules service not translated

### DIFF
--- a/app/presenters/calculate_charge.presenter.js
+++ b/app/presenters/calculate_charge.presenter.js
@@ -21,7 +21,7 @@ class CalculateChargePresenter extends BasePresenter {
         chargeElementAgreement: data.lineAttr10,
         eiucSourceFactor: data.lineAttr13,
         eiuc: data.lineAttr14,
-        suc: data.sucFactor
+        suc: data.lineAttr4
       }
     }
   }

--- a/app/translators/rules_service.translator.js
+++ b/app/translators/rules_service.translator.js
@@ -16,7 +16,7 @@ class RulesServiceTranslator extends BaseTranslator {
     this.chargeCalculation = JSON.stringify(data)
 
     this.chargeValue = this._convertToPence(this._data.chargeValue)
-    this.sucFactor = this._convertToPence(this._data.sucFactor)
+    this.lineAttr4 = this._convertToPence(this._data.sucFactor)
 
     // Charge element agreement is determined based on rules service response
     this.lineAttr10 = this._determineChargeElementAgreement()
@@ -40,7 +40,6 @@ class RulesServiceTranslator extends BaseTranslator {
   _translations () {
     return {
       chargeValue: 'chargeValue',
-      sucFactor: 'lineAttr4',
       sourceFactor: 'lineAttr6',
       seasonFactor: 'lineAttr7',
       lossFactor: 'lineAttr8',


### PR DESCRIPTION
Spotted that when we get the result from the `RulesService` we are storing it in the `RulesServiceTranslator` as `sucFactor`. Our service understands this as `lineAttr4` on the transaction. We did have the translation listed. But we were also adding a `sucFactor` property. As can be seen in the subsequent line our convention in a translator _if_ we have to set a property is to use the translated name.

So this updates `RulesServiceTranslator` to fix this issue. The end result is when we use the translated fields in an [Objection insert query](https://vincit.github.io/objection.js/guide/query-examples.html#insert-queries) the fields will match what is in the table.