### PR TITLE
Add missing test coverage 4 RulesServiceTranslator

### DIFF
--- a/app/translators/rules_service.translator.js
+++ b/app/translators/rules_service.translator.js
@@ -68,10 +68,6 @@ class RulesServiceTranslator extends BaseTranslator {
   _convertToPence (value) {
     const floatValue = parseFloat(value)
 
-    if (isNaN(floatValue)) {
-      return null
-    }
-
     return Math.round(floatValue * 100)
   }
 }

--- a/test/translators/rules_service.translator.test.js
+++ b/test/translators/rules_service.translator.test.js
@@ -31,6 +31,16 @@ describe('Rules Service translator', () => {
     })
   })
 
+  describe("the 'sucFactor' property", () => {
+    it('is translated to pence instead of pounds and pence', async () => {
+      data.WRLSChargingResponse.sucFactor = 123.45
+
+      const testTranslator = new RulesServiceTranslator(data)
+
+      expect(testTranslator.lineAttr4).to.equal(12345)
+    })
+  })
+
   describe("the 'lineAttr10' property", () => {
     it('returns S127 value if present', async () => {
       data.WRLSChargingResponse.abatementAdjustment = 'S126 x 0.5'


### PR DESCRIPTION
Our test coverage has been showing a couple of lines always being missed in the `RulesServiceTranslator`. These were in the `_convertToPence()` method and were to handle if the param passed in was not a number.

In the context of the `RulesServiceTranslator` this would never happen. We use this method with `chargeValue` and `sucFactor` and the validation requires that they are numbers. We'd get a validation error before we ever attempted to pass in null to `_convertToPence()`.

So the first part of this fix is to remove the code that will never be used. Then whilst we were looking at `sucFactor` we spotted there was no specific test to confirm it gets converted to pence. So this change also adds a missing test for that.