### PR TITLE
Remove transactions controller

### DIFF
--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -9,7 +9,6 @@ const DatabaseController = require('./admin/health/database.controller')
 const NotSupportedController = require('./not_supported.controller')
 const PresrocBillRunsController = require('./presroc/bill_runs.controller')
 const PresrocCalculateChargeController = require('./presroc/calculate_charge.controller')
-const PresrocTransactionsController = require('./presroc/transactions.controller')
 
 module.exports = {
   RootController,
@@ -19,6 +18,5 @@ module.exports = {
   DatabaseController,
   PresrocBillRunsController,
   PresrocCalculateChargeController,
-  PresrocTransactionsController,
   NotSupportedController
 }

--- a/app/controllers/presroc/transactions.controller.js
+++ b/app/controllers/presroc/transactions.controller.js
@@ -1,9 +1,0 @@
-'use strict'
-
-class TransactionsController {
-  static async index (_req, _h) {
-    return 'hello, pre-sroc transactions'
-  }
-}
-
-module.exports = TransactionsController

--- a/app/routes/transaction.routes.js
+++ b/app/routes/transaction.routes.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { NotSupportedController, PresrocTransactionsController } = require('../controllers')
+const { NotSupportedController } = require('../controllers')
 
 const routes = [
   {
@@ -12,11 +12,6 @@ const routes = [
     method: 'GET',
     path: '/v1/{regimeId}/transactions/{transactionId}',
     handler: NotSupportedController.index
-  },
-  {
-    method: 'GET',
-    path: '/v2/{regimeId}/transactions',
-    handler: PresrocTransactionsController.index
   }
 ]
 


### PR DESCRIPTION
This was added at the start of the project as a demonstration of how we could structure our controllers across regimes. It doesn't have any functionality, and we are some way off actually implementing support for the transaction endpoints.

As we move towards this version 2 of the API being tested and put through its paces, we're taking this opportunity to remove something that is currently purely for demo purposes.