### PR TITLE
Add default for status in bill run table

### DIFF
--- a/db/migrations/20201224094044_alter_bill_runs.js
+++ b/db/migrations/20201224094044_alter_bill_runs.js
@@ -1,0 +1,23 @@
+'use strict'
+
+const tableName = 'bill_runs'
+
+exports.up = async function (knex) {
+  await knex
+    .schema
+    .alterTable(tableName, table => {
+      // Alter existing columns
+      // alter() requires you list everything, not just the thing you are changing. This is why existing constraints
+      // like notNullable() are listed as well. If we didn't, they would be dropped.
+      table.string('status').defaultTo('initialised').notNullable().alter()
+    })
+}
+
+exports.down = async function (knex) {
+  await knex
+    .schema
+    .alterTable(tableName, table => {
+      // Revert alterations
+      table.string('status').notNullable().alter()
+    })
+}


### PR DESCRIPTION
The staus for all bill runs when first created is set to 'initialised'. For other tables, we've set a default for the field so this change adds one for bill runs.