### PR TITLE
Add foreign key constraint to bill run id in trans

### DIFF
--- a/db/migrations/20201203144442_create_transactions.js
+++ b/db/migrations/20201203144442_create_transactions.js
@@ -10,7 +10,7 @@ exports.up = async function (knex) {
       table.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'))
 
       // Data
-      table.uuid('bill_run_id').notNullable()
+      table.uuid('bill_run_id').notNullable().references('bill_runs.id')
       table.integer('charge_value').notNullable()
       table.boolean('charge_credit').notNullable()
 

--- a/test/services/create_transaction.service.test.js
+++ b/test/services/create_transaction.service.test.js
@@ -9,7 +9,13 @@ const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const { AuthorisedSystemHelper, DatabaseHelper, GeneralHelper, RegimeHelper } = require('../support/helpers')
+const {
+  AuthorisedSystemHelper,
+  BillRunHelper,
+  DatabaseHelper,
+  GeneralHelper,
+  RegimeHelper
+} = require('../support/helpers')
 const { TransactionModel } = require('../../app/models')
 const { ValidationError } = require('joi')
 
@@ -43,12 +49,14 @@ describe('Create Transaction service', () => {
   })
 
   describe('When the data is valid', () => {
+    let billRun
     let transaction
     let result
 
     beforeEach(async () => {
       Sinon.stub(RulesService, 'go').returns(chargeFixtures.simple.rulesService)
-      transaction = await CreateTransactionService.go(payload, billRunId, authorisedSystem, regime)
+      billRun = await BillRunHelper.addBillRun(authorisedSystem.id, regime.id)
+      transaction = await CreateTransactionService.go(payload, billRun.id, authorisedSystem, regime)
       result = await TransactionModel.query().findById(transaction.transaction.id)
     })
 

--- a/test/services/create_transaction.service.test.js
+++ b/test/services/create_transaction.service.test.js
@@ -18,6 +18,7 @@ const {
 } = require('../support/helpers')
 const { TransactionModel } = require('../../app/models')
 const { ValidationError } = require('joi')
+const { ForeignKeyViolationError } = require('db-errors')
 
 const { presroc: requestFixtures } = require('../support/fixtures/create_transaction')
 const { presroc: chargeFixtures } = require('../support/fixtures/calculate_charge')
@@ -103,6 +104,18 @@ describe('Create Transaction service', () => {
     describe("because 'regime' is not specified", () => {
       it('throws an error', async () => {
         const err = await expect(CreateTransactionService.go(payload, billRunId, authorisedSystem)).to.reject(TypeError)
+
+        expect(err).to.be.an.error()
+      })
+    })
+
+    describe("because the 'bill run' does not exist", () => {
+      beforeEach(async () => {
+        Sinon.stub(RulesService, 'go').returns(chargeFixtures.simple.rulesService)
+      })
+
+      it('throws an error', async () => {
+        const err = await expect(CreateTransactionService.go(payload, billRunId, authorisedSystem, regime)).to.reject(ForeignKeyViolationError)
 
         expect(err).to.be.an.error()
       })


### PR DESCRIPTION
This adds a foreign key constraint on the `bill_run_id` field in the `transactions` table.

By adding the constraint in the table it means we don't have to query for a matching bill run every time a transaction is added. We can manage by exception those times when someone attempts to add a transaction for a bill run that does not exist. We do it this way for performance reasons.