### PR TITLE
Alter transactions to use BigInts

### DIFF
--- a/db/migrations/20210108140838_alter_transactions.js
+++ b/db/migrations/20210108140838_alter_transactions.js
@@ -1,0 +1,23 @@
+'use strict'
+
+const tableName = 'transactions'
+
+exports.up = async function (knex) {
+  await knex
+    .schema
+    .alterTable(tableName, table => {
+      // Alter existing columns
+      // alter() requires you list everything, not just the thing you are changing. This is why existing constraints
+      // like notNullable() are listed as well. If we didn't, they would be dropped.
+      table.bigInteger('charge_value').notNullable().alter()
+    })
+}
+
+exports.down = async function (knex) {
+  await knex
+    .schema
+    .alterTable(tableName, table => {
+      // Revert alterations
+      table.integer('charge_value').notNullable().alter()
+    })
+}

--- a/test/features/bigint_handling.test.js
+++ b/test/features/bigint_handling.test.js
@@ -1,0 +1,66 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const {
+  AuthorisedSystemHelper,
+  BillRunHelper,
+  DatabaseHelper,
+  RegimeHelper
+} = require('../support/helpers')
+const { TransactionModel } = require('../../app/models')
+
+describe('Handling BigInts', () => {
+  let authorisedSystem
+  let regime
+  let billRun
+
+  const dummyTransaction = (regimeId, createdBy, billRunId) => {
+    return {
+      chargeValue: 2547483647,
+      ruleset: 'presroc',
+      regimeId,
+      createdBy,
+      billRunId
+    }
+  }
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+
+    regime = await RegimeHelper.addRegime('wrls', 'WRLS')
+    authorisedSystem = await AuthorisedSystemHelper.addSystem('1234546789', 'system1', [regime])
+    billRun = await BillRunHelper.addBillRun(authorisedSystem.id, regime.id)
+  })
+
+  describe('Transactions', () => {
+    let transaction
+
+    beforeEach(async () => {
+      transaction = await TransactionModel.query()
+        .insert(dummyTransaction(regime.id, authorisedSystem.id, billRun.id))
+    })
+
+    describe('When a transaction is added', () => {
+      it('handles a charge value greater than 2147483647', async () => {
+        expect(transaction.id).to.exist()
+      })
+    })
+
+    describe('When a transaction is selected', () => {
+      it('the charge value is returned as an integer', async () => {
+        const selectedTransaction = await TransactionModel.query().findById(transaction.id)
+
+        expect(selectedTransaction.id).to.equal(transaction.id)
+        expect(selectedTransaction.chargeValue).to.be.a.number()
+        expect(selectedTransaction.chargeValue).to.equal(2547483647)
+      })
+    })
+  })
+})


### PR DESCRIPTION
https://trello.com/c/HPENPD7d

We have previously faced an issue with the differences between what a PostgreSQL integer can hold and what a JavaScript one can. The issue was spotted when attempting to generate bill runs where the total value was more than 2147483647 pence.

We fixed it for bill runs. It was highlighted at the time that _if_ the calculated charge value for a single transaction was more than £21.4 million we'd face the same problem there. We put off updating the transaction because there are DB size and performance implications to using BigInts vs Integers. But latest intelligence shows though we've never had a single transaction for more than £21.4 million, proposed changes make it likely that we might.

So this change updates the relevant fields in the `transactions` table to use [PostgreSQL BigInts](https://www.postgresql.org/docs/13/datatype-numeric.html#DATATYPE-INT).