### PR TITLE
Change some instances of ' use strict' to 'use strict'

### DIFF
--- a/app/translators/authorised_system.translator.js
+++ b/app/translators/authorised_system.translator.js
@@ -1,4 +1,4 @@
-' use strict'
+'use strict'
 
 const BaseTranslator = require('./base.translator')
 const Joi = require('joi')

--- a/app/translators/bill_run.translator.js
+++ b/app/translators/bill_run.translator.js
@@ -1,4 +1,4 @@
-' use strict'
+'use strict'
 
 const BaseTranslator = require('./base.translator')
 const Joi = require('joi')

--- a/app/translators/transaction.translator.js
+++ b/app/translators/transaction.translator.js
@@ -1,4 +1,4 @@
-' use strict'
+'use strict'
 
 const BaseTranslator = require('./base.translator')
 const Joi = require('joi')


### PR DESCRIPTION
A rogue space had crept into some of the `'use strict'` declarations so they were `' use strict'` -- this change fixes that.