### PR TITLE
Add bill run status check to add transaction

### DIFF
--- a/app/models/bill_run.model.js
+++ b/app/models/bill_run.model.js
@@ -54,7 +54,7 @@ class BillRunModel extends BaseModel {
    * cause the generated result to be invalid.
    */
   $editable () {
-    return true
+    return ['initialised', 'summarised'].includes(this.status)
   }
 }
 

--- a/app/models/bill_run.model.js
+++ b/app/models/bill_run.model.js
@@ -40,6 +40,22 @@ class BillRunModel extends BaseModel {
       }
     }
   }
+
+  /**
+   * Returns whether the bill run can be 'edited'
+   *
+   * Once a bill run has been 'sent', which means the transaction file is generated, it cannot be edited. This includes
+   * adding or deleting transactions, or deleting the bill run altogether.
+   *
+   * After being 'sent' the bill run status may change to `billed` or `billing_not_required` but it still remains
+   * uneditable.
+   *
+   * A bill run is also uneditable if it's in the middle of generating its summary. We can't allow changes which will
+   * cause the generated result to be invalid.
+   */
+  $editable () {
+    return true
+  }
 }
 
 module.exports = BillRunModel

--- a/app/services/bill_run.service.js
+++ b/app/services/bill_run.service.js
@@ -1,0 +1,37 @@
+'use strict'
+
+/**
+ * @module BillRunService
+ */
+
+const Boom = require('@hapi/boom')
+
+const { BillRunModel } = require('../models')
+
+class BillRunService {
+  /**
+  * Finds the matching bill run and determines if a transaction can be added to it.
+  *
+  * @param {Object} billRunId Id of the bill run to find and assess
+  * @returns {module:BillRunModel} a `BillRunModel` if found else it will throw a `Boom` error
+  */
+  static async go (billRunId) {
+    const billRun = await BillRunModel.query().findById(billRunId)
+
+    this._validateBillRun(billRun, billRunId)
+
+    return billRun
+  }
+
+  static _validateBillRun (billRun, billRunId) {
+    if (!billRun) {
+      throw Boom.badData(`Bill run ${billRunId} is unknown.`)
+    }
+
+    if (!billRun.$editable()) {
+      throw Boom.badData(`Bill run ${billRun.id} cannot be edited because its status is ${billRun.status}.`)
+    }
+  }
+}
+
+module.exports = BillRunService

--- a/app/services/create_transaction.service.js
+++ b/app/services/create_transaction.service.js
@@ -6,6 +6,7 @@
 
 const { TransactionModel } = require('../models')
 const { TransactionTranslator } = require('../translators')
+const BillRunService = require('./bill_run.service')
 const CalculateChargeService = require('./calculate_charge.service')
 const InvoiceService = require('./invoice.service')
 const { CreateTransactionPresenter } = require('../presenters')
@@ -13,6 +14,11 @@ const { CreateTransactionPresenter } = require('../presenters')
 class CreateTransactionService {
   static async go (payload, billRunId, authorisedSystem, regime) {
     const translator = this._translateRequest(payload, billRunId, authorisedSystem, regime)
+
+    // TODO: Retain the result of this method call once we start updating the summary details of the bill run. For now,
+    // it is used to confirm the bill run exists and is in an 'editable' state
+    await this._billRun(billRunId)
+
     const calculatedCharge = await this._calculateCharge(translator, regime)
 
     this._applyCalculatedCharge(translator, calculatedCharge)
@@ -31,6 +37,10 @@ class CreateTransactionService {
       regimeId: regime.id,
       authorisedSystemId: authorisedSystem.id
     })
+  }
+
+  static async _billRun (billRunId) {
+    return BillRunService.go(billRunId)
   }
 
   static _calculateCharge (translator, regime) {

--- a/app/services/index.js
+++ b/app/services/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const AuthorisationService = require('./authorisation.service')
+const BillRunService = require('./bill_run.service')
 const CalculateChargeService = require('./calculate_charge.service')
 const CognitoJwtToPemService = require('./cognito_jwt_to_pem.service')
 const CreateAuthorisedSystemService = require('./create_authorised_system.service')
@@ -18,6 +19,7 @@ const ShowRegimeService = require('./show_regime.service')
 
 module.exports = {
   AuthorisationService,
+  BillRunService,
   CalculateChargeService,
   CognitoJwtToPemService,
   CreateAuthorisedSystemService,

--- a/test/models/bill_run.model.test.js
+++ b/test/models/bill_run.model.test.js
@@ -24,25 +24,25 @@ describe('Bill Run Model', () => {
       expect(instance.$editable()).to.be.true()
     })
 
-    it("returns 'false' when the status is not 'generating'", async () => {
+    it("returns 'false' when the status is 'generating'", async () => {
       const instance = BillRunModel.fromJson({ status: 'generating' })
 
       expect(instance.$editable()).to.be.false()
     })
 
-    it("returns 'false' when the status is not 'pending'", async () => {
+    it("returns 'false' when the status is 'pending'", async () => {
       const instance = BillRunModel.fromJson({ status: 'pending' })
 
       expect(instance.$editable()).to.be.false()
     })
 
-    it("returns 'false' when the status is not 'billed'", async () => {
+    it("returns 'false' when the status is 'billed'", async () => {
       const instance = BillRunModel.fromJson({ status: 'billed' })
 
       expect(instance.$editable()).to.be.false()
     })
 
-    it("returns 'false' when the status is not 'billing_not_required'", async () => {
+    it("returns 'false' when the status is 'billing_not_required'", async () => {
       const instance = BillRunModel.fromJson({ status: 'billing_not_required' })
 
       expect(instance.$editable()).to.be.false()

--- a/test/models/bill_run.model.test.js
+++ b/test/models/bill_run.model.test.js
@@ -1,0 +1,51 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Thing under test
+const { BillRunModel } = require('../../app/models')
+
+describe('Bill Run Model', () => {
+  describe('the $editable() method', () => {
+    it("returns 'true' when the status is 'initialised'", async () => {
+      const instance = BillRunModel.fromJson({ status: 'initialised' })
+
+      expect(instance.$editable()).to.be.true()
+    })
+
+    it("returns 'true' when the status is 'summarised'", async () => {
+      const instance = BillRunModel.fromJson({ status: 'summarised' })
+
+      expect(instance.$editable()).to.be.true()
+    })
+
+    it("returns 'false' when the status is not 'generating'", async () => {
+      const instance = BillRunModel.fromJson({ status: 'generating' })
+
+      expect(instance.$editable()).to.be.false()
+    })
+
+    it("returns 'false' when the status is not 'pending'", async () => {
+      const instance = BillRunModel.fromJson({ status: 'pending' })
+
+      expect(instance.$editable()).to.be.false()
+    })
+
+    it("returns 'false' when the status is not 'billed'", async () => {
+      const instance = BillRunModel.fromJson({ status: 'billed' })
+
+      expect(instance.$editable()).to.be.false()
+    })
+
+    it("returns 'false' when the status is not 'billing_not_required'", async () => {
+      const instance = BillRunModel.fromJson({ status: 'billing_not_required' })
+
+      expect(instance.$editable()).to.be.false()
+    })
+  })
+})

--- a/test/services/bill_run.service.test.js
+++ b/test/services/bill_run.service.test.js
@@ -1,0 +1,64 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const { BillRunHelper, DatabaseHelper } = require('../support/helpers')
+
+// Thing under test
+const { BillRunService } = require('../../app/services')
+
+describe('Invoice service', () => {
+  const authorisedSystemId = '6fd613d8-effb-4bcd-86c7-b0025d121692'
+  const regimeId = '4206994c-5db9-4539-84a6-d4b6a671e2ba'
+  let billRun
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+  })
+
+  describe('When a valid bill run ID is supplied', () => {
+    beforeEach(async () => {
+      billRun = await BillRunHelper.addBillRun(authorisedSystemId, regimeId)
+    })
+
+    it('returns the matching bill run', async () => {
+      const result = await BillRunService.go(billRun.id)
+
+      expect(result.id).to.equal(billRun.id)
+    })
+  })
+
+  describe('When an invalid bill run ID is supplied', () => {
+    const unknownBillRunId = '05f32bd9-7bce-42c2-8d6a-b14a8e26d531'
+
+    describe('because no matching bill run exists', () => {
+      it('throws an error', async () => {
+        const err = await expect(BillRunService.go(unknownBillRunId)).to.reject()
+
+        expect(err).to.be.an.error()
+        expect(err.output.payload.message).to.equal(`Bill run ${unknownBillRunId} is unknown.`)
+      })
+    })
+
+    describe('because the bill run is not editable', () => {
+      beforeEach(async () => {
+        billRun = await BillRunHelper.addBillRun(authorisedSystemId, regimeId, 'A', 'billed')
+      })
+
+      it('throws an error', async () => {
+        const err = await expect(BillRunService.go(billRun.id)).to.reject()
+
+        expect(err).to.be.an.error()
+        expect(err.output.payload.message)
+          .to
+          .equal(`Bill run ${billRun.id} cannot be edited because its status is billed.`)
+      })
+    })
+  })
+})

--- a/test/services/create_transaction.service.test.js
+++ b/test/services/create_transaction.service.test.js
@@ -120,5 +120,22 @@ describe('Create Transaction service', () => {
         expect(err).to.be.an.error()
       })
     })
+
+    describe("because the 'bill run' is not 'editable'", () => {
+      let billRun
+
+      beforeEach(async () => {
+        Sinon.stub(RulesService, 'go').returns(chargeFixtures.simple.rulesService)
+        billRun = await BillRunHelper.addBillRun(authorisedSystem.id, regime.id, 'A', 'billed')
+      })
+
+      it('throws an error', async () => {
+        const err = await expect(
+          CreateTransactionService.go(payload, billRun.id, authorisedSystem, regime)
+        ).to.reject(TypeError)
+
+        expect(err).to.be.an.error()
+      })
+    })
   })
 })


### PR DESCRIPTION
https://trello.com/c/gTcQmR8M

When adding a transaction to a bill run we should be checking the status of the bill run. If the bill run is `sent` or `billed` (admittedly statuses we're not using just yet) the request should be rejected. This is because the bill run is considered 'done'.

In coming changes we'll need to handle what we do with the bill run in other states. For example, when the summary has been generated we'll need to invalidate it and the relevant invoice and licence details when new transaction is added.

But for now this change is just focusing on ensuring you cannot add a transaction to a 'done' bill run.