### PR TITLE
Add licence model and service

### DIFF
--- a/app/models/index.js
+++ b/app/models/index.js
@@ -4,6 +4,7 @@ const AuthorisedSystemModel = require('./authorised_system.model')
 const BaseModel = require('./base.model')
 const BillRunModel = require('./bill_run.model')
 const InvoiceModel = require('./invoice.model')
+const LicenceModel = require('./licence.model')
 const RegimeModel = require('./regime.model')
 const SequenceCounterModel = require('./sequence_counter.model')
 const TransactionModel = require('./transaction.model')
@@ -13,6 +14,7 @@ module.exports = {
   BaseModel,
   BillRunModel,
   InvoiceModel,
+  LicenceModel,
   RegimeModel,
   SequenceCounterModel,
   TransactionModel

--- a/app/models/invoice.model.js
+++ b/app/models/invoice.model.js
@@ -32,7 +32,7 @@ class InvoiceModel extends BaseModel {
       },
       licences: {
         relation: Model.HasManyRelation,
-        modelClass: 'transaction.model',
+        modelClass: 'licence.model',
         join: {
           from: 'invoices.id',
           to: 'licences.invoice_id'

--- a/app/models/invoice.model.js
+++ b/app/models/invoice.model.js
@@ -29,6 +29,14 @@ class InvoiceModel extends BaseModel {
           from: 'invoices.id',
           to: 'transactions.invoice_id'
         }
+      },
+      licences: {
+        relation: Model.HasManyRelation,
+        modelClass: 'transaction.model',
+        join: {
+          from: 'invoices.id',
+          to: 'licences.invoice_id'
+        }
       }
     }
   }

--- a/app/models/licence.model.js
+++ b/app/models/licence.model.js
@@ -29,6 +29,14 @@ class LicenceModel extends BaseModel {
           from: 'licences.id',
           to: 'transactions.licence_id'
         }
+      },
+      billRun: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: 'bill_run.model',
+        join: {
+          from: 'licences.bill_run_id',
+          to: 'bill_runs.id'
+        }
       }
     }
   }

--- a/app/models/licence.model.js
+++ b/app/models/licence.model.js
@@ -1,0 +1,37 @@
+'use strict'
+
+/**
+ * @module LicenceModel
+ */
+
+const { Model } = require('objection')
+const BaseModel = require('./base.model')
+
+class LicenceModel extends BaseModel {
+  static get tableName () {
+    return 'licences'
+  }
+
+  static get relationMappings () {
+    return {
+      invoice: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: 'invoice.model',
+        join: {
+          from: 'licences.invoice_id',
+          to: 'invoices.id'
+        }
+      },
+      transactions: {
+        relation: Model.HasManyRelation,
+        modelClass: 'transaction.model',
+        join: {
+          from: 'licences.id',
+          to: 'transactions.licence_id'
+        }
+      }
+    }
+  }
+}
+
+module.exports = LicenceModel

--- a/app/models/transaction.model.js
+++ b/app/models/transaction.model.js
@@ -45,6 +45,14 @@ class TransactionModel extends BaseModel {
           from: 'transactions.invoice_id',
           to: 'invoices.id'
         }
+      },
+      licence: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: 'licence.model',
+        join: {
+          from: 'transactions.licence_id',
+          to: 'licences.id'
+        }
       }
     }
   }

--- a/app/services/index.js
+++ b/app/services/index.js
@@ -8,6 +8,7 @@ const CreateBillRunService = require('./create_bill_run.service')
 const CreateTransactionService = require('./create_transaction.service')
 const DatabaseHealthCheckService = require('./database_health_check.service')
 const InvoiceService = require('./invoice.service')
+const LicenceService = require('./licence.service')
 const ListAuthorisedSystemsService = require('./list_authorised_systems.service')
 const ListRegimesService = require('./list_regimes.service')
 const NextBillRunNumberService = require('./next_bill_run_number.service')
@@ -25,6 +26,7 @@ module.exports = {
   CreateTransactionService,
   DatabaseHealthCheckService,
   InvoiceService,
+  LicenceService,
   ListAuthorisedSystemsService,
   ListRegimesService,
   ObjectCleaningService,

--- a/app/services/licence.service.js
+++ b/app/services/licence.service.js
@@ -32,7 +32,7 @@ class LicenceService {
       .findOrInsert(
         {
           invoice_id: invoiceId,
-          line_attr1: licenceNumber,
+          licence_number: licenceNumber,
           customer_reference: customerReference,
           financial_year: financialYear
         }

--- a/app/services/licence.service.js
+++ b/app/services/licence.service.js
@@ -1,0 +1,59 @@
+'use strict'
+
+/**
+ * @module InvoiceService
+ */
+
+const { LicenceModel } = require('../models')
+
+class LicenceService {
+  /**
+  * Accepts a transaction and creates an entry in the Licences table if one doesn't already exist for the transaction's
+  * invoice/licence/customer ref/financial year. It updates the count and value stats as per the transaction details
+  * and returns the resulting licence.
+  *
+  * Note that the updated stats are _not_ saved back to the database; it is up to the caller to do this.
+  *
+  * @param {Object} A transaction object
+  * @returns {Object} A licence object
+  */
+
+  static async go (transaction) {
+    // licence number is lineAttr1 in database
+    const licence = await this._licence(transaction.invoiceId, transaction.lineAttr1, transaction.customerReference, transaction.chargeFinancialYear)
+
+    this._updateStats(licence, transaction)
+
+    return licence
+  }
+
+  static async _licence (invoiceId, licenceNumber, customerReference, financialYear) {
+    return LicenceModel.query()
+      .findOrInsert(
+        {
+          invoice_id: invoiceId,
+          line_attr1: licenceNumber,
+          customer_reference: customerReference,
+          financial_year: financialYear
+        }
+      )
+  }
+
+  static _updateStats (licence, transaction) {
+    if (transaction.chargeCredit) {
+      licence.creditCount += 1
+      licence.creditValue += transaction.chargeValue
+    } else if (transaction.chargeValue === 0) {
+      licence.zeroCount += 1
+    } else {
+      licence.debitCount += 1
+      licence.debitValue += transaction.chargeValue
+    }
+
+    if (transaction.newLicence) {
+      licence.newLicenceCount += 1
+    }
+  }
+}
+
+module.exports = LicenceService

--- a/app/services/licence.service.js
+++ b/app/services/licence.service.js
@@ -20,20 +20,20 @@ class LicenceService {
 
   static async go (transaction) {
     // licence number is lineAttr1 in database
-    const licence = await this._licence(
-      transaction.invoiceId,
-      transaction.billRunId,
-      transaction.lineAttr1,
-      transaction.customerReference,
-      transaction.chargeFinancialYear
-    )
+    const licence = await this._licence(transaction)
 
     this._updateStats(licence, transaction)
 
     return licence
   }
 
-  static async _licence (invoiceId, billRunId, licenceNumber, customerReference, financialYear) {
+  static async _licence ({
+    invoiceId,
+    billRunId,
+    lineAttr1: licenceNumber,
+    customerReference,
+    chargeFinancialYear: financialYear
+  }) {
     return LicenceModel.query()
       .findOrInsert(
         {

--- a/app/services/licence.service.js
+++ b/app/services/licence.service.js
@@ -20,18 +20,25 @@ class LicenceService {
 
   static async go (transaction) {
     // licence number is lineAttr1 in database
-    const licence = await this._licence(transaction.invoiceId, transaction.lineAttr1, transaction.customerReference, transaction.chargeFinancialYear)
+    const licence = await this._licence(
+      transaction.invoiceId,
+      transaction.billRunId,
+      transaction.lineAttr1,
+      transaction.customerReference,
+      transaction.chargeFinancialYear
+    )
 
     this._updateStats(licence, transaction)
 
     return licence
   }
 
-  static async _licence (invoiceId, licenceNumber, customerReference, financialYear) {
+  static async _licence (invoiceId, billRunId, licenceNumber, customerReference, financialYear) {
     return LicenceModel.query()
       .findOrInsert(
         {
           invoice_id: invoiceId,
+          bill_run_id: billRunId,
           licence_number: licenceNumber,
           customer_reference: customerReference,
           financial_year: financialYear

--- a/app/services/licence.service.js
+++ b/app/services/licence.service.js
@@ -30,18 +30,14 @@ class LicenceService {
   static async _licence ({
     invoiceId,
     billRunId,
-    lineAttr1: licenceNumber,
-    customerReference,
-    chargeFinancialYear: financialYear
+    lineAttr1: licenceNumber
   }) {
     return LicenceModel.query()
       .findOrInsert(
         {
           invoice_id: invoiceId,
           bill_run_id: billRunId,
-          licence_number: licenceNumber,
-          customer_reference: customerReference,
-          financial_year: financialYear
+          licence_number: licenceNumber
         }
       )
   }

--- a/db/migrations/20210111171826_create_licences.js
+++ b/db/migrations/20210111171826_create_licences.js
@@ -1,0 +1,48 @@
+'use strict'
+
+const tableName = 'licences'
+
+exports.up = async function (knex) {
+  await knex
+    .schema
+    .createTable(tableName, table => {
+      // Primary Key
+      table.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'))
+
+      // Data
+      table.uuid('invoice_id').notNullable()
+      table.string('line_attr1').notNullable() // Licence number is represented as line_attr1
+      table.string('customer_reference').notNullable()
+      table.integer('financial_year').notNullable()
+
+      table.integer('credit_count').notNullable().defaultTo(0)
+      table.bigInteger('credit_value').notNullable().defaultTo(0)
+
+      table.integer('debit_count').notNullable().defaultTo(0)
+      table.bigInteger('debit_value').notNullable().defaultTo(0)
+
+      table.integer('zero_count').notNullable().defaultTo(0)
+
+      table.integer('new_licence_count').notNullable().defaultTo(0)
+
+      // There can only be 1 customer summary per invoice per financial year for a licence
+      table.unique(['invoice_id', 'line_attr1', 'customer_reference', 'financial_year'])
+
+      // Automatic timestamps
+      table.timestamps(false, true)
+    })
+
+  await knex.raw(`
+    CREATE TRIGGER update_timestamp
+    BEFORE UPDATE
+    ON ${tableName}
+    FOR EACH ROW
+    EXECUTE PROCEDURE update_timestamp();
+  `)
+}
+
+exports.down = async function (knex) {
+  return knex
+    .schema
+    .dropTableIfExists(tableName)
+}

--- a/db/migrations/20210111171826_create_licences.js
+++ b/db/migrations/20210111171826_create_licences.js
@@ -11,7 +11,8 @@ exports.up = async function (knex) {
 
       // Data
       table.uuid('invoice_id').notNullable()
-      table.string('line_attr1').notNullable() // Licence number is represented as line_attr1
+      table.uuid('bill_run_id').notNullable()
+      table.string('licence_number').notNullable()
       table.string('customer_reference').notNullable()
       table.integer('financial_year').notNullable()
 
@@ -25,8 +26,9 @@ exports.up = async function (knex) {
 
       table.integer('new_licence_count').notNullable().defaultTo(0)
 
-      // There can only be 1 customer summary per invoice per financial year for a licence
-      table.unique(['invoice_id', 'line_attr1', 'customer_reference', 'financial_year'])
+      // There can only be 1 customer summary per invoice for a licence]
+      // (note that each invoice is unique to a customer and financial year)
+      table.unique(['invoice_id', 'licence_number'])
 
       // Automatic timestamps
       table.timestamps(false, true)

--- a/db/migrations/20210111171826_create_licences.js
+++ b/db/migrations/20210111171826_create_licences.js
@@ -13,8 +13,6 @@ exports.up = async function (knex) {
       table.uuid('invoice_id').notNullable()
       table.uuid('bill_run_id').notNullable()
       table.string('licence_number').notNullable()
-      table.string('customer_reference').notNullable()
-      table.integer('financial_year').notNullable()
 
       table.integer('credit_count').notNullable().defaultTo(0)
       table.bigInteger('credit_value').notNullable().defaultTo(0)

--- a/db/migrations/20210112121936_alter_transactions.js
+++ b/db/migrations/20210112121936_alter_transactions.js
@@ -1,0 +1,21 @@
+'use strict'
+
+const tableName = 'transactions'
+
+exports.up = async function (knex) {
+  await knex
+    .schema
+    .alterTable(tableName, table => {
+      // Add new column
+      table.uuid('licence_id').notNullable()
+    })
+}
+
+exports.down = async function (knex) {
+  await knex
+    .schema
+    .alterTable(tableName, table => {
+      // Drop the column we added
+      table.dropColumns('licence_id')
+    })
+}

--- a/test/features/bigint_handling.test.js
+++ b/test/features/bigint_handling.test.js
@@ -26,6 +26,7 @@ describe('Handling BigInts', () => {
       chargeValue: 2547483647,
       ruleset: 'presroc',
       invoiceId: 'f0d3b4dc-2cae-11eb-adc1-0242ac120002',
+      licenceId: 'f0d3b4dc-2cae-11eb-adc1-0242ac120002',
       regimeId,
       createdBy,
       billRunId

--- a/test/services/licence.service.test.js
+++ b/test/services/licence.service.test.js
@@ -47,8 +47,8 @@ describe('Licence service', () => {
       const licence = await LicenceService.go(transaction)
 
       expect(licence.invoiceId).to.equal(transaction.invoiceId)
-      expect(licence.customerReference).to.equal(transaction.customerReference)
-      expect(licence.financialYear).to.equal(transaction.chargeFinancialYear)
+      expect(licence.billRunId).to.equal(transaction.billRunId)
+      expect(licence.licenceNumber).to.equal(transaction.lineAttr1)
     })
   })
 

--- a/test/services/licence.service.test.js
+++ b/test/services/licence.service.test.js
@@ -19,6 +19,7 @@ describe('Licence service', () => {
 
   const dummyTransaction = {
     invoiceId: 'f0d3b4dc-2cae-11eb-adc1-0242ac120002',
+    billRunId: 'f0d3b4dc-2cae-11eb-adc1-0242ac120002',
     lineAttr1: 'LICENCE_NUMBER',
     customerReference: 'CUSTOMER_REFERENCE',
     chargeFinancialYear: 2021,

--- a/test/services/licence.service.test.js
+++ b/test/services/licence.service.test.js
@@ -1,0 +1,103 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const { DatabaseHelper, GeneralHelper } = require('../support/helpers')
+const { LicenceModel } = require('../../app/models')
+
+// Thing under test
+const { LicenceService } = require('../../app/services')
+
+describe('Licence service', () => {
+  let transaction
+
+  const dummyTransaction = {
+    invoiceId: 'f0d3b4dc-2cae-11eb-adc1-0242ac120002',
+    lineAttr1: 'LICENCE_NUMBER',
+    customerReference: 'CUSTOMER_REFERENCE',
+    chargeFinancialYear: 2021,
+    chargeCredit: false,
+    chargeValue: 5678
+  }
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+
+    // We clone the request fixture as our payload so we have it available for modification in the invalid tests. For
+    // the valid tests we can use it straight as
+    transaction = GeneralHelper.cloneObject(dummyTransaction)
+  })
+
+  describe('When a valid transaction is supplied', () => {
+    it('creates a licence', async () => {
+      const licence = await LicenceService.go(transaction)
+      const result = await LicenceModel.query().findById(licence.id)
+
+      expect(result.id).to.exist()
+    })
+
+    it('returns correct data', async () => {
+      const licence = await LicenceService.go(transaction)
+
+      expect(licence.invoiceId).to.equal(transaction.invoiceId)
+      expect(licence.customerReference).to.equal(transaction.customerReference)
+      expect(licence.financialYear).to.equal(transaction.chargeFinancialYear)
+    })
+  })
+
+  describe('When a debit transaction is supplied', () => {
+    it('correctly calculates the summary', async () => {
+      const licence = await LicenceService.go(transaction)
+
+      expect(licence.debitCount).to.equal(1)
+      expect(licence.debitValue).to.equal(transaction.chargeValue)
+    })
+  })
+
+  describe('When a credit transaction is supplied', () => {
+    it('correctly calculates the summary', async () => {
+      transaction.chargeCredit = true
+      const licence = await LicenceService.go(transaction)
+
+      expect(licence.creditCount).to.equal(1)
+      expect(licence.creditValue).to.equal(transaction.chargeValue)
+    })
+  })
+
+  describe('When a zero value transaction is supplied', () => {
+    it('correctly calculates the summary', async () => {
+      transaction.chargeValue = 0
+      const licence = await LicenceService.go(transaction)
+
+      expect(licence.zeroCount).to.equal(1)
+    })
+  })
+
+  describe('When a new licence transaction is supplied', () => {
+    it('correctly sets the new licence flag', async () => {
+      transaction.newLicence = true
+      const licence = await LicenceService.go(transaction)
+
+      expect(licence.newLicenceCount).to.equal(1)
+    })
+  })
+
+  describe('When two transactions are created', () => {
+    it('correctly calculates the summary', async () => {
+      const firstLicence = await LicenceService.go(transaction)
+      // We save the licence with stats to the database as this isn't done by LicenceService
+      await LicenceModel.query().update(firstLicence)
+
+      const secondLicence = await LicenceService.go(transaction)
+
+      expect(secondLicence.debitCount).to.equal(2)
+      expect(secondLicence.debitValue).to.equal(transaction.chargeValue * 2)
+    })
+  })
+})


### PR DESCRIPTION
This implements `LicenceService` (along with a `Licence` model) and updates CreateTransactionService to use it. Creating a transaction now creates an licence if one doesn't already exist for the invvoice/customer/year and updates the licence stats (credit/debit count and value etc.)