### PR TITLE
Add summary to bill run service

### DIFF
--- a/app/services/bill_run.service.js
+++ b/app/services/bill_run.service.js
@@ -12,13 +12,13 @@ class BillRunService {
   /**
   * Finds the matching bill run and determines if a transaction can be added to it.
   *
-  * @param {Object} billRunId Id of the bill run to find and assess
+  * @param {Object} transaction translator belonging to the bill run to find and assess
   * @returns {module:BillRunModel} a `BillRunModel` if found else it will throw a `Boom` error
   */
-  static async go (billRunId) {
-    const billRun = await BillRunModel.query().findById(billRunId)
+  static async go (transaction) {
+    const billRun = await BillRunModel.query().findById(transaction.billRunId)
 
-    this._validateBillRun(billRun, billRunId)
+    this._validateBillRun(billRun, transaction.billRunId)
 
     return billRun
   }

--- a/app/services/bill_run.service.js
+++ b/app/services/bill_run.service.js
@@ -10,7 +10,10 @@ const { BillRunModel } = require('../models')
 
 class BillRunService {
   /**
-  * Finds the matching bill run and determines if a transaction can be added to it.
+  * Finds the matching bill run, determines if a transaction can be added to it and updates updates the count and value
+  * stats as per the transaction details.
+  *
+  * Note that the updated stats are _not_ saved back to the database; it is up to the caller to do this.
   *
   * @param {Object} transaction translator belonging to the bill run to find and assess
   * @returns {module:BillRunModel} a `BillRunModel` if found else it will throw a `Boom` error
@@ -19,6 +22,7 @@ class BillRunService {
     const billRun = await BillRunModel.query().findById(transaction.billRunId)
 
     this._validateBillRun(billRun, transaction.billRunId)
+    this._updateStats(billRun, transaction)
 
     return billRun
   }
@@ -30,6 +34,22 @@ class BillRunService {
 
     if (!billRun.$editable()) {
       throw Boom.badData(`Bill run ${billRun.id} cannot be edited because its status is ${billRun.status}.`)
+    }
+  }
+
+  static _updateStats (billRun, transaction) {
+    if (transaction.chargeCredit) {
+      billRun.creditCount += 1
+      billRun.creditValue += transaction.chargeValue
+    } else if (transaction.chargeValue === 0) {
+      billRun.zeroCount += 1
+    } else {
+      billRun.debitCount += 1
+      billRun.debitValue += transaction.chargeValue
+    }
+
+    if (transaction.newLicence) {
+      billRun.newLicenceCount += 1
     }
   }
 }

--- a/app/services/bill_run.service.js
+++ b/app/services/bill_run.service.js
@@ -10,8 +10,8 @@ const { BillRunModel } = require('../models')
 
 class BillRunService {
   /**
-  * Finds the matching bill run, determines if a transaction can be added to it and updates updates the count and value
-  * stats as per the transaction details.
+  * Finds the matching bill run, determines if a transaction can be added to it and updates the count and value stat
+  * as per the transaction details.
   *
   * Note that the updated stats are _not_ saved back to the database; it is up to the caller to do this.
   *

--- a/app/services/create_transaction.service.js
+++ b/app/services/create_transaction.service.js
@@ -18,7 +18,7 @@ class CreateTransactionService {
 
     // TODO: Retain the result of this method call once we start updating the summary details of the bill run. For now,
     // it is used to confirm the bill run exists and is in an 'editable' state
-    await this._billRun(billRunId)
+    await this._billRun(translator)
 
     const calculatedCharge = await this._calculateCharge(translator, regime)
 
@@ -41,8 +41,8 @@ class CreateTransactionService {
     })
   }
 
-  static async _billRun (billRunId) {
-    return BillRunService.go(billRunId)
+  static async _billRun (transaction) {
+    return BillRunService.go(transaction)
   }
 
   static _calculateCharge (translator, regime) {

--- a/db/migrations/20210114152743_alter_bill_runs.js
+++ b/db/migrations/20210114152743_alter_bill_runs.js
@@ -1,0 +1,36 @@
+'use strict'
+
+const tableName = 'bill_runs'
+
+exports.up = async function (knex) {
+  await knex
+    .schema
+    .alterTable(tableName, table => {
+      // Add new columns
+      table.integer('credit_count').notNullable().defaultTo(0)
+      table.bigInteger('credit_value').notNullable().defaultTo(0)
+
+      table.integer('debit_count').notNullable().defaultTo(0)
+      table.bigInteger('debit_value').notNullable().defaultTo(0)
+
+      table.integer('zero_count').notNullable().defaultTo(0)
+
+      table.integer('new_licence_count').notNullable().defaultTo(0)
+    })
+}
+
+exports.down = async function (knex) {
+  await knex
+    .schema
+    .alterTable(tableName, table => {
+      // Drop the columns we added
+      table.dropColumns(
+        'credit_count',
+        'credit_value',
+        'debit_count',
+        'debit_value',
+        'zero_count',
+        'new_licence_count'
+      )
+    })
+}

--- a/test/services/bill_run.service.test.js
+++ b/test/services/bill_run.service.test.js
@@ -13,7 +13,7 @@ const { BillRunHelper, DatabaseHelper } = require('../support/helpers')
 // Thing under test
 const { BillRunService } = require('../../app/services')
 
-describe('Invoice service', () => {
+describe('Bill Run service', () => {
   const authorisedSystemId = '6fd613d8-effb-4bcd-86c7-b0025d121692'
   const regimeId = '4206994c-5db9-4539-84a6-d4b6a671e2ba'
   let billRun
@@ -28,7 +28,9 @@ describe('Invoice service', () => {
     })
 
     it('returns the matching bill run', async () => {
-      const result = await BillRunService.go(billRun.id)
+      const transaction = { billRunId: billRun.id }
+
+      const result = await BillRunService.go(transaction)
 
       expect(result.id).to.equal(billRun.id)
     })
@@ -39,7 +41,9 @@ describe('Invoice service', () => {
 
     describe('because no matching bill run exists', () => {
       it('throws an error', async () => {
-        const err = await expect(BillRunService.go(unknownBillRunId)).to.reject()
+        const transaction = { billRunId: unknownBillRunId }
+
+        const err = await expect(BillRunService.go(transaction)).to.reject()
 
         expect(err).to.be.an.error()
         expect(err.output.payload.message).to.equal(`Bill run ${unknownBillRunId} is unknown.`)
@@ -52,7 +56,9 @@ describe('Invoice service', () => {
       })
 
       it('throws an error', async () => {
-        const err = await expect(BillRunService.go(billRun.id)).to.reject()
+        const transaction = { billRunId: billRun.id }
+
+        const err = await expect(BillRunService.go(transaction)).to.reject()
 
         expect(err).to.be.an.error()
         expect(err.output.payload.message)

--- a/test/services/bill_run.service.test.js
+++ b/test/services/bill_run.service.test.js
@@ -9,6 +9,7 @@ const { expect } = Code
 
 // Test helpers
 const { BillRunHelper, DatabaseHelper } = require('../support/helpers')
+const { BillRunModel } = require('../../app/models')
 
 // Thing under test
 const { BillRunService } = require('../../app/services')
@@ -16,6 +17,12 @@ const { BillRunService } = require('../../app/services')
 describe('Bill Run service', () => {
   const authorisedSystemId = '6fd613d8-effb-4bcd-86c7-b0025d121692'
   const regimeId = '4206994c-5db9-4539-84a6-d4b6a671e2ba'
+  const dummyTransaction = {
+    customerReference: 'CUSTOMER_REFERENCE',
+    chargeFinancialYear: 2021,
+    chargeCredit: false,
+    chargeValue: 5678
+  }
   let billRun
 
   beforeEach(async () => {
@@ -28,11 +35,67 @@ describe('Bill Run service', () => {
     })
 
     it('returns the matching bill run', async () => {
-      const transaction = { billRunId: billRun.id }
+      const transaction = { ...dummyTransaction, billRunId: billRun.id }
 
       const result = await BillRunService.go(transaction)
 
       expect(result.id).to.equal(billRun.id)
+    })
+
+    describe('When a debit transaction is supplied', () => {
+      it('correctly calculates the summary', async () => {
+        const transaction = { ...dummyTransaction, billRunId: billRun.id }
+
+        const result = await BillRunService.go(transaction)
+
+        expect(result.debitCount).to.equal(1)
+        expect(result.debitValue).to.equal(transaction.chargeValue)
+      })
+    })
+
+    describe('When a credit transaction is supplied', () => {
+      it('correctly calculates the summary', async () => {
+        const transaction = { ...dummyTransaction, billRunId: billRun.id, chargeCredit: true }
+
+        const result = await BillRunService.go(transaction)
+
+        expect(result.creditCount).to.equal(1)
+        expect(result.creditValue).to.equal(transaction.chargeValue)
+      })
+    })
+
+    describe('When a zero value transaction is supplied', () => {
+      it('correctly calculates the summary', async () => {
+        const transaction = { ...dummyTransaction, billRunId: billRun.id, chargeValue: 0 }
+
+        const result = await BillRunService.go(transaction)
+
+        expect(result.zeroCount).to.equal(1)
+      })
+    })
+
+    describe('When a new licence transaction is supplied', () => {
+      it('correctly sets the new licence flag', async () => {
+        const transaction = { ...dummyTransaction, billRunId: billRun.id, newLicence: true }
+
+        const result = await BillRunService.go(transaction)
+
+        expect(result.newLicenceCount).to.equal(1)
+      })
+    })
+
+    describe('When two transactions are created', () => {
+      it('correctly calculates the summary', async () => {
+        const transaction = { ...dummyTransaction, billRunId: billRun.id }
+        const firstResult = await BillRunService.go(transaction)
+        // We save the invoice with stats to the database as this isn't done by BillRunService
+        await BillRunModel.query().update(firstResult)
+
+        const secondResult = await BillRunService.go(transaction)
+
+        expect(secondResult.debitCount).to.equal(2)
+        expect(secondResult.debitValue).to.equal(transaction.chargeValue * 2)
+      })
     })
   })
 
@@ -41,7 +104,7 @@ describe('Bill Run service', () => {
 
     describe('because no matching bill run exists', () => {
       it('throws an error', async () => {
-        const transaction = { billRunId: unknownBillRunId }
+        const transaction = { ...dummyTransaction, billRunId: unknownBillRunId }
 
         const err = await expect(BillRunService.go(transaction)).to.reject()
 
@@ -56,7 +119,7 @@ describe('Bill Run service', () => {
       })
 
       it('throws an error', async () => {
-        const transaction = { billRunId: billRun.id }
+        const transaction = { ...dummyTransaction, billRunId: billRun.id }
 
         const err = await expect(BillRunService.go(transaction)).to.reject()
 

--- a/test/services/bill_run.service.test.js
+++ b/test/services/bill_run.service.test.js
@@ -30,13 +30,14 @@ describe('Bill Run service', () => {
   })
 
   describe('When a valid bill run ID is supplied', () => {
+    let transaction
+
     beforeEach(async () => {
       billRun = await BillRunHelper.addBillRun(authorisedSystemId, regimeId)
+      transaction = { ...dummyTransaction, billRunId: billRun.id }
     })
 
     it('returns the matching bill run', async () => {
-      const transaction = { ...dummyTransaction, billRunId: billRun.id }
-
       const result = await BillRunService.go(transaction)
 
       expect(result.id).to.equal(billRun.id)
@@ -44,8 +45,6 @@ describe('Bill Run service', () => {
 
     describe('When a debit transaction is supplied', () => {
       it('correctly calculates the summary', async () => {
-        const transaction = { ...dummyTransaction, billRunId: billRun.id }
-
         const result = await BillRunService.go(transaction)
 
         expect(result.debitCount).to.equal(1)
@@ -55,7 +54,7 @@ describe('Bill Run service', () => {
 
     describe('When a credit transaction is supplied', () => {
       it('correctly calculates the summary', async () => {
-        const transaction = { ...dummyTransaction, billRunId: billRun.id, chargeCredit: true }
+        transaction.chargeCredit = true
 
         const result = await BillRunService.go(transaction)
 
@@ -66,7 +65,7 @@ describe('Bill Run service', () => {
 
     describe('When a zero value transaction is supplied', () => {
       it('correctly calculates the summary', async () => {
-        const transaction = { ...dummyTransaction, billRunId: billRun.id, chargeValue: 0 }
+        transaction.chargeValue = 0
 
         const result = await BillRunService.go(transaction)
 
@@ -76,7 +75,7 @@ describe('Bill Run service', () => {
 
     describe('When a new licence transaction is supplied', () => {
       it('correctly sets the new licence flag', async () => {
-        const transaction = { ...dummyTransaction, billRunId: billRun.id, newLicence: true }
+        transaction.newLicence = true
 
         const result = await BillRunService.go(transaction)
 
@@ -86,7 +85,7 @@ describe('Bill Run service', () => {
 
     describe('When two transactions are created', () => {
       it('correctly calculates the summary', async () => {
-        const transaction = { ...dummyTransaction, billRunId: billRun.id }
+        transaction.billRunId = billRun.id
         const firstResult = await BillRunService.go(transaction)
         // We save the invoice with stats to the database as this isn't done by BillRunService
         await BillRunModel.query().update(firstResult)


### PR DESCRIPTION
This change implements bill run-level stats as follows:

- The `bill_runs` table now includes bill run stats columns (credit/debit count and value etc.)
- `BillRunService` accepts a transaction and returns updated stats
- `CreateTransactionService` saves these stats in the database