### PR TITLE
Fix missing knexfile.application.js to docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,7 @@
 !db
 !entrypoint.sh
 !keys
+!knexfile.application.js
 !knexfile.js
 !package-lock.json
 !package.json


### PR DESCRIPTION
We recently [made a change](https://github.com/DEFRA/sroc-charging-module-api/pull/150) to start using Knex's snake case mappers rather than Objection's.

To deal with migrations we needed to add a new `knexfile.application.js` file to the project. However, we neglected to update the Docker build, specifically the `.dockerignore` to ensure its included when the image is built.

This fix corrects the issue.