### PR TITLE
Add git and docker tags to Docker image

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,7 +7,7 @@
       "label": "Start sroc-cma environment",
       "detail": "Build if needed then run a local docker environment",
       "type": "shell",
-      "command": "docker-compose up",
+      "command": "GIT_COMMIT=$(git rev-parse HEAD) docker-compose up",
       "group": "test",
       "presentation": {
         "echo": true,

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,14 @@ USER node
 #
 FROM node_base AS development
 
+# Version information for both the app and the image. The app will use this information to let us the delivery team
+# know exactly what we are talking to. The ARG values need to be provided in the build image command. The ENVs will
+# then get set to these values whenever a container is started.
+ARG GIT_COMMIT
+ENV GIT_COMMIT $GIT_COMMIT
+ARG DOCKER_TAG
+ENV DOCKER_TAG $DOCKER_TAG
+
 # Set our node environment. Defaults to production, though our docker-compose overrides this to development on build and
 # run
 ENV NODE_ENV development

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,6 +80,14 @@ CMD [ "../node_modules/.bin/nodemon", "--inspect=0.0.0.0:9229", "./server.js" ]
 #
 FROM node_base AS production
 
+# Version information for both the app and the image. The app will use this information to let us the delivery team
+# know exactly what we are talking to. The ARG values need to be provided in the build image command. The ENVs will
+# then get set to these values whenever a container is started.
+ARG GIT_COMMIT
+ENV GIT_COMMIT $GIT_COMMIT
+ARG DOCKER_TAG
+ENV DOCKER_TAG $DOCKER_TAG
+
 # Set our node environment. Defaults to production, though our docker-compose overrides this to development on build and
 # run
 ENV NODE_ENV production

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ FROM node_base AS development
 # know exactly what we are talking to. The ARG values need to be provided in the build image command. The ENVs will
 # then get set to these values whenever a container is started.
 ARG GIT_COMMIT
-ENV GIT_COMMIT $GIT_COMMIT
+ENV GIT_COMMIT=${GIT_COMMIT}
 ARG DOCKER_TAG
 ENV DOCKER_TAG $DOCKER_TAG
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ FROM node_base AS development
 # know exactly what we are talking to. The ARG values need to be provided in the build image command. The ENVs will
 # then get set to these values whenever a container is started.
 ARG GIT_COMMIT
-ENV GIT_COMMIT=${GIT_COMMIT}
+ENV GIT_COMMIT $GIT_COMMIT
 ARG DOCKER_TAG
 ENV DOCKER_TAG $DOCKER_TAG
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,11 @@ services:
       - cma_db_volume:/var/lib/postgresql/data
     ports:
       - "54320:5432"
+    # This is not something we'd worry about in production. But to avoid confusion locally we want the commit hash
+    # reported back by the API to reflect the current commit, not just the one at the time the image was originally
+    # built. So we can override the env var in the container with whatever it is when we call `docker-compose up`.
+    environment:
+      - GIT_COMMIT=${GIT_COMMIT}
     env_file:
       - .env
 
@@ -14,6 +19,14 @@ services:
     build:
       context: .
       target: development
+      # Used to support the API returning diagnostic information about which versions of the app and image it is
+      # running. In the local development environment the DOCKER_TAG will always be latest. We get the git commit hash
+      # by running `git rev-parse HEAD`. However, that type of interpolation is not supported in a `docker.compose.yml`
+      # file. So, we have to rely on it having been set as an env var locally before `docker-compose up` is run.
+      # If you checkout `.vscode/tasks.json` you'll see we've baked it into our start CMA environment command.
+      args:
+        - GIT_COMMIT=${GIT_COMMIT}
+        - DOCKER_TAG=latest
     ports:
       - "3003:3000"
       - "9229:9229"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,11 +7,6 @@ services:
       - cma_db_volume:/var/lib/postgresql/data
     ports:
       - "54320:5432"
-    # This is not something we'd worry about in production. But to avoid confusion locally we want the commit hash
-    # reported back by the API to reflect the current commit, not just the one at the time the image was originally
-    # built. So we can override the env var in the container with whatever it is when we call `docker-compose up`.
-    environment:
-      - GIT_COMMIT=${GIT_COMMIT}
     env_file:
       - .env
 


### PR DESCRIPTION
When we update the image in our AWS ECS environment, AWS starts a process of 'draining the swamp'. It stops sending requests to the old running containers and then asks them to stop. Meantime new containers are being started. The process seems to take a few minutes but it is a period of uncertainty. When I make a request, what version of the app and which Docker image is responding?

So this change is the first step in being able to get this information back. By adding the current git commit tag plus the Docker tag we generated into the image as we create it, we can include this information in the responses we send back. No more uncertainty!