### PR TITLE
Add version info to responses plugin

### DIFF
--- a/app/plugins/index.js
+++ b/app/plugins/index.js
@@ -12,6 +12,7 @@ const MissingPayloadPlugin = require('./missing_payload.plugin')
 const PayloadCleanerPlugin = require('./payload_cleaner.plugin')
 const RouterPlugin = require('./router.plugin')
 const StopPlugin = require('./stop.plugin')
+const VersionInfoPlugin = require('./version_info.plugin')
 
 // These plugins are only used when the app is running in NODE_ENV=development. This means we don't want them or their
 // dependencies available in production. The problem is when we build the image any dev dependencies won't be installed.
@@ -39,5 +40,6 @@ module.exports = {
   MissingPayloadPlugin,
   PayloadCleanerPlugin,
   RouterPlugin,
-  StopPlugin
+  StopPlugin,
+  VersionInfoPlugin
 }

--- a/app/plugins/version_info.plugin.js
+++ b/app/plugins/version_info.plugin.js
@@ -1,0 +1,33 @@
+'use strict'
+
+/**
+ * @module VersionInfoPlugin
+ */
+
+const addGitCommitHeader = response => {
+  const value = process.env.GIT_COMMIT || 'unknown'
+
+  response.header('x-cma-git-commit', value)
+}
+
+const addDockerTagHeader = response => {
+  const value = process.env.DOCKER_TAG || 'unknown'
+
+  response.header('x-cma-docker-tag', value)
+}
+
+const VersionInfoPlugin = {
+  name: 'version_info',
+  register: (server, _options) => {
+    server.ext('onPreResponse', (request, h) => {
+      const response = request.response
+
+      addGitCommitHeader(response)
+      addDockerTagHeader(response)
+
+      return response
+    })
+  }
+}
+
+module.exports = VersionInfoPlugin

--- a/app/plugins/version_info.plugin.js
+++ b/app/plugins/version_info.plugin.js
@@ -51,7 +51,7 @@ const addDockerTagHeader = response => {
 const VersionInfoPlugin = {
   name: 'version_info',
   register: (server, _options) => {
-    server.ext('onPreResponse', (request, h) => {
+    server.ext('onPreResponse', (request, _h) => {
       const response = request.response
 
       addGitCommitHeader(response)

--- a/app/plugins/version_info.plugin.js
+++ b/app/plugins/version_info.plugin.js
@@ -1,6 +1,38 @@
 'use strict'
 
 /**
+ * Add git commit and docker tag details as headers to all responses
+ *
+ * With the access we have to our AWS ECS environment we cannot say for certain which docker image is being run. We can
+ * make an assumption base on when the task definition was last updated and what image tag was selected in the Jenkins
+ * job.
+ *
+ * But it's only an assumption. Plus, there are times, for example after deploying an update that a response might have
+ * come from either the old or new image used for the ECS containers.
+ *
+ * So, we have created this plugin to read a git commit hash and a docker tag from env vars set when the image was
+ * built. This information is then included in two customer headers we add to _every_ response from the API. The
+ * delivery team can then use this information to help with debugging and investigating issues, and to confirm if a new
+ * version has been successfully deployed.
+ *
+ * ## To `x-` or not to `x-`
+ *
+ * There is a "convention" of prefixing custom headers with an `x-`.
+ * {@link http://tools.ietf.org/html/rfc6648|RFC 6648} deprecated that recommendation in 2012 and stated that custom
+ * headers _SHOULD NOT_ use `x-`. The argument is that if a custom header becomes a standard removing the `x-` breaks
+ * backwards compatibility.
+ *
+ * However, many have argued they never expect their custom headers to become standard. They are purely for use within
+ * their own domain. Using `x-` puts them at less risk of conflicting with a customer header that does become a standard
+ * in the future. Examples include
+ * {@link https://cloud.google.com/load-balancing/docs/custom-headers|Google documentation} which still recommends using
+ * `x-`. This {@link https://stackoverflow.com/q/3561381/6117745|stackoverflow post} includes detailed notes on the
+ * topic of whether to add them or not.
+ *
+ * After reading through them, we have come to the decision to prefix our custom headers with `x-cma`. To new developers
+ * and clients of the API aware of the convention it will be clear these are something custom we are adding to our
+ * responses. We are also 100% confident these will never become standard, so the risk of breaking backwards
+ * compatibility does not apply. The `-cma-` indicates it's a custom header set by us.
  * @module VersionInfoPlugin
  */
 

--- a/server.js
+++ b/server.js
@@ -15,7 +15,8 @@ const {
   MissingPayloadPlugin,
   PayloadCleanerPlugin,
   RouterPlugin,
-  StopPlugin
+  StopPlugin,
+  VersionInfoPlugin
 } = require('./app/plugins')
 
 exports.deployment = async start => {
@@ -37,6 +38,7 @@ exports.deployment = async start => {
   await server.register(InvalidCharactersPlugin)
   await server.register(PayloadCleanerPlugin)
   await server.register(DbErrorsPlugin)
+  await server.register(VersionInfoPlugin)
   await server.register(HapiPinoPlugin(TestConfig.logInTest))
 
   // Register non-production plugins

--- a/test/features/version_info.test.js
+++ b/test/features/version_info.test.js
@@ -1,0 +1,55 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, before, beforeEach, afterEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// For running our service
+const { deployment } = require('../../server')
+
+// Test helpers
+const { RouteHelper } = require('../support/helpers')
+
+const options = {
+  method: 'GET',
+  url: '/test/public'
+}
+
+describe('Add version information to all responses', () => {
+  let server
+
+  // Create server before each test
+  before(async () => {
+    server = await deployment()
+    RouteHelper.addPublicRoute(server)
+  })
+
+  beforeEach(async () => {
+    Sinon.stub(process.env, 'GIT_COMMIT').value('abc123')
+    Sinon.stub(process.env, 'DOCKER_TAG').value('v0.1.0-99-gaabc123')
+  })
+
+  afterEach(async () => {
+    Sinon.restore()
+  })
+
+  describe('When a request is made', () => {
+    it('the response headers include git commit details', async () => {
+      const response = await server.inject(options)
+
+      expect(response.statusCode).to.equal(200)
+      expect(response.headers['x-cma-git-commit']).to.equal('foobar')
+    })
+
+    it('the response headers include docker tag details', async () => {
+      const response = await server.inject(options)
+
+      expect(response.statusCode).to.equal(200)
+      expect(response.headers['x-cma-docker-tag']).to.equal('foobar')
+    })
+  })
+})

--- a/test/features/version_info.test.js
+++ b/test/features/version_info.test.js
@@ -3,7 +3,6 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
-const Sinon = require('sinon')
 
 const { describe, it, before, beforeEach, afterEach } = exports.lab = Lab.script()
 const { expect } = Code
@@ -12,7 +11,7 @@ const { expect } = Code
 const { deployment } = require('../../server')
 
 // Test helpers
-const { RouteHelper } = require('../support/helpers')
+const { GeneralHelper, RouteHelper } = require('../support/helpers')
 
 const options = {
   method: 'GET',
@@ -20,6 +19,16 @@ const options = {
 }
 
 describe('Add version information to all responses', () => {
+  // We need to 'stub' process.env. However, if a property does not already exist Sinon, the tool we normally use,
+  // throws an error
+  //
+  //  Cannot stub non-existent property GIT_COMMIT
+  //
+  // Locally it's likely the env vars will be set, and we could set them in our CI workflow. However, we think the
+  // VersionInfoPlugin is more robust if our tests prove it will work as expected whether the env vars exist or not. So,
+  // instead we have gone with a method where we clone the existing process.env prior to running our tests, and restore
+  // it after each one to ensure the changes don't leak into other tests.
+  const env = GeneralHelper.cloneObject(process.env)
   let server
 
   // Create server before each test
@@ -29,14 +38,14 @@ describe('Add version information to all responses', () => {
   })
 
   afterEach(async () => {
-    Sinon.restore()
+    process.env = env
   })
 
   describe('When a request is made', () => {
     describe('if the version environment variables are present', () => {
       beforeEach(async () => {
-        Sinon.stub(process.env, 'GIT_COMMIT').value('abc123')
-        Sinon.stub(process.env, 'DOCKER_TAG').value('v0.1.0-99-gaabc123')
+        process.env.GIT_COMMIT = 'abc123'
+        process.env.DOCKER_TAG = 'v0.1.0-99-gaabc123'
       })
 
       it('includes git commit details in a response header', async () => {
@@ -56,8 +65,8 @@ describe('Add version information to all responses', () => {
 
     describe('if the version environment variables are not present', () => {
       beforeEach(async () => {
-        Sinon.stub(process.env, 'GIT_COMMIT').value('')
-        Sinon.stub(process.env, 'DOCKER_TAG').value('')
+        delete process.env.GIT_COMMIT
+        delete process.env.DOCKER_TAG
       })
 
       it("sets the git commit details in a response header to 'unknown'", async () => {


### PR DESCRIPTION
This is the second part of providing version information about the app and the docker image being used to a response. The first covered [adding git and docker tags to the image](https://github.com/DEFRA/sroc-charging-module-api/pull/155).

With the access we have, we can't confirm for certain which of our docker images provided a response. We can make assumptions based on when the AWS ECS task definition was last updated. But for a period after the update, there is always some uncertainty.

By building the information into the docker image and providing it in every response we can be certain whatever the circumstances. So, this change adds a new plugin that will handle this new feature.

<details>
<summary>Example of headers</summary>

<img width="591" alt="Screenshot 2021-02-01 at 22 20 10" src="https://user-images.githubusercontent.com/1789650/106528177-3d5eb180-64e0-11eb-9388-e72243fd3728.png">

</details>