### PR TITLE
Add trans. region must match bill run check

### DIFF
--- a/app/services/bill_run.service.js
+++ b/app/services/bill_run.service.js
@@ -29,7 +29,7 @@ class BillRunService {
 
   static _validateBillRun (billRun, transaction) {
     if (!billRun) {
-      throw Boom.badData(`Bill run ${billRunId} is unknown.`)
+      throw Boom.badData(`Bill run ${transaction.billRunId} is unknown.`)
     }
 
     if (!billRun.$editable()) {

--- a/app/services/bill_run.service.js
+++ b/app/services/bill_run.service.js
@@ -21,7 +21,7 @@ class BillRunService {
   static async go (transaction) {
     const billRun = await BillRunModel.query().findById(transaction.billRunId)
 
-    this._validateBillRun(billRun, transaction.billRunId, transaction)
+    this._validateBillRun(billRun, transaction)
     this._updateStats(billRun, transaction)
 
     return billRun

--- a/app/services/bill_run.service.js
+++ b/app/services/bill_run.service.js
@@ -27,7 +27,7 @@ class BillRunService {
     return billRun
   }
 
-  static _validateBillRun (billRun, billRunId, transaction) {
+  static _validateBillRun (billRun, transaction) {
     if (!billRun) {
       throw Boom.badData(`Bill run ${billRunId} is unknown.`)
     }

--- a/app/services/bill_run.service.js
+++ b/app/services/bill_run.service.js
@@ -21,19 +21,25 @@ class BillRunService {
   static async go (transaction) {
     const billRun = await BillRunModel.query().findById(transaction.billRunId)
 
-    this._validateBillRun(billRun, transaction.billRunId)
+    this._validateBillRun(billRun, transaction.billRunId, transaction)
     this._updateStats(billRun, transaction)
 
     return billRun
   }
 
-  static _validateBillRun (billRun, billRunId) {
+  static _validateBillRun (billRun, billRunId, transaction) {
     if (!billRun) {
       throw Boom.badData(`Bill run ${billRunId} is unknown.`)
     }
 
     if (!billRun.$editable()) {
       throw Boom.badData(`Bill run ${billRun.id} cannot be edited because its status is ${billRun.status}.`)
+    }
+
+    if (billRun.region !== transaction.region) {
+      throw Boom.badData(
+        `Bill run ${billRun.id} is for region ${billRun.region} but transaction is for region ${transaction.region}.`
+      )
     }
   }
 

--- a/test/services/bill_run.service.test.js
+++ b/test/services/bill_run.service.test.js
@@ -19,6 +19,7 @@ describe('Bill Run service', () => {
   const regimeId = '4206994c-5db9-4539-84a6-d4b6a671e2ba'
   const dummyTransaction = {
     customerReference: 'CUSTOMER_REFERENCE',
+    region: 'A',
     chargeFinancialYear: 2021,
     chargeCredit: false,
     chargeValue: 5678
@@ -126,6 +127,23 @@ describe('Bill Run service', () => {
         expect(err.output.payload.message)
           .to
           .equal(`Bill run ${billRun.id} cannot be edited because its status is billed.`)
+      })
+    })
+
+    describe('because the bill run is for a different region', () => {
+      beforeEach(async () => {
+        billRun = await BillRunHelper.addBillRun(authorisedSystemId, regimeId, 'W')
+      })
+
+      it('throws an error', async () => {
+        const transaction = { ...dummyTransaction, billRunId: billRun.id }
+
+        const err = await expect(BillRunService.go(transaction)).to.reject()
+
+        expect(err).to.be.an.error()
+        expect(err.output.payload.message)
+          .to
+          .equal(`Bill run ${billRun.id} is for region ${billRun.region} but transaction is for region ${transaction.region}.`)
       })
     })
   })


### PR DESCRIPTION
https://trello.com/c/YleRl9ts

In version 1 of the API, a check is made against the region of a transaction being added to ensure it matches the region of set against the bill run. We are not doing this check-in version 2. If a client did add a transaction with a different region to the bill run it would cause major problems upstream when the transaction file is generated and passed to SOP.

This change adds the check to the create transaction process.