### PR TITLE
Fix create bill run returns 500 if region missing

### DIFF
--- a/app/translators/bill_run.translator.js
+++ b/app/translators/bill_run.translator.js
@@ -17,7 +17,7 @@ class BillRunTranslator extends BaseTranslator {
     return Joi.object({
       authorisedSystemId: Joi.string().required(),
       regimeId: Joi.string().required(),
-      region: Joi.string().uppercase().valid(...this._validRegions()),
+      region: Joi.string().uppercase().valid(...this._validRegions()).required(),
       status: Joi.string().default('initialised')
     })
   }

--- a/test/services/create_bill_run.service.test.js
+++ b/test/services/create_bill_run.service.test.js
@@ -61,15 +61,29 @@ describe('Create Bill Run service', () => {
   })
 
   describe('When the data is invalid', () => {
-    describe("because 'payload' is invalid", () => {
-      const invalidPayload = {
-        region: 'Z'
-      }
+    describe("because the 'payload'", () => {
+      describe('contains an unrecognised region', () => {
+        const invalidPayload = {
+          region: 'Z'
+        }
 
-      it('throws an error', async () => {
-        const err = await expect(CreateBillRunService.go(invalidPayload, authorisedSystem, regime)).to.reject(ValidationError)
+        it('throws an error', async () => {
+          const err = await expect(CreateBillRunService.go(invalidPayload, authorisedSystem, regime)).to.reject(ValidationError)
 
-        expect(err).to.be.an.error()
+          expect(err).to.be.an.error()
+        })
+      })
+
+      describe('contains an empty region', () => {
+        const invalidPayload = {
+          region: ''
+        }
+
+        it('throws an error', async () => {
+          const err = await expect(CreateBillRunService.go(invalidPayload, authorisedSystem, regime)).to.reject(ValidationError)
+
+          expect(err).to.be.an.error()
+        })
       })
     })
 

--- a/test/translators/bill_run.translator.test.js
+++ b/test/translators/bill_run.translator.test.js
@@ -48,7 +48,6 @@ describe('Bill Run translator', () => {
 
       it("does not throw an error if the 'region' is lowercase", async () => {
         const lowercasePayload = {
-          ...payload,
           region: 'a'
         }
 
@@ -60,7 +59,6 @@ describe('Bill Run translator', () => {
       describe("because the 'region' is missing", () => {
         it('throws an error', async () => {
           const invalidPayload = {
-            ...payload,
             region: ''
           }
 
@@ -71,11 +69,18 @@ describe('Bill Run translator', () => {
       describe("because the 'region' is unrecognised", () => {
         it('throws an error', async () => {
           const invalidPayload = {
-            ...payload,
             region: 'Z'
           }
 
           expect(() => new BillRunTranslator(data(invalidPayload))).to.throw(ValidationError)
+        })
+      })
+
+      describe('because the payload is empty', () => {
+        it('throws an error', async () => {
+          const emptyPayload = { }
+
+          expect(() => new BillRunTranslator(data(emptyPayload))).to.throw(ValidationError)
         })
       })
     })


### PR DESCRIPTION
https://trello.com/c/MJ6w1HYe

When the region is missing from the create bill run payload we are returning a `500` when we should be returning a `422` with a nice error message.

This change fixes it.

<details>
<summary>Screenshot of fix result</summary>

<img width="416" alt="Screenshot 2021-01-26 at 21 53 15" src="https://user-images.githubusercontent.com/1789650/105910652-253eec00-6021-11eb-993d-09a8b40deba3.png">

</details>