### PR TITLE
Calculate Minimum Charge Transaction service

### DIFF
--- a/app/models/invoice.model.js
+++ b/app/models/invoice.model.js
@@ -8,6 +8,7 @@ const { Model } = require('objection')
 const BaseModel = require('./base.model')
 
 const DEMINIMIS_LIMIT = 500
+const MINIMUM_CHARGE_LIMIT = 2500
 
 class InvoiceModel extends BaseModel {
   static get tableName () {
@@ -69,8 +70,16 @@ class InvoiceModel extends BaseModel {
         query
           .whereRaw('credit_value - debit_value > 0')
           .whereRaw('credit_value - debit_value < ?', DEMINIMIS_LIMIT)
-      }
+      },
 
+      /**
+       * minimum charge modifier selects all invoices where minimum charge applies.
+       */
+      minimumCharge (query) {
+        query
+          .where('subjectToMinimumChargeCreditValue', '<', MINIMUM_CHARGE_LIMIT)
+          .orWhere('subjectToMinimumChargeDebitValue', '<', MINIMUM_CHARGE_LIMIT)
+      }
     }
   }
 }

--- a/app/services/calculate_minimum_charge.service.js
+++ b/app/services/calculate_minimum_charge.service.js
@@ -1,0 +1,57 @@
+'use strict'
+
+/**
+ * @module CalculateMinimumChargeService
+ */
+
+// Files in the same folder cannot be destructured from index.js so have to be required directly
+const CreateMinimumChargeAdjustmentService = require('./create_minimum_charge_adjustment.service')
+
+const MINIMUM_CHARGE_LIMIT = 2500
+
+class CalculateMinimumChargeService {
+  /**
+   * Determines whether minimum charge applies to the licences on the provided bill run.
+   */
+  static async go (billRun) {
+    const minimumChargeLicences = await this._retrieveMinimumChargeLicences(billRun)
+    const adjustments = await this._createAdjustmentTransactions(minimumChargeLicences)
+    return adjustments
+  }
+
+  // TODO: Document
+  // TODO: Select only fields we need
+  static async _retrieveMinimumChargeLicences (billRun) {
+    return billRun.$relatedQuery('invoices')
+      .modify('minimumCharge')
+      .withGraphFetched('licences')
+  }
+
+  static async _createAdjustmentTransactions (licences) {
+    const adjustments = []
+
+    for (const licence of licences) {
+      const creditAdjustment = await this._adjustment(licence, licence.creditValue, true)
+      const debitAdjustment = await this._adjustment(licence, licence.debitValue, false)
+
+      if (creditAdjustment !== null) {
+        adjustments.push(creditAdjustment)
+      }
+
+      if (debitAdjustment !== null) {
+        adjustments.push(debitAdjustment)
+      }
+    }
+
+    return adjustments
+  }
+
+  static async _adjustment (licence, value, credit) {
+    if (value === 0) { return null }
+    if (value >= MINIMUM_CHARGE_LIMIT) { return null }
+    const adjustmentValue = MINIMUM_CHARGE_LIMIT - value
+    return CreateMinimumChargeAdjustmentService.go(licence, adjustmentValue, credit)
+  }
+}
+
+module.exports = CalculateMinimumChargeService

--- a/app/services/calculate_minimum_charge.service.js
+++ b/app/services/calculate_minimum_charge.service.js
@@ -56,8 +56,13 @@ class CalculateMinimumChargeService {
   }
 
   static async _adjustment (licence, value, credit) {
-    if (value === 0) { return null }
-    if (value >= MINIMUM_CHARGE_LIMIT) { return null }
+    if (value === 0) {
+      return null
+    }
+
+    if (value >= MINIMUM_CHARGE_LIMIT) {
+      return null
+    }
 
     const adjustmentValue = MINIMUM_CHARGE_LIMIT - value
     return CreateMinimumChargeAdjustmentService.go(licence, adjustmentValue, credit)

--- a/app/services/calculate_minimum_charge.service.js
+++ b/app/services/calculate_minimum_charge.service.js
@@ -11,44 +11,54 @@ const MINIMUM_CHARGE_LIMIT = 2500
 
 class CalculateMinimumChargeService {
   /**
-   * Determines whether minimum charge applies to the licences on the provided bill run.
+   * Calculates and returns minimum charge adjustment transactions for all licences under a bill run.
+   *
+   * @param {module:BillRunModel} Bill run to create minimum charge transactions for.
+   * @returns {array} All created minimum charge transactions for the provided bill run.
    */
   static async go (billRun) {
-    const minimumChargeLicences = await this._retrieveMinimumChargeLicences(billRun)
-    const adjustments = await this._createAdjustmentTransactions(minimumChargeLicences)
-    return adjustments
+    const minimumChargeInvoices = await this._retrieveMinimumChargeInvoices(billRun)
+    const licences = this._extractLicences(minimumChargeInvoices)
+    return this._createAdjustmentTransactions(licences)
   }
 
-  // TODO: Document
-  // TODO: Select only fields we need
-  static async _retrieveMinimumChargeLicences (billRun) {
+  static async _retrieveMinimumChargeInvoices (billRun) {
+    // We .select('') so that only the licences list of each invoice is returned
     return billRun.$relatedQuery('invoices')
       .modify('minimumCharge')
       .withGraphFetched('licences')
+      .select('')
   }
 
+  /**
+   * Return a flattened array of licences under the invoice array passed to the function
+   */
+  static _extractLicences (invoices) {
+    return invoices.map(invoice => invoice.licences).flat()
+  }
+
+  /**
+   * Iterate over every licence and generate any needed minimum charge adjustments
+   */
   static async _createAdjustmentTransactions (licences) {
     const adjustments = []
 
+    /**
+     * Generate credit and debit adjustments and add them to the adjustments array.
+     * If no adjustment is needed then null will be added -- we will filter these out before we return.
+     */
     for (const licence of licences) {
-      const creditAdjustment = await this._adjustment(licence, licence.creditValue, true)
-      const debitAdjustment = await this._adjustment(licence, licence.debitValue, false)
-
-      if (creditAdjustment !== null) {
-        adjustments.push(creditAdjustment)
-      }
-
-      if (debitAdjustment !== null) {
-        adjustments.push(debitAdjustment)
-      }
+      adjustments.push(await this._adjustment(licence, licence.creditValue, true))
+      adjustments.push(await this._adjustment(licence, licence.debitValue, false))
     }
 
-    return adjustments
+    return adjustments.filter(transaction => transaction)
   }
 
   static async _adjustment (licence, value, credit) {
     if (value === 0) { return null }
     if (value >= MINIMUM_CHARGE_LIMIT) { return null }
+
     const adjustmentValue = MINIMUM_CHARGE_LIMIT - value
     return CreateMinimumChargeAdjustmentService.go(licence, adjustmentValue, credit)
   }

--- a/app/services/create_minimum_charge_adjustment.service.js
+++ b/app/services/create_minimum_charge_adjustment.service.js
@@ -33,7 +33,7 @@ class CreateMinimumChargeAdjustmentService {
 
     this._applyChargeValue(transactionTemplate, chargeValue)
     this._applyChargeCredit(transactionTemplate, chargeCredit)
-    this._applysubjectToMinimumChargeFlag(transactionTemplate)
+    this._applyMinimumChargeFlags(transactionTemplate)
 
     return transactionTemplate
   }
@@ -53,13 +53,18 @@ class CreateMinimumChargeAdjustmentService {
   }
 
   /**
-   * Set the subjectToMinimumCharge flag to true
+   * Set the subjectToMinimumCharge and minimumChargeAdjustment flags to true
    *
    * Minimum charge adjustment is only applied when an invoice has subjectToMinimumCharge set to true, so we would want the
    * adjustment transaction to have subjectToMinimumCharge set to true as well
+   *
+   * The minimumChargeAdjustment flag indicates that the transaction is an adjustment
    */
-  static _applysubjectToMinimumChargeFlag (translator) {
-    Object.assign(translator, { subjectToMinimumCharge: true })
+  static _applyMinimumChargeFlags (translator) {
+    Object.assign(translator, {
+      subjectToMinimumCharge: true,
+      minimumChargeAdjustment: true
+    })
   }
 }
 

--- a/app/services/index.js
+++ b/app/services/index.js
@@ -3,6 +3,7 @@
 const AuthorisationService = require('./authorisation.service')
 const BillRunService = require('./bill_run.service')
 const CalculateChargeService = require('./calculate_charge.service')
+const CalculateMinimumChargeService = require('./calculate_minimum_charge.service')
 const CognitoJwtToPemService = require('./cognito_jwt_to_pem.service')
 const CreateAuthorisedSystemService = require('./create_authorised_system.service')
 const CreateBillRunService = require('./create_bill_run.service')
@@ -24,6 +25,7 @@ module.exports = {
   AuthorisationService,
   BillRunService,
   CalculateChargeService,
+  CalculateMinimumChargeService,
   CognitoJwtToPemService,
   CreateAuthorisedSystemService,
   CreateMinimumChargeAdjustmentService,

--- a/test/services/calculate_minimum_charge.service.test.js
+++ b/test/services/calculate_minimum_charge.service.test.js
@@ -1,0 +1,143 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+const Nock = require('nock')
+
+const { describe, it, before, beforeEach, after, afterEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const {
+  AuthorisedSystemHelper,
+  BillRunHelper,
+  DatabaseHelper,
+  GeneralHelper,
+  RegimeHelper,
+  RulesServiceHelper
+} = require('../support/helpers')
+const { TransactionModel } = require('../../app/models')
+
+const { CreateTransactionService } = require('../../app/services')
+
+const { presroc: requestFixtures } = require('../support/fixtures/create_transaction')
+const { presroc: chargeFixtures } = require('../support/fixtures/calculate_charge')
+
+const MINIMUM_CHARGE_LIMIT = 2500
+
+// Thing under test
+const { CalculateMinimumChargeService } = require('../../app/services')
+
+describe('Calculate Minimum Charge service', () => {
+  let authorisedSystem
+  let regime
+  let payload
+
+  before(async () => {
+    // Intercept all requests in this test suite as we don't actually want to call the service. Tell Nock to persist()
+    // the interception rather than remove it after the first request
+    Nock(RulesServiceHelper.url)
+      .post(() => true)
+      .reply(200, chargeFixtures.simple.rulesService)
+      .persist()
+  })
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+    regime = await RegimeHelper.addRegime('wrls', 'WRLS')
+    authorisedSystem = await AuthorisedSystemHelper.addSystem('1234546789', 'system1', [regime])
+
+    // We clone the request fixture as our payload so we have it available for modification in the invalid tests. For
+    // the valid tests we can use it straight as
+    payload = GeneralHelper.cloneObject(requestFixtures.simple)
+  })
+
+  afterEach(async () => {
+    Sinon.restore()
+  })
+
+  after(async () => {
+    Nock.cleanAll()
+  })
+
+  describe('When a minimum charge adjustment is required', () => {
+    let billRun
+
+    beforeEach(async () => {
+      billRun = await BillRunHelper.addBillRun(authorisedSystem.id, regime.id)
+      payload.subjectToMinimumCharge = true
+    })
+
+    it('returns an array of transactions', async () => {
+      await CreateTransactionService.go(payload, billRun.id, authorisedSystem, regime)
+
+      const calculatedMinimumCharges = await CalculateMinimumChargeService.go(billRun)
+
+      expect(calculatedMinimumCharges).to.be.be.an.instanceof(Array)
+      expect(calculatedMinimumCharges[0]).to.be.an.instanceOf(TransactionModel)
+    })
+
+    it('correctly calculates the debit value', async () => {
+      const transaction = await CreateTransactionService.go(payload, billRun.id, authorisedSystem, regime)
+      const transactionRecord = await TransactionModel.query().findById(transaction.transaction.id)
+
+      const calculatedMinimumCharges = await CalculateMinimumChargeService.go(billRun)
+
+      const minimumChargeTransaction = calculatedMinimumCharges[0]
+      expect(minimumChargeTransaction.chargeValue).to.equal(MINIMUM_CHARGE_LIMIT - transactionRecord.chargeValue)
+      expect(minimumChargeTransaction.chargeCredit).to.equal(false)
+    })
+
+    it('correctly calculates the credit value', async () => {
+      const transaction = await CreateTransactionService.go({ ...payload, credit: true }, billRun.id, authorisedSystem, regime)
+      const transactionRecord = await TransactionModel.query().findById(transaction.transaction.id)
+
+      const calculatedMinimumCharges = await CalculateMinimumChargeService.go(billRun)
+
+      const minimumChargeTransaction = calculatedMinimumCharges[0]
+      expect(minimumChargeTransaction.chargeValue).to.equal(MINIMUM_CHARGE_LIMIT - transactionRecord.chargeValue)
+      expect(minimumChargeTransaction.chargeCredit).to.equal(true)
+    })
+
+    it('correctly calculates both a credit and debit if required', async () => {
+      const creditTransaction = await CreateTransactionService.go(payload, billRun.id, authorisedSystem, regime)
+      const debitTransaction = await CreateTransactionService.go({ ...payload, credit: true }, billRun.id, authorisedSystem, regime)
+      const creditTransactionRecord = await TransactionModel.query().findById(creditTransaction.transaction.id)
+      const debitTransactionRecord = await TransactionModel.query().findById(debitTransaction.transaction.id)
+
+      const calculatedMinimumCharges = await CalculateMinimumChargeService.go(billRun)
+
+      const creditMinimumChargeTransction = calculatedMinimumCharges[0]
+      const debitMinimumChargeTransction = calculatedMinimumCharges[1]
+      expect(creditMinimumChargeTransction.chargeValue).to.equal(MINIMUM_CHARGE_LIMIT - creditTransactionRecord.chargeValue)
+      expect(creditMinimumChargeTransction.chargeCredit).to.equal(true)
+      expect(debitMinimumChargeTransction.chargeValue).to.equal(MINIMUM_CHARGE_LIMIT - debitTransactionRecord.chargeValue)
+      expect(debitMinimumChargeTransction.chargeCredit).to.equal(false)
+    })
+  })
+
+  describe('When no minimum charge adjustment is required', () => {
+    let billRun
+
+    beforeEach(async () => {
+      billRun = await BillRunHelper.addBillRun(authorisedSystem.id, regime.id)
+      payload.subjectToMinimumCharge = true
+    })
+
+    it('returns an empty array', async () => {
+      // Create 5 transactions to ensure we are over the minimum charge limit
+      await CreateTransactionService.go(payload, billRun.id, authorisedSystem, regime)
+      await CreateTransactionService.go(payload, billRun.id, authorisedSystem, regime)
+      await CreateTransactionService.go(payload, billRun.id, authorisedSystem, regime)
+      await CreateTransactionService.go(payload, billRun.id, authorisedSystem, regime)
+      await CreateTransactionService.go(payload, billRun.id, authorisedSystem, regime)
+
+      const calculatedMinimumCharges = await CalculateMinimumChargeService.go(billRun)
+
+      expect(calculatedMinimumCharges).to.be.be.an.instanceof(Array)
+      expect(calculatedMinimumCharges).to.be.empty()
+    })
+  })
+})

--- a/test/services/calculate_minimum_charge.service.test.js
+++ b/test/services/calculate_minimum_charge.service.test.js
@@ -30,7 +30,7 @@ const MINIMUM_CHARGE_LIMIT = 2500
 // Thing under test
 const { CalculateMinimumChargeService } = require('../../app/services')
 
-describe.only('Calculate Minimum Charge service', () => {
+describe('Calculate Minimum Charge service', () => {
   let authorisedSystem
   let regime
   let payload

--- a/test/services/calculate_minimum_charge.service.test.js
+++ b/test/services/calculate_minimum_charge.service.test.js
@@ -6,7 +6,7 @@ const Code = require('@hapi/code')
 const Sinon = require('sinon')
 const Nock = require('nock')
 
-const { describe, it, before, beforeEach, after, afterEach } = exports.lab = Lab.script()
+const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers

--- a/test/services/create_minimum_charge_adjustment.service.test.js
+++ b/test/services/create_minimum_charge_adjustment.service.test.js
@@ -94,6 +94,10 @@ describe('Create Minimum Charge Adjustment service', () => {
       expect(minimumChargeAdjustment.subjectToMinimumCharge).to.equal(true)
     })
 
+    it('has minimumChargeAdjustment set to true', async () => {
+      expect(minimumChargeAdjustment.minimumChargeAdjustment).to.equal(true)
+    })
+
     it('reads data from another transaction within the licence', async () => {
       const fieldsToTest = [
         'billRunId',


### PR DESCRIPTION
The next stage of generating a bill run-level summary is to handle minimum charge. This branch introduces `calculateMinimumChargeService` which will handle checking whether minimum charge applies to the licences under a bill run, calculates the value of any adjustment transactions, and creates those transactions.