### PR TITLE
Minimum charge database changes

### DIFF
--- a/app/services/bill_run.service.js
+++ b/app/services/bill_run.service.js
@@ -54,8 +54,8 @@ class BillRunService {
       billRun.debitValue += transaction.chargeValue
     }
 
-    if (transaction.newLicence) {
-      billRun.newLicenceCount += 1
+    if (transaction.subjectToMinimumCharge) {
+      billRun.subjectToMinimumChargeCount += 1
     }
   }
 }

--- a/app/services/bill_run.service.js
+++ b/app/services/bill_run.service.js
@@ -43,19 +43,21 @@ class BillRunService {
     }
   }
 
-  static _updateStats (billRun, transaction) {
+  static _updateStats (object, transaction) {
     if (transaction.chargeCredit) {
-      billRun.creditCount += 1
-      billRun.creditValue += transaction.chargeValue
+      object.creditCount += 1
+      object.creditValue += transaction.chargeValue
+      object.subjectToMinimumChargeCreditValue += transaction.subjectToMinimumCharge ? transaction.chargeValue : 0
     } else if (transaction.chargeValue === 0) {
-      billRun.zeroCount += 1
+      object.zeroCount += 1
     } else {
-      billRun.debitCount += 1
-      billRun.debitValue += transaction.chargeValue
+      object.debitCount += 1
+      object.debitValue += transaction.chargeValue
+      object.subjectToMinimumChargeDebitValue += transaction.subjectToMinimumCharge ? transaction.chargeValue : 0
     }
 
     if (transaction.subjectToMinimumCharge) {
-      billRun.subjectToMinimumChargeCount += 1
+      object.subjectToMinimumChargeCount += 1
     }
   }
 }

--- a/app/services/create_minimum_charge_adjustment.service.js
+++ b/app/services/create_minimum_charge_adjustment.service.js
@@ -33,7 +33,7 @@ class CreateMinimumChargeAdjustmentService {
 
     this._applyChargeValue(transactionTemplate, chargeValue)
     this._applyChargeCredit(transactionTemplate, chargeCredit)
-    this._applyNewLicenceFlag(transactionTemplate)
+    this._applysubjectToMinimumChargeFlag(transactionTemplate)
 
     return transactionTemplate
   }
@@ -53,13 +53,13 @@ class CreateMinimumChargeAdjustmentService {
   }
 
   /**
-   * Set the newLicence flag to true
+   * Set the subjectToMinimumCharge flag to true
    *
-   * Minimum charge adjustment is only applied when an invoice has newLicence set to true, so we would want the
-   * adjustment transaction to have newLicence set to true as well
+   * Minimum charge adjustment is only applied when an invoice has subjectToMinimumCharge set to true, so we would want the
+   * adjustment transaction to have subjectToMinimumCharge set to true as well
    */
-  static _applyNewLicenceFlag (translator) {
-    Object.assign(translator, { newLicence: true })
+  static _applysubjectToMinimumChargeFlag (translator) {
+    Object.assign(translator, { subjectToMinimumCharge: true })
   }
 }
 

--- a/app/services/invoice.service.js
+++ b/app/services/invoice.service.js
@@ -41,19 +41,21 @@ class InvoiceService {
       )
   }
 
-  static _updateStats (invoice, transaction) {
+  static _updateStats (object, transaction) {
     if (transaction.chargeCredit) {
-      invoice.creditCount += 1
-      invoice.creditValue += transaction.chargeValue
+      object.creditCount += 1
+      object.creditValue += transaction.chargeValue
+      object.subjectToMinimumChargeCreditValue += transaction.subjectToMinimumCharge ? transaction.chargeValue : 0
     } else if (transaction.chargeValue === 0) {
-      invoice.zeroCount += 1
+      object.zeroCount += 1
     } else {
-      invoice.debitCount += 1
-      invoice.debitValue += transaction.chargeValue
+      object.debitCount += 1
+      object.debitValue += transaction.chargeValue
+      object.subjectToMinimumChargeDebitValue += transaction.subjectToMinimumCharge ? transaction.chargeValue : 0
     }
 
     if (transaction.subjectToMinimumCharge) {
-      invoice.subjectToMinimumChargeCount += 1
+      object.subjectToMinimumChargeCount += 1
     }
   }
 }

--- a/app/services/invoice.service.js
+++ b/app/services/invoice.service.js
@@ -52,8 +52,8 @@ class InvoiceService {
       invoice.debitValue += transaction.chargeValue
     }
 
-    if (transaction.newLicence) {
-      invoice.newLicenceCount += 1
+    if (transaction.subjectToMinimumCharge) {
+      invoice.subjectToMinimumChargeCount += 1
     }
   }
 }

--- a/app/services/licence.service.js
+++ b/app/services/licence.service.js
@@ -42,19 +42,21 @@ class LicenceService {
       )
   }
 
-  static _updateStats (licence, transaction) {
+  static _updateStats (object, transaction) {
     if (transaction.chargeCredit) {
-      licence.creditCount += 1
-      licence.creditValue += transaction.chargeValue
+      object.creditCount += 1
+      object.creditValue += transaction.chargeValue
+      object.subjectToMinimumChargeCreditValue += transaction.subjectToMinimumCharge ? transaction.chargeValue : 0
     } else if (transaction.chargeValue === 0) {
-      licence.zeroCount += 1
+      object.zeroCount += 1
     } else {
-      licence.debitCount += 1
-      licence.debitValue += transaction.chargeValue
+      object.debitCount += 1
+      object.debitValue += transaction.chargeValue
+      object.subjectToMinimumChargeDebitValue += transaction.subjectToMinimumCharge ? transaction.chargeValue : 0
     }
 
     if (transaction.subjectToMinimumCharge) {
-      licence.subjectToMinimumChargeCount += 1
+      object.subjectToMinimumChargeCount += 1
     }
   }
 }

--- a/app/services/licence.service.js
+++ b/app/services/licence.service.js
@@ -53,8 +53,8 @@ class LicenceService {
       licence.debitValue += transaction.chargeValue
     }
 
-    if (transaction.newLicence) {
-      licence.newLicenceCount += 1
+    if (transaction.subjectToMinimumCharge) {
+      licence.subjectToMinimumChargeCount += 1
     }
   }
 }

--- a/app/translators/transaction.translator.js
+++ b/app/translators/transaction.translator.js
@@ -17,7 +17,7 @@ class TransactionTranslator extends BaseTranslator {
       chargeElementId: Joi.string().allow('', null),
       areaCode: Joi.string().uppercase().valid(...this._validAreas()),
       lineDescription: Joi.string().max(240).required(),
-      newLicence: Joi.boolean().default(false),
+      subjectToMinimumCharge: Joi.boolean().default(false),
       clientId: Joi.string().allow('', null),
       // Set a new field called ruleset. This will identify which ruleset the transaction and it's charge relates to
       ruleset: Joi.string().default('presroc')
@@ -34,7 +34,7 @@ class TransactionTranslator extends BaseTranslator {
       customerReference: 'customerReference',
       periodStart: 'chargePeriodStart',
       periodEnd: 'chargePeriodEnd',
-      newLicence: 'newLicence',
+      subjectToMinimumCharge: 'subjectToMinimumCharge',
       clientId: 'clientId',
       credit: 'chargeCredit',
       areaCode: 'lineAreaCode',

--- a/db/migrations/20210126164808_alter_invoices.js
+++ b/db/migrations/20210126164808_alter_invoices.js
@@ -1,0 +1,31 @@
+'use strict'
+
+const tableName = 'invoices'
+
+exports.up = async function (knex) {
+  await knex
+    .schema
+    .alterTable(tableName, table => {
+      // Rename 'new_licence_count' to 'subject_to_minimum_charge_count'
+      table.renameColumn('new_licence_count', 'subject_to_minimum_charge_count')
+
+      // Add minimum charge credit and debit value columns
+      table.bigInteger('subject_to_minimum_charge_credit_value').notNullable().defaultTo(0)
+      table.bigInteger('subject_to_minimum_charge_debit_value').notNullable().defaultTo(0)
+    })
+}
+
+exports.down = async function (knex) {
+  await knex
+    .schema
+    .alterTable(tableName, table => {
+      // Rename column back
+      table.renameColumn('subject_to_minimum_charge_count', 'new_licence_count')
+
+      // Drop added columns
+      table.dropColumns(
+        'subject_to_minimum_charge_credit_value',
+        'subject_to_minimum_charge_debit_value'
+      )
+    })
+}

--- a/db/migrations/20210126165247_alter_licences.js
+++ b/db/migrations/20210126165247_alter_licences.js
@@ -1,0 +1,31 @@
+'use strict'
+
+const tableName = 'licences'
+
+exports.up = async function (knex) {
+  await knex
+    .schema
+    .alterTable(tableName, table => {
+      // Rename 'new_licence_count' to 'subject_to_minimum_charge_count'
+      table.renameColumn('new_licence_count', 'subject_to_minimum_charge_count')
+
+      // Add minimum charge credit and debit value columns
+      table.bigInteger('subject_to_minimum_charge_credit_value').notNullable().defaultTo(0)
+      table.bigInteger('subject_to_minimum_charge_debit_value').notNullable().defaultTo(0)
+    })
+}
+
+exports.down = async function (knex) {
+  await knex
+    .schema
+    .alterTable(tableName, table => {
+      // Rename column back
+      table.renameColumn('subject_to_minimum_charge_count', 'new_licence_count')
+
+      // Drop added columns
+      table.dropColumns(
+        'subject_to_minimum_charge_credit_value',
+        'subject_to_minimum_charge_debit_value'
+      )
+    })
+}

--- a/db/migrations/20210126165650_alter_transactions.js
+++ b/db/migrations/20210126165650_alter_transactions.js
@@ -1,0 +1,21 @@
+'use strict'
+
+const tableName = 'transactions'
+
+exports.up = async function (knex) {
+  await knex
+    .schema
+    .alterTable(tableName, table => {
+      // Rename 'new_licence' to 'minimum_charge'
+      table.renameColumn('new_licence', 'subject_to_minimum_charge')
+    })
+}
+
+exports.down = async function (knex) {
+  await knex
+    .schema
+    .alterTable(tableName, table => {
+      // Rename column back
+      table.renameColumn('subject_to_minimum_charge', 'new_licence')
+    })
+}

--- a/db/migrations/20210126170439_alter_bill_runs.js
+++ b/db/migrations/20210126170439_alter_bill_runs.js
@@ -1,0 +1,31 @@
+'use strict'
+
+const tableName = 'bill_runs'
+
+exports.up = async function (knex) {
+  await knex
+    .schema
+    .alterTable(tableName, table => {
+      // Rename 'new_licence_count' to 'subject_to_minimum_charge_count'
+      table.renameColumn('new_licence_count', 'subject_to_minimum_charge_count')
+
+      // Add minimum charge credit and debit value columns
+      table.bigInteger('subject_to_minimum_charge_credit_value').notNullable().defaultTo(0)
+      table.bigInteger('subject_to_minimum_charge_debit_value').notNullable().defaultTo(0)
+    })
+}
+
+exports.down = async function (knex) {
+  await knex
+    .schema
+    .alterTable(tableName, table => {
+      // Rename column back
+      table.renameColumn('subject_to_minimum_charge_count', 'new_licence_count')
+
+      // Drop added columns
+      table.dropColumns(
+        'subject_to_minimum_charge_credit_value',
+        'subject_to_minimum_charge_debit_value'
+      )
+    })
+}

--- a/test/services/bill_run.service.test.js
+++ b/test/services/bill_run.service.test.js
@@ -74,13 +74,13 @@ describe('Bill Run service', () => {
       })
     })
 
-    describe('When a new licence transaction is supplied', () => {
-      it('correctly sets the new licence flag', async () => {
-        transaction.newLicence = true
+    describe('When a transaction subject to minimum charge is supplied', () => {
+      it.only('correctly sets the subject to minimum charge flag', async () => {
+        transaction.subjectToMinimumCharge = true
 
         const result = await BillRunService.go(transaction)
 
-        expect(result.newLicenceCount).to.equal(1)
+        expect(result.subjectToMinimumChargeCount).to.equal(1)
       })
     })
 

--- a/test/services/create_minimum_charge_adjustment.service.test.js
+++ b/test/services/create_minimum_charge_adjustment.service.test.js
@@ -90,8 +90,8 @@ describe('Create Minimum Charge Adjustment service', () => {
       expect(minimumChargeAdjustment.chargeCredit).to.equal(chargeCredit)
     })
 
-    it('has newLicence set to true', async () => {
-      expect(minimumChargeAdjustment.newLicence).to.equal(true)
+    it('has subjectToMinimumCharge set to true', async () => {
+      expect(minimumChargeAdjustment.subjectToMinimumCharge).to.equal(true)
     })
 
     it('reads data from another transaction within the licence', async () => {

--- a/test/services/invoice.service.test.js
+++ b/test/services/invoice.service.test.js
@@ -78,12 +78,12 @@ describe('Invoice service', () => {
     })
   })
 
-  describe('When a new licence transaction is supplied', () => {
-    it('correctly sets the new licence flag', async () => {
-      transaction.newLicence = true
+  describe('When a transaction subject to minimum charge is supplied', () => {
+    it('correctly sets the subject to minimum charge flag', async () => {
+      transaction.subjectToMinimumCharge = true
       const invoice = await InvoiceService.go(transaction)
 
-      expect(invoice.newLicenceCount).to.equal(1)
+      expect(invoice.subjectToMinimumChargeCount).to.equal(1)
     })
   })
 

--- a/test/services/invoice.service.test.js
+++ b/test/services/invoice.service.test.js
@@ -79,19 +79,48 @@ describe('Invoice service', () => {
   })
 
   describe('When a transaction subject to minimum charge is supplied', () => {
-    it('correctly sets the subject to minimum charge flag', async () => {
+    beforeEach(async () => {
       transaction.subjectToMinimumCharge = true
-      const invoice = await InvoiceService.go(transaction)
+    })
 
-      expect(invoice.subjectToMinimumChargeCount).to.equal(1)
+    it('correctly sets the subject to minimum charge flag', async () => {
+      const result = await InvoiceService.go(transaction)
+
+      expect(result.subjectToMinimumChargeCount).to.equal(1)
+    })
+
+    describe('and the total is needed', () => {
+      it('correctly calculates the total for a debit', async () => {
+        const firstResult = await InvoiceService.go(transaction)
+        // We save the invoice with stats to the database as this isn't done by InvoiceService
+        await InvoiceModel.query().update(firstResult)
+
+        const secondInvoice = await InvoiceService.go(transaction)
+
+        expect(secondInvoice.subjectToMinimumChargeCount).to.equal(2)
+        expect(secondInvoice.subjectToMinimumChargeDebitValue).to.equal(transaction.chargeValue * 2)
+      })
+
+      it('correctly calculates the total for a credit', async () => {
+        transaction.chargeCredit = true
+
+        const firstResult = await InvoiceService.go(transaction)
+        // We save the invoice with stats to the database as this isn't done by InvoiceService
+        await InvoiceModel.query().update(firstResult)
+
+        const secondInvoice = await InvoiceService.go(transaction)
+
+        expect(secondInvoice.subjectToMinimumChargeCount).to.equal(2)
+        expect(secondInvoice.subjectToMinimumChargeCreditValue).to.equal(transaction.chargeValue * 2)
+      })
     })
   })
 
   describe('When two transactions are created', () => {
     it('correctly calculates the summary', async () => {
-      const firstInvoice = await InvoiceService.go(transaction)
+      const firstResult = await InvoiceService.go(transaction)
       // We save the invoice with stats to the database as this isn't done by InvoiceService
-      await InvoiceModel.query().update(firstInvoice)
+      await InvoiceModel.query().update(firstResult)
 
       const secondInvoice = await InvoiceService.go(transaction)
 

--- a/test/services/licence.service.test.js
+++ b/test/services/licence.service.test.js
@@ -80,12 +80,12 @@ describe('Licence service', () => {
     })
   })
 
-  describe('When a new licence transaction is supplied', () => {
-    it('correctly sets the new licence flag', async () => {
-      transaction.newLicence = true
+  describe('When a transaction subject to minimum charge is supplied', () => {
+    it('correctly sets the subject to minimum charge flag', async () => {
+      transaction.subjectToMinimumCharge = true
       const licence = await LicenceService.go(transaction)
 
-      expect(licence.newLicenceCount).to.equal(1)
+      expect(licence.subjectToMinimumChargeCount).to.equal(1)
     })
   })
 

--- a/test/translators/transaction.translator.test.js
+++ b/test/translators/transaction.translator.test.js
@@ -55,10 +55,10 @@ describe('Transaction translator', () => {
   }
 
   describe('Default values', () => {
-    it("defaults 'newLicence' to 'false'", async () => {
+    it("defaults 'subjectToMinimumCharge' to 'false'", async () => {
       const testTranslator = new TransactionTranslator(data(payload))
 
-      expect(testTranslator.newLicence).to.be.a.boolean().and.equal(false)
+      expect(testTranslator.subjectToMinimumCharge).to.be.a.boolean().and.equal(false)
     })
 
     it("defaults 'ruleset' to 'presroc'", async () => {


### PR DESCRIPTION
At present, we apply minimum charge to licences which are flagged as "new licences". However minimum charge may be more widely applied than this in future. We are therefore renaming `newLicence` wherever it occurs to `subjectToMinimumCharge`.

Future changes also mean that an invoice could potentially have a mix of transactions, some of which are subject to minimum charge and some of which aren't. Therefore we cannot guarantee that, for example, a licence with a credit value of `5000` is not subject to minimum charge; if `1000` of this is flagged as subject to minimum charge then a minimum charge adjustment would be needed to bring this portion up to `2500`. We are therefore also adding `subject_to_minimum_charge_credit_value` and `subject_to_minimum_charge_debit_value` fields at the bill run, invoice and licence level in order to determine whether an invoice is truly subject to minimum charge.