### PR TITLE
Fix 500 error when compensation charge set to true

### DIFF
--- a/app/translators/calculate_charge.translator.js
+++ b/app/translators/calculate_charge.translator.js
@@ -69,6 +69,7 @@ class CalculateChargeTranslator extends BaseTranslator {
       billableDays: 'regimeValue4',
       compensationCharge: 'regimeValue17',
       credit: 'chargeCredit',
+      eiucSource: 'regimeValue13',
       loss: 'regimeValue8',
       periodEnd: 'chargePeriodEnd',
       periodStart: 'chargePeriodStart',

--- a/test/translators/calculate_charge.translator.test.js
+++ b/test/translators/calculate_charge.translator.test.js
@@ -105,29 +105,6 @@ describe('Calculate Charge translator', () => {
     })
   })
 
-  describe("translating 'eiucSource'", () => {
-    describe("when 'compensationCharge' is 'false'", () => {
-      it('returns the translated value', async () => {
-        const testTranslator = new CalculateChargeTranslator(data(payload))
-
-        expect(testTranslator.regimeValue13).to.be.a.string().and.equal('Tidal')
-      })
-    })
-
-    describe("when 'compensationCharge' is 'true'", () => {
-      it('returns the translated value', async () => {
-        const compensationChargePayload = {
-          ...payload,
-          compensationCharge: true
-        }
-
-        const testTranslator = new CalculateChargeTranslator(data(compensationChargePayload))
-
-        expect(testTranslator.regimeValue13).to.be.a.string().and.equal('Tidal')
-      })
-    })
-  })
-
   describe('Validation', () => {
     describe('when the data is valid', () => {
       it('does not throw an error', async () => {

--- a/test/translators/calculate_charge.translator.test.js
+++ b/test/translators/calculate_charge.translator.test.js
@@ -105,6 +105,29 @@ describe('Calculate Charge translator', () => {
     })
   })
 
+  describe("translating 'eiucSource'", () => {
+    describe("when 'compensationCharge' is 'false'", () => {
+      it('returns the translated value', async () => {
+        const testTranslator = new CalculateChargeTranslator(data(payload))
+
+        expect(testTranslator.regimeValue13).to.be.a.string().and.equal('Tidal')
+      })
+    })
+
+    describe("when 'compensationCharge' is 'true'", () => {
+      it('returns the translated value', async () => {
+        const compensationChargePayload = {
+          ...payload,
+          compensationCharge: true
+        }
+
+        const testTranslator = new CalculateChargeTranslator(data(compensationChargePayload))
+
+        expect(testTranslator.regimeValue13).to.be.a.string().and.equal('Tidal')
+      })
+    })
+  })
+
   describe('Validation', () => {
     describe('when the data is valid', () => {
       it('does not throw an error', async () => {


### PR DESCRIPTION
https://trello.com/c/YleRl9ts
https://trello.com/c/xoHCMKqf

When adding a bill run transaction or calling the calculate charge endpoint if `compensationCharge` is true we are returning a `500` error.

This change fixes the issue.