### PR TITLE
Prevent duplicate transactions with clientID check

### DIFF
--- a/db/migrations/20210127145707_alter_transactions.js
+++ b/db/migrations/20210127145707_alter_transactions.js
@@ -1,0 +1,21 @@
+'use strict'
+
+const tableName = 'transactions'
+
+exports.up = async function (knex) {
+  await knex
+    .schema
+    .alterTable(tableName, table => {
+      // Add unique constraint
+      table.unique(['regime_id', 'client_id'])
+    })
+}
+
+exports.down = async function (knex) {
+  await knex
+    .schema
+    .alterTable(tableName, table => {
+      // Remove unique constraint
+      table.dropUnique(['regime_id', 'client_id'])
+    })
+}

--- a/test/services/create_transaction.service.test.js
+++ b/test/services/create_transaction.service.test.js
@@ -137,5 +137,28 @@ describe('Create Transaction service', () => {
         expect(err).to.be.an.error()
       })
     })
+
+    describe.only('because the request is for a duplicate transaction', () => {
+      let billRun
+
+      beforeEach(async () => {
+        Sinon.stub(RulesService, 'go').returns(chargeFixtures.simple.rulesService)
+        billRun = await BillRunHelper.addBillRun(authorisedSystem.id, regime.id)
+      })
+
+      it('throws an error', async () => {
+        payload.clientId = 'DOUBLEIMPACT'
+
+        // Add the first transaction
+        await CreateTransactionService.go(payload, billRun.id, authorisedSystem, regime)
+
+        // Attempt to add a transaction with a duplicate clientId
+        const err = await expect(
+          CreateTransactionService.go(payload, billRun.id, authorisedSystem, regime)
+        ).to.reject()
+
+        expect(err).to.be.an.error()
+      })
+    })
   })
 })

--- a/test/services/create_transaction.service.test.js
+++ b/test/services/create_transaction.service.test.js
@@ -138,7 +138,7 @@ describe('Create Transaction service', () => {
       })
     })
 
-    describe.only('because the request is for a duplicate transaction', () => {
+    describe("because the request is for a duplicate transaction (matching clientId's)", () => {
       let billRun
 
       beforeEach(async () => {


### PR DESCRIPTION
https://trello.com/c/FkpwxW8V

We allow client systems to provide a `clientID` in the create transaction request payload. In the [V1 charging-module-api](https://github.com/DEFRA/charging-module-api/pull/172) this is used to prevent a client system from accidentally adding a duplicate transaction.

The scenario is a client system attempts to add a transaction but it fails. They want confidence that if they try again, they won't mistakenly be adding a duplicate. The idea is we ensure this by blocking any attempt to add a transaction if its `regime_id` and `client_id` matches an existing transaction.

We have the field in the DB, and we accept and store the `client_id` in the current request. What we have not done is implement the blocking logic.

In V1 we added a service that queried the DB for a matching transaction. In V2 we instead intend to create a [SQL Unique constraint](https://www.postgresql.org/docs/12/ddl-constraints.html#DDL-CONSTRAINTS-UNIQUE-CONSTRAINTS) on the transactions table.

As we are focused on performance, we want to avoid the additional query to the DB for a matching transaction. Especially as this is a protection for an edge case. We don't expect a client system to ever send a duplicate so we want to avoid the extra overhead for a scenario we don't expect to happen.

Instead, by adding the constraint we ensure if an attempt is made to insert a duplicate it will error. But we avoid the overhead of pre-emptive check.