### PR TITLE
Fix ensure volume is required for charge and trans

### DIFF
--- a/app/translators/calculate_charge.translator.js
+++ b/app/translators/calculate_charge.translator.js
@@ -57,7 +57,7 @@ class CalculateChargeTranslator extends BaseTranslator {
       section130Agreement: Joi.boolean().required(),
       source: Joi.string().required(), // validated in rules service
       twoPartTariff: Joi.boolean().required(),
-      volume: Joi.number().min(0),
+      volume: Joi.number().min(0).required(),
       waterUndertaker: Joi.boolean().required(),
       regime: Joi.string().required() // needed to determine which endpoints to call in the rules service
     })


### PR DESCRIPTION
https://trello.com/c/YleRl9ts
https://trello.com/c/xoHCMKqf

If `volume` is not part of the create transaction request, or the request to calculate charge the rules service will still return a result. It is not a required field for it.

But we want to try and ensure that client systems are explicit in a request that will return a 0 charge. `volume` is the key factor in determining a WRLS charge result so we are happy to support `volume: 0`. But we want to avoid returning a £0 charge just because `volume` was inadvertently not part of the request.

This change updates the validation for `volume` to be `required()`.

> Raised as a fix because it should have been `required()` from the start.

<details>
<summary>Screenshot of response</summary>

<img width="413" alt="Screenshot 2021-01-27 at 16 29 57" src="https://user-images.githubusercontent.com/1789650/106021838-1e65b700-60bd-11eb-99e6-eca1bfbc4433.png">

</details>