### PR TITLE
Fix Joi validations using US date format

### DIFF
--- a/app/translators/calculate_charge.translator.js
+++ b/app/translators/calculate_charge.translator.js
@@ -5,7 +5,7 @@
  */
 
 const BaseTranslator = require('./base.translator')
-const Joi = require('joi')
+const Joi = require('joi').extend(require('@joi/date'))
 const Boom = require('@hapi/boom')
 
 class CalculateChargeTranslator extends BaseTranslator {
@@ -36,6 +36,8 @@ class CalculateChargeTranslator extends BaseTranslator {
   }
 
   _schema () {
+    const validDateFormats = ['DD-MMM-YYYY', 'DD-MM-YYYY', 'YYYY-MM-DD', 'DD/MM/YYYY', 'YYYY/MM/DD']
+
     return Joi.object({
       authorisedDays: Joi.number().integer().min(0).max(366).required(),
       billableDays: Joi.number().integer().min(0).max(366).required(),
@@ -44,8 +46,8 @@ class CalculateChargeTranslator extends BaseTranslator {
       // validated in the rules service
       eiucSource: Joi.when('compensationCharge', { is: true, then: Joi.string().required() }),
       loss: Joi.string().required(), // validated in rules service
-      periodStart: Joi.date().less(Joi.ref('periodEnd')).min('01-APR-2014').required(),
-      periodEnd: Joi.date().required(),
+      periodStart: Joi.date().format(validDateFormats).less(Joi.ref('periodEnd')).min('01-APR-2014').required(),
+      periodEnd: Joi.date().format(validDateFormats).required(),
       regionalChargingArea: Joi.string().required(), // validated in the rules service
       // Set a new field called ruleset. This will be used to determine which ruleset to query in the rules service. If
       // the data comes from a calculate charge request we deafult it. If the data comes from a create transaction

--- a/package-lock.json
+++ b/package-lock.json
@@ -846,6 +846,14 @@
         "@hapi/hoek": "9.x.x"
       }
     },
+    "@joi/date": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@joi/date/-/date-2.0.1.tgz",
+      "integrity": "sha512-vAnBxaPmyXRmHlbr5H3zY6x8ToW1a3c3gCo91dsf/HPKP2vS4sz2xzjyCE1up0vmFmSWgfDIyJMpRWVOG2cpZQ==",
+      "requires": {
+        "moment": "2.x.x"
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
@@ -4225,6 +4233,11 @@
       "requires": {
         "minimist": "^1.2.5"
       }
+    },
+    "moment": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "mri": {
       "version": "1.1.4",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@airbrake/node": "^1.4.1",
     "@hapi/hapi": "^20.0.1",
     "@hapi/joi": "^17.1.1",
+    "@joi/date": "^2.0.1",
     "@now-ims/hapi-now-auth": "^2.0.2",
     "blipp": "^4.0.1",
     "dotenv": "^8.2.0",

--- a/test/translators/calculate_charge.translator.test.js
+++ b/test/translators/calculate_charge.translator.test.js
@@ -105,6 +105,93 @@ describe('Calculate Charge translator', () => {
     })
   })
 
+  describe('handling of date formats', () => {
+    describe("when period start and end are formatted as 'DD-MMM-YYYY'", () => {
+      it('parses them correctly', async () => {
+        const result = new CalculateChargeTranslator(data(payload))
+
+        expect(result.chargePeriodStart).to.be.a.date()
+
+        expect(result.chargePeriodStart.getDate()).to.equal(1)
+        // Months are zero based, for example, January is 0 and December is 11
+        expect(result.chargePeriodStart.getMonth()).to.equal(3)
+        expect(result.chargePeriodStart.getFullYear()).to.equal(2020)
+      })
+    })
+
+    describe("when period start and end are formatted as 'DD-MM-YYYY'", () => {
+      it('parses them correctly', async () => {
+        const dateFormatPayload = {
+          ...payload,
+          periodStart: '01-04-2020',
+          periodEnd: '31-03-2021'
+        }
+        const result = new CalculateChargeTranslator(data(dateFormatPayload))
+
+        expect(result.chargePeriodStart).to.be.a.date()
+
+        expect(result.chargePeriodStart.getDate()).to.equal(1)
+        // Months are zero based, for example, January is 0 and December is 11
+        expect(result.chargePeriodStart.getMonth()).to.equal(3)
+        expect(result.chargePeriodStart.getFullYear()).to.equal(2020)
+      })
+    })
+
+    describe("when period start and end are formatted as 'YYYY-MM-DD'", () => {
+      it('parses them correctly', async () => {
+        const dateFormatPayload = {
+          ...payload,
+          periodStart: '2020-04-01',
+          periodEnd: '2021-03-31'
+        }
+        const result = new CalculateChargeTranslator(data(dateFormatPayload))
+
+        expect(result.chargePeriodStart).to.be.a.date()
+
+        expect(result.chargePeriodStart.getDate()).to.equal(1)
+        // Months are zero based, for example, January is 0 and December is 11
+        expect(result.chargePeriodStart.getMonth()).to.equal(3)
+        expect(result.chargePeriodStart.getFullYear()).to.equal(2020)
+      })
+    })
+
+    describe("when period start and end are formatted as 'DD/MM/YYYY'", () => {
+      it('parses them correctly', async () => {
+        const dateFormatPayload = {
+          ...payload,
+          periodStart: '01/04/2020',
+          periodEnd: '31/03/2021'
+        }
+        const result = new CalculateChargeTranslator(data(dateFormatPayload))
+
+        expect(result.chargePeriodStart).to.be.a.date()
+
+        expect(result.chargePeriodStart.getDate()).to.equal(1)
+        // Months are zero based, for example, January is 0 and December is 11
+        expect(result.chargePeriodStart.getMonth()).to.equal(3)
+        expect(result.chargePeriodStart.getFullYear()).to.equal(2020)
+      })
+    })
+
+    describe("when period start and end are formatted as 'YYYY/MM/DD'", () => {
+      it('parses them correctly', async () => {
+        const dateFormatPayload = {
+          ...payload,
+          periodStart: '2020/04/01',
+          periodEnd: '2021/03/31'
+        }
+        const result = new CalculateChargeTranslator(data(dateFormatPayload))
+
+        expect(result.chargePeriodStart).to.be.a.date()
+
+        expect(result.chargePeriodStart.getDate()).to.equal(1)
+        // Months are zero based, for example, January is 0 and December is 11
+        expect(result.chargePeriodStart.getMonth()).to.equal(3)
+        expect(result.chargePeriodStart.getFullYear()).to.equal(2020)
+      })
+    })
+  })
+
   describe('Validation', () => {
     describe('when the data is valid', () => {
       it('does not throw an error', async () => {


### PR DESCRIPTION
For folks not aware, UK dates are written as either `YYYY-MM-DD` or `DD-MM-YYYY`. In the US month and day are reversed so they use `YYYY-DD-MM` or `MM-DD-YYYY`.

We use [Joi](https://github.com/sideway/joi) to validate our requests. What we have found is that when passed dates in certain formats it appears to use the US format rather than the UK. For example, it will see `01-04-2020` as 4 January 2020. `31-03-2020` will cause the API to return an invalid date error.

The convention with the API is that folks have been passing period end and start dates as `DD-MMM-YYYY`. But we don't want to force client systems to use only this format. We want to allow as many reasonable variations as possible.

We had hoped there would be a global 'catch-all' solution, either at the system or Joi level which would allow us to default to expecting dates in a UK format. But our understanding is that Joi relies on whatever the JavaScript [Date.parse()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse) returns

> If the validation convert option is on (enabled by default), a string or number will be converted to a Date if specified. Note that some invalid date strings will be accepted if they can be adjusted to valid dates (e.g. '2/31/2019' will be converted to '3/3/2019') by the internal JS Date.parse() implementation.
>
> https://joi.dev/api/?v=17.3.0#date

Our research concluded that

- you need to add the [joi-date extension](https://joi.dev/module/joi-date/)
- you then have to be explicit with the formats you expect

This change implements those changes to allow us to handle properly the expected date formats for `periodEnd` and `periodStart` when creating a transaction or calculating a charge.
