### PR TITLE
Update Joi dependency from Hapi to sideway

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -404,38 +404,6 @@
         "@hapi/hoek": "9.x.x"
       }
     },
-    "@hapi/joi": {
-      "version": "17.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-17.1.1.tgz",
-      "integrity": "sha512-p4DKeZAoeZW4g3u7ZeRo+vCDuSDgSvtsB/NpfjXEHTUjSeINAi/RrVOWiVQ1isaoLzMvFEhe8n5065mQq1AdQg==",
-      "requires": {
-        "@hapi/address": "^4.0.1",
-        "@hapi/formula": "^2.0.0",
-        "@hapi/hoek": "^9.0.0",
-        "@hapi/pinpoint": "^2.0.0",
-        "@hapi/topo": "^5.0.0"
-      },
-      "dependencies": {
-        "@hapi/address": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/@hapi/address/-/address-4.1.0.tgz",
-          "integrity": "sha512-SkszZf13HVgGmChdHo/PxchnSaCJ6cetVqLzyciudzZRT0jcOouIF/Q93mgjw8cce+D+4F4C1Z/WrfFN+O3VHQ==",
-          "requires": {
-            "@hapi/hoek": "^9.0.0"
-          }
-        },
-        "@hapi/formula": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-2.0.0.tgz",
-          "integrity": "sha512-V87P8fv7PI0LH7LiVi8Lkf3x+KCO7pQozXRssAHNXXL9L1K+uyu4XypLXwxqVDKgyQai6qj3/KteNlrqDx4W5A=="
-        },
-        "@hapi/pinpoint": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.0.tgz",
-          "integrity": "sha512-vzXR5MY7n4XeIvLpfl3HtE3coZYO4raKXW766R6DZw/6aLqR26iuZ109K7a0NtF2Db0jxqh7xz2AxkUwpUFybw=="
-        }
-      }
-    },
     "@hapi/lab": {
       "version": "24.1.0",
       "resolved": "https://registry.npmjs.org/@hapi/lab/-/lab-24.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "dependencies": {
     "@airbrake/node": "^1.4.1",
     "@hapi/hapi": "^20.0.1",
-    "@hapi/joi": "^17.1.1",
     "@now-ims/hapi-now-auth": "^2.0.2",
     "blipp": "^4.0.1",
     "dotenv": "^8.2.0",


### PR DESCRIPTION
Currently, we reference [@hapi/joi](https://www.npmjs.com/package/@hapi/joi) in our [package.json](https://github.com/DEFRA/sroc-charging-module-api/blob/main/package.json) file.

But the npm entry has a deprecation notice

> This package has been deprecated [..] Switch to 'npm install joi'

We understand under the hood they are the same thing. But this just reflects what happened when [hueniverse](https://github.com/hueniverse), the originator of Hapi, left the project. Most things remained under the [hapijs organisation](https://github.com/hapijs) but Joi went with **hueniverse** to [sideway](https://github.com/sideway).

So this change updates the project to follow the latest advice.