### PR TITLE
Add Database error plugin

### DIFF
--- a/app/plugins/db_errors.plugin.js
+++ b/app/plugins/db_errors.plugin.js
@@ -1,0 +1,55 @@
+'use strict'
+
+/**
+ * @module CleanPayloadPlugin
+ */
+
+const Boom = require('@hapi/boom')
+const { UniqueViolationError } = require('db-errors')
+
+const parseError = (error, data) => {
+  if (error instanceof UniqueViolationError) {
+    return handleUniqueViolationError(error, data)
+  } else {
+    return error
+  }
+}
+
+const handleUniqueViolationError = (error, data) => {
+  console.log(JSON.stringify(error))
+  const regimeId = data.params.regimeId
+  let message
+
+  if (error.constraint === 'transactions_regime_id_client_id_unique') {
+    message = `A transaction with Client ID '${data.payload.clientId}' for Regime '${regimeId}' already exists.`
+  } else {
+    message = `${error.name} - ${error.nativeError.detail}`
+  }
+
+  return new Boom.Boom(
+    message,
+    { statusCode: 409 }
+  )
+}
+
+const DbErrorsPlugin = {
+  name: 'db_errors',
+  register: (server, _options) => {
+    server.ext('onPreResponse', (request, h) => {
+      const response = request.response
+
+      if (!response.isBoom) {
+        return h.continue
+      }
+
+      const data = {
+        payload: request.payload,
+        params: request.params
+      }
+
+      return parseError(response, data)
+    })
+  }
+}
+
+module.exports = DbErrorsPlugin

--- a/app/plugins/db_errors.plugin.js
+++ b/app/plugins/db_errors.plugin.js
@@ -1,36 +1,10 @@
 'use strict'
 
 /**
- * @module CleanPayloadPlugin
+ * @module DbErrorsPlugin
  */
 
-const Boom = require('@hapi/boom')
-const { UniqueViolationError } = require('db-errors')
-
-const parseError = (error, data) => {
-  if (error instanceof UniqueViolationError) {
-    return handleUniqueViolationError(error, data)
-  } else {
-    return error
-  }
-}
-
-const handleUniqueViolationError = (error, data) => {
-  console.log(JSON.stringify(error))
-  const regimeId = data.params.regimeId
-  let message
-
-  if (error.constraint === 'transactions_regime_id_client_id_unique') {
-    message = `A transaction with Client ID '${data.payload.clientId}' for Regime '${regimeId}' already exists.`
-  } else {
-    message = `${error.name} - ${error.nativeError.detail}`
-  }
-
-  return new Boom.Boom(
-    message,
-    { statusCode: 409 }
-  )
-}
+const { DbErrorsService } = require('../services')
 
 const DbErrorsPlugin = {
   name: 'db_errors',
@@ -47,7 +21,7 @@ const DbErrorsPlugin = {
         params: request.params
       }
 
-      return parseError(response, data)
+      return DbErrorsService.go(response, data)
     })
   }
 }

--- a/app/plugins/db_errors.plugin.js
+++ b/app/plugins/db_errors.plugin.js
@@ -1,6 +1,16 @@
 'use strict'
 
 /**
+ * Check if the response we're sending to the client system is a database error.
+ * If it is, parse it to provide a better error. Else send the response 'as is'.
+ *
+ * Mainly to make testing easier, the core logic for parsing database errors and
+ * determining how to respond is in the `DbErrorsService`. See it for more
+ * details.
+ *
+ * This solution was heavily inspired by
+ * {@link https://andv.medium.com/hapi-transforming-an-internal-server-error-occured-into-correct-boom-errors-1a2a72e6ffff|Hapi — transforming “An internal server error occured” into correct Boom errors}
+ *
  * @module DbErrorsPlugin
  */
 

--- a/app/plugins/index.js
+++ b/app/plugins/index.js
@@ -4,6 +4,7 @@ const { ServerConfig } = require('../../config')
 
 const AirbrakePlugin = require('./airbrake.plugin')
 const AuthorisationPlugin = require('./authorisation.plugin')
+const DbErrorsPlugin = require('./db_errors.plugin')
 const HapiNowAuthPlugin = require('./hapi_now_auth.plugin')
 const HapiPinoPlugin = require('./hapi_pino.plugin')
 const InvalidCharactersPlugin = require('./invalid_characters.plugin')
@@ -30,6 +31,7 @@ module.exports = {
   AirbrakePlugin,
   AuthorisationPlugin,
   BlippPlugin,
+  DbErrorsPlugin,
   HpalDebugPlugin,
   HapiNowAuthPlugin,
   HapiPinoPlugin,

--- a/app/services/db_errors.service.js
+++ b/app/services/db_errors.service.js
@@ -1,0 +1,53 @@
+'use strict'
+
+/**
+ * @module DbErrorsService
+ */
+
+const Boom = require('@hapi/boom')
+const { DBError, UniqueViolationError } = require('db-errors')
+
+class DbErrorsService {
+  static go (error, data = {}) {
+    if (error instanceof DBError) {
+      return this._parseError(error, data)
+    } else {
+      return error
+    }
+  }
+
+  static _parseError (error, data) {
+    if (error instanceof UniqueViolationError) {
+      return this._uniqueViolationError(error, data)
+    } else {
+      return this._dbError(error)
+    }
+  }
+
+  static _uniqueViolationError (error, data) {
+    let message
+
+    if (error.constraint === 'transactions_regime_id_client_id_unique') {
+      const regimeId = data.params.regimeId
+      message = `A transaction with Client ID '${data.payload.clientId}' for Regime '${regimeId}' already exists.`
+    } else {
+      message = `${error.name} - ${error.nativeError.detail}`
+    }
+
+    return new Boom.Boom(
+      message,
+      { statusCode: 409 }
+    )
+  }
+
+  static _dbError (error) {
+    const message = `${error.name} - ${error.nativeError.detail}`
+
+    return new Boom.Boom(
+      message,
+      { statusCode: 400 }
+    )
+  }
+}
+
+module.exports = DbErrorsService

--- a/app/services/db_errors.service.js
+++ b/app/services/db_errors.service.js
@@ -8,6 +8,31 @@ const Boom = require('@hapi/boom')
 const { DBError, UniqueViolationError } = require('db-errors')
 
 class DbErrorsService {
+  /**
+   * Determine if the passed in error is an instance of `DBError` and if so generate the appropriate response
+   *
+   * Without this service and the associated `DbErrorsPlugin`, if a database error occurs the user will just get a
+   * generic '500' response with no details.
+   *
+   * We have specific cases where we need to provide a more detailed response, for example, if an attempt is made to
+   * create a transaction with a duplicate `clientId` for the same regime. Also, if we send a
+   * {@link https://hapi.dev/module/boom/api/?v=9.1.1#boombadimplementationmessage-data---alias-internal|Boom 5xx}
+   * we cannot provide any extra info for the client.
+   *
+   * > [Boom docs] All 500 errors hide your message from the end user.
+   *
+   * So if the database error is not something we handle, we return a generic
+   * {@link https://hapi.dev/module/boom/api/?v=9.1.1#boombadrequestmessage-data|Boom 400} response with detail that
+   * indicates the root issue. If it is something we handle, the Boom response we generate will use a more appropriate
+   * status code and feature a tailored message detailing the problem.
+   *
+   * @param {Object} error The error to be assessed and handled. It is assumed this has been provided by the plugin and
+   * taken from `request.response`. If its not an instance of `DBError, the service will just return it
+   * @param {Object} data Data taken from the request. The service assumes data will contain both a `payload` and
+   * `params` property and will use this information to tailor the message we respond to the client with
+   *
+   * @returns {module:Boom} A boom error object
+   */
   static go (error, data = {}) {
     if (error instanceof DBError) {
       return this._parseError(error, data)

--- a/app/services/index.js
+++ b/app/services/index.js
@@ -10,6 +10,7 @@ const CreateBillRunService = require('./create_bill_run.service')
 const CreateMinimumChargeAdjustmentService = require('./create_minimum_charge_adjustment.service')
 const CreateTransactionService = require('./create_transaction.service')
 const DatabaseHealthCheckService = require('./database_health_check.service')
+const DbErrorsService = require('./db_errors.service')
 const GenerateBillRunService = require('./generate_bill_run.service')
 const InvoiceService = require('./invoice.service')
 const LicenceService = require('./licence.service')
@@ -32,6 +33,7 @@ module.exports = {
   CreateBillRunService,
   CreateTransactionService,
   DatabaseHealthCheckService,
+  DbErrorsService,
   GenerateBillRunService,
   InvoiceService,
   LicenceService,

--- a/server.js
+++ b/server.js
@@ -7,6 +7,7 @@ const {
   AirbrakePlugin,
   AuthorisationPlugin,
   BlippPlugin,
+  DbErrorsPlugin,
   HpalDebugPlugin,
   HapiNowAuthPlugin,
   HapiPinoPlugin,
@@ -35,6 +36,7 @@ exports.deployment = async start => {
   await server.register(MissingPayloadPlugin)
   await server.register(InvalidCharactersPlugin)
   await server.register(PayloadCleanerPlugin)
+  await server.register(DbErrorsPlugin)
   await server.register(HapiPinoPlugin(TestConfig.logInTest))
 
   // Register non-production plugins

--- a/test/controllers/presroc/bill_runs.controller.test.js
+++ b/test/controllers/presroc/bill_runs.controller.test.js
@@ -139,12 +139,14 @@ describe('Presroc Bill Runs controller', () => {
     })
 
     describe('When the request is invalid', () => {
-      it('returns an error', async () => {
-        payload.periodStart = '01-APR-2021'
+      describe('because it contains invalid data', () => {
+        it('returns an error', async () => {
+          payload.periodStart = '01-APR-2021'
 
-        const response = await server.inject(options(authToken, payload, billRun.id))
+          const response = await server.inject(options(authToken, payload, billRun.id))
 
-        expect(response.statusCode).to.equal(422)
+          expect(response.statusCode).to.equal(422)
+        })
       })
     })
   })

--- a/test/controllers/presroc/bill_runs.controller.test.js
+++ b/test/controllers/presroc/bill_runs.controller.test.js
@@ -21,7 +21,8 @@ const {
   GeneralHelper,
   RegimeHelper,
   RulesServiceHelper,
-  SequenceCounterHelper
+  SequenceCounterHelper,
+  TransactionHelper
 } = require('../../support/helpers')
 
 const { CreateTransactionService } = require('../../../app/services')
@@ -146,6 +147,20 @@ describe('Presroc Bill Runs controller', () => {
           const response = await server.inject(options(authToken, payload, billRun.id))
 
           expect(response.statusCode).to.equal(422)
+        })
+      })
+
+      describe("because the request is for a duplicate transaction (matching clientId's)", () => {
+        it('returns an error', async () => {
+          // Add the first transaction
+          await TransactionHelper.addTransaction(billRun.id, { regimeId: regime.id, clientId: 'DOUBLEIMPACT' })
+
+          payload.clientId = 'DOUBLEIMPACT'
+
+          // Attempt to add the second
+          const response = await server.inject(options(authToken, payload, billRun.id))
+
+          expect(response.statusCode).to.equal(409)
         })
       })
     })

--- a/test/services/db_errors.service.test.js
+++ b/test/services/db_errors.service.test.js
@@ -1,0 +1,92 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const { DBError, UniqueViolationError } = require('db-errors')
+
+// Thing under test
+const { DbErrorsService } = require('../../app/services')
+
+describe('Db Errors service', () => {
+  describe('If the value passed in is a DB error', () => {
+    describe('but its not a DB error we handle', () => {
+      it("returns a '400' Boom error", () => {
+        const args = {
+          client: 'postgresql',
+          nativeError: {
+            detail: 'Database go bang'
+          }
+        }
+        const result = DbErrorsService.go(new DBError(args))
+
+        expect(result.isBoom).to.be.true()
+        expect(result.output.statusCode).to.equal(400)
+        expect(result.output.payload.message).to.equal(`DBError - ${args.nativeError.detail}`)
+      })
+    })
+
+    describe("and it is a 'UniqueViolationError'", () => {
+      describe('but not one we handle', () => {
+        it("returns a '409' Boom error", () => {
+          const args = {
+            client: 'postgresql',
+            constraint: 'shopping_item_id_customer_id_unique',
+            nativeError: {
+              detail: 'Already got one of those'
+            }
+          }
+          const result = DbErrorsService.go(new UniqueViolationError(args))
+
+          expect(result.isBoom).to.be.true()
+          expect(result.output.statusCode).to.equal(409)
+          expect(result.output.payload.message).to.equal(`UniqueViolationError - ${args.nativeError.detail}`)
+        })
+      })
+
+      describe('specifically a duplicate client Id for the same regime', () => {
+        it("returns a '409' Boom error with a tailored message", () => {
+          const args = {
+            client: 'postgresql',
+            constraint: 'transactions_regime_id_client_id_unique',
+            nativeError: {
+              detail: 'Duplicate client Id for same regime'
+            }
+          }
+          const data = {
+            payload: {
+              clientId: 'DOUBLEIMPACT'
+            },
+            params: {
+              regimeId: 'wrls'
+            }
+          }
+
+          const result = DbErrorsService.go(new UniqueViolationError(args), data)
+
+          expect(result.isBoom).to.be.true()
+          expect(result.output.statusCode).to.equal(409)
+          expect(result.output.payload.message).to.equal(
+            "A transaction with Client ID 'DOUBLEIMPACT' for Regime 'wrls' already exists."
+          )
+        })
+      })
+    })
+  })
+
+  describe('If the value passed in is not a DB error', () => {
+    it('just returns the value', () => {
+      const notAnError = {
+        foo: 'bar'
+      }
+      const result = DbErrorsService.go(notAnError)
+
+      expect(result).to.equal(notAnError)
+    })
+  })
+})


### PR DESCRIPTION
Currently, any database errors result in a generic `500` response from the API. We see the actual error in the logs and in Errbit. But it's a poor experience for the client system. There are also scenarios where a DB error is expected, for example, if you try and add 2 transactions with the same regime and client ID.

When these occur we want our responses to be more meaningful but we also don't want to pollute the code with duplicate `try/catch` blocks all over the place. So, instead this change will add a new plugin that will add an `onPreResponse` hook. It will check for database errors and generate meaningful Boom errors for the scenarios it expects. For those it doesn't it will attempt to return something moe meaningful than a generic `500`.