### PR TITLE
Add uuid4 generator to test GeneralHelper

### DIFF
--- a/test/controllers/admin/authorised_systems.controller.test.js
+++ b/test/controllers/admin/authorised_systems.controller.test.js
@@ -12,7 +12,12 @@ const { expect } = Code
 const { deployment } = require('../../../server')
 
 // Test helpers
-const { AuthorisationHelper, AuthorisedSystemHelper, DatabaseHelper } = require('../../support/helpers')
+const {
+  AuthorisationHelper,
+  AuthorisedSystemHelper,
+  DatabaseHelper,
+  GeneralHelper
+} = require('../../support/helpers')
 
 // Things we need to stub
 const JsonWebToken = require('jsonwebtoken')
@@ -102,7 +107,7 @@ describe('Authorised systems controller', () => {
 
     describe('When the authorised system does not exist', () => {
       it("returns a 404 'not found' response", async () => {
-        const id = 'f0d3b4dc-2cae-11eb-adc1-0242ac120002'
+        const id = GeneralHelper.uuid4()
         const response = await server.inject(options(id, authToken))
 
         const payload = JSON.parse(response.payload)

--- a/test/controllers/admin/regimes.controller.test.js
+++ b/test/controllers/admin/regimes.controller.test.js
@@ -12,7 +12,13 @@ const { expect } = Code
 const { deployment } = require('../../../server')
 
 // Test helpers
-const { AuthorisationHelper, AuthorisedSystemHelper, DatabaseHelper, RegimeHelper } = require('../../support/helpers')
+const {
+  AuthorisationHelper,
+  AuthorisedSystemHelper,
+  DatabaseHelper,
+  GeneralHelper,
+  RegimeHelper
+} = require('../../support/helpers')
 
 // Things we need to stub
 const JsonWebToken = require('jsonwebtoken')
@@ -101,7 +107,7 @@ describe('Regimes controller', () => {
 
     describe('When the regime does not exist', () => {
       it("returns a 404 'not found' response", async () => {
-        const id = 'f0d3b4dc-2cae-11eb-adc1-0242ac120002'
+        const id = GeneralHelper.uuid4()
         const response = await server.inject(options(id, authToken))
 
         const payload = JSON.parse(response.payload)

--- a/test/presenters/create_bill_run.presenter.test.js
+++ b/test/presenters/create_bill_run.presenter.test.js
@@ -7,6 +7,9 @@ const Code = require('@hapi/code')
 const { describe, it } = exports.lab = Lab.script()
 const { expect } = Code
 
+// Test helpers
+const { GeneralHelper } = require('../support/helpers')
+
 // Thing under test
 const { CreateBillRunPresenter } = require('../../app/presenters')
 
@@ -15,10 +18,10 @@ describe('Create Bill Run presenter', () => {
     const data = {
       billRunNumber: 10001,
       region: 'A',
-      regimeId: 'ff75f82d-d56f-4807-9cad-12f23d6b29a8',
-      createdBy: 'e46b816a-3fe8-438a-a3f9-7a1a8eb525ce',
+      regimeId: GeneralHelper.uuid4(),
+      createdBy: GeneralHelper.uuid4(),
       status: 'initialised',
-      id: 'e2a28efc-09eb-439e-95bc-e64c68ab1ea5'
+      id: GeneralHelper.uuid4()
     }
 
     const testPresenter = new CreateBillRunPresenter(data)

--- a/test/presenters/create_transaction.presenter.test.js
+++ b/test/presenters/create_transaction.presenter.test.js
@@ -7,6 +7,9 @@ const Code = require('@hapi/code')
 const { describe, it } = exports.lab = Lab.script()
 const { expect } = Code
 
+// Test helpers
+const { GeneralHelper } = require('../support/helpers')
+
 // Thing under test
 const { CreateTransactionPresenter } = require('../../app/presenters')
 
@@ -16,10 +19,10 @@ describe('Create Transaction presenter', () => {
     // presenter can pull what it needs from it
     const data = {
       region: 'A',
-      regimeId: 'ff75f82d-d56f-4807-9cad-12f23d6b29a8',
-      createdBy: 'e46b816a-3fe8-438a-a3f9-7a1a8eb525ce',
+      regimeId: GeneralHelper.uuid4(),
+      createdBy: GeneralHelper.uuid4(),
       status: 'initialised',
-      id: 'e2a28efc-09eb-439e-95bc-e64c68ab1ea5'
+      id: GeneralHelper.uuid4()
     }
 
     const presenter = new CreateTransactionPresenter(data)

--- a/test/services/bill_run.service.test.js
+++ b/test/services/bill_run.service.test.js
@@ -8,15 +8,15 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const { BillRunHelper, DatabaseHelper } = require('../support/helpers')
+const { BillRunHelper, DatabaseHelper, GeneralHelper } = require('../support/helpers')
 const { BillRunModel } = require('../../app/models')
 
 // Thing under test
 const { BillRunService } = require('../../app/services')
 
 describe('Bill Run service', () => {
-  const authorisedSystemId = '6fd613d8-effb-4bcd-86c7-b0025d121692'
-  const regimeId = '4206994c-5db9-4539-84a6-d4b6a671e2ba'
+  const authorisedSystemId = GeneralHelper.uuid4()
+  const regimeId = GeneralHelper.uuid4()
   const dummyTransaction = {
     customerReference: 'CUSTOMER_REFERENCE',
     region: 'A',
@@ -132,7 +132,7 @@ describe('Bill Run service', () => {
   })
 
   describe('When an invalid bill run ID is supplied', () => {
-    const unknownBillRunId = '05f32bd9-7bce-42c2-8d6a-b14a8e26d531'
+    const unknownBillRunId = GeneralHelper.uuid4()
 
     describe('because no matching bill run exists', () => {
       it('throws an error', async () => {

--- a/test/services/create_transaction.service.test.js
+++ b/test/services/create_transaction.service.test.js
@@ -29,7 +29,7 @@ const { RulesService } = require('../../app/services')
 const { CreateTransactionService } = require('../../app/services')
 
 describe('Create Transaction service', () => {
-  const billRunId = 'b976d8e4-3644-11eb-adc1-0242ac120002'
+  const billRunId = GeneralHelper.uuid4()
   let authorisedSystem
   let regime
   let payload

--- a/test/services/generate_bill_run.service.test.js
+++ b/test/services/generate_bill_run.service.test.js
@@ -8,15 +8,15 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const { BillRunHelper, DatabaseHelper, InvoiceHelper } = require('../support/helpers')
+const { BillRunHelper, DatabaseHelper, GeneralHelper, InvoiceHelper } = require('../support/helpers')
 const { InvoiceModel } = require('../../app/models')
 
 // Thing under test
 const { GenerateBillRunService } = require('../../app/services')
 
 describe('Generate Bill Run Summary service', () => {
-  const authorisedSystemId = '6fd613d8-effb-4bcd-86c7-b0025d121692'
-  const regimeId = '4206994c-5db9-4539-84a6-d4b6a671e2ba'
+  const authorisedSystemId = GeneralHelper.uuid4()
+  const regimeId = GeneralHelper.uuid4()
   const customerReference = 'A11111111A'
 
   let billRun
@@ -98,7 +98,7 @@ describe('Generate Bill Run Summary service', () => {
   describe('When an invalid bill run ID is supplied', () => {
     describe('because no matching bill run exists', () => {
       it('throws an error', async () => {
-        const unknownBillRunId = '05f32bd9-7bce-42c2-8d6a-b14a8e26d531'
+        const unknownBillRunId = GeneralHelper.uuid4()
 
         const err = await expect(GenerateBillRunService.go(unknownBillRunId)).to.reject()
 

--- a/test/services/show_authorised_system.service.test.js
+++ b/test/services/show_authorised_system.service.test.js
@@ -8,7 +8,7 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const { AuthorisedSystemHelper, DatabaseHelper, RegimeHelper } = require('../support/helpers')
+const { AuthorisedSystemHelper, DatabaseHelper, GeneralHelper, RegimeHelper } = require('../support/helpers')
 const AuthorisedSystemModel = require('../../app/models/authorised_system.model')
 const { DataError } = require('objection')
 
@@ -59,7 +59,7 @@ describe('Show Authorised System service', () => {
 
   describe('When there is no matching regime', () => {
     it('throws an error', async () => {
-      const id = 'f0d3b4dc-2cae-11eb-adc1-0242ac120002'
+      const id = GeneralHelper.uuid4()
       const err = await expect(ShowAuthorisedSystemService.go(id)).to.reject(Error, `No authorised system found with id ${id}`)
 
       expect(err).to.be.an.error()

--- a/test/services/show_regime.service.test.js
+++ b/test/services/show_regime.service.test.js
@@ -8,7 +8,12 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const { AuthorisedSystemHelper, DatabaseHelper, RegimeHelper } = require('../support/helpers')
+const {
+  AuthorisedSystemHelper,
+  DatabaseHelper,
+  GeneralHelper,
+  RegimeHelper
+} = require('../support/helpers')
 const RegimeModel = require('../../app/models/regime.model')
 const { DataError } = require('objection')
 
@@ -44,7 +49,7 @@ describe('Show Regime service', () => {
 
   describe('When there is no matching regime', () => {
     it('returns throws an error', async () => {
-      const id = 'f0d3b4dc-2cae-11eb-adc1-0242ac120002'
+      const id = GeneralHelper.uuid4()
       const err = await expect(ShowRegimeService.go(id)).to.reject(Error, `No regime found with id ${id}`)
 
       expect(err).to.be.an.error()

--- a/test/support/helpers/general.helper.js
+++ b/test/support/helpers/general.helper.js
@@ -29,6 +29,31 @@ class GeneralHelper {
   static cloneObject (thingToBeCloned) {
     return Hoek.clone(thingToBeCloned)
   }
+
+  /**
+   * Generate a {@link https://www.ietf.org/rfc/rfc4122.txt|RFC4122} compliant UUID
+   *
+   * We use UUID's as record ids in our database. PostgreSQL handles generating these for us when we insert a record.
+   * Some of our models have a requirement that linked item ID's are also populated. For example, a `transaction`
+   * expects its `invoice_id` and `licence_id` fields to be populated.
+   *
+   * When testing though there are times we want to create a record without also having to create its dependents. We
+   * just need to populate a foreign key field with a valid UUID. For those times you can use this to generate a valid
+   * UUID v4 ID just like we use in the database.
+   *
+   * **WARNING!** The UUIDs this generates would not be safe for production usage. They depend on JavaScript's
+   * `Math.random()` which isn't seen as _random enough_ for generating non-clashing UUIDs.
+   *
+   * Credits: https://stackoverflow.com/a/2117523/6117745
+   */
+  static uuid4 () {
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+      const r = Math.random() * 16 | 0
+      const v = c === 'x' ? r : (r & 0x3 | 0x8)
+
+      return v.toString(16)
+    })
+  }
 }
 
 module.exports = GeneralHelper

--- a/test/translators/bill_run.translator.test.js
+++ b/test/translators/bill_run.translator.test.js
@@ -9,6 +9,7 @@ const { expect } = Code
 
 // Test helpers
 const { ValidationError } = require('joi')
+const { GeneralHelper } = require('../support/helpers')
 
 // Thing under test
 const { BillRunTranslator } = require('../../app/translators')
@@ -20,8 +21,8 @@ describe('Bill Run translator', () => {
 
   const data = (
     payload,
-    regimeId = 'ff75f82d-d56f-4807-9cad-12f23d6b29a8',
-    authorisedSystemId = 'e46b816a-3fe8-438a-a3f9-7a1a8eb525ce'
+    regimeId = GeneralHelper.uuid4(),
+    authorisedSystemId = GeneralHelper.uuid4()
   ) => {
     return {
       regimeId,

--- a/test/translators/transaction.translator.test.js
+++ b/test/translators/transaction.translator.test.js
@@ -9,6 +9,7 @@ const { expect } = Code
 
 // Test helpers
 const { ValidationError } = require('joi')
+const { GeneralHelper } = require('../support/helpers')
 
 // Thing under test
 const { TransactionTranslator } = require('../../app/translators')
@@ -43,9 +44,9 @@ describe('Transaction translator', () => {
 
   const data = (
     payload,
-    billRunId = 'e2a28efc-09eb-439e-95bc-e64c68ab1ea5',
-    regimeId = 'ff75f82d-d56f-4807-9cad-12f23d6b29a8',
-    authorisedSystemId = 'e46b816a-3fe8-438a-a3f9-7a1a8eb525ce') => {
+    billRunId = GeneralHelper.uuid4(),
+    regimeId = GeneralHelper.uuid4(),
+    authorisedSystemId = GeneralHelper.uuid4()) => {
     return {
       billRunId,
       regimeId,


### PR DESCRIPTION
We use UUID's as record ids in our database. PostgreSQL handles generating these for us when we insert a record. Some of our models have a requirement that linked item ID's are also populated. For example, a `transaction` expects its `invoice_id` and `licence_id` fields to be populated.

When testing though there are times we want to create a record without also having to create its dependents. So far we have been using hardcoded UUID's specified within the tests. But we foresee tests where we may need to create a number of items so managing lists of UUID's will become unmaintainable.

This change adds a UUID4 generator to our current `GeneralHelper` and updates the existing tests to use it where applicable. We will then have this available for those tests that need valid but meaningless UUIDs in the future.