### PR TITLE
Fix waterundertaker validation on charge

### DIFF
--- a/app/translators/calculate_charge.translator.js
+++ b/app/translators/calculate_charge.translator.js
@@ -60,7 +60,7 @@ class CalculateChargeTranslator extends BaseTranslator {
       source: Joi.string().required(), // validated in rules service
       twoPartTariff: Joi.boolean().required(),
       volume: Joi.number().min(0).required(),
-      waterUndertaker: Joi.boolean().required(),
+      waterUndertaker: Joi.when('compensationCharge', { is: true, then: Joi.boolean().required() }),
       regime: Joi.string().required() // needed to determine which endpoints to call in the rules service
     })
   }

--- a/test/translators/calculate_charge.translator.test.js
+++ b/test/translators/calculate_charge.translator.test.js
@@ -11,7 +11,7 @@ const { ValidationError } = require('joi')
 // Thing under test
 const { CalculateChargeTranslator } = require('../../app/translators')
 
-describe('Calculate Charge translator', () => {
+describe.only('Calculate Charge translator', () => {
   const payload = {
     periodStart: '01-APR-2020',
     periodEnd: '31-MAR-2021',
@@ -199,6 +199,21 @@ describe('Calculate Charge translator', () => {
 
         expect(result).to.not.be.an.error()
       })
+
+      describe("if 'compensationCharge' is true", () => {
+        describe("and 'eiucSource' is empty", () => {
+          it('still does not throw an error', async () => {
+            const validPayload = {
+              ...payload,
+              compensationCharge: false,
+              eiucSource: ''
+            }
+            const result = new CalculateChargeTranslator(data(validPayload))
+
+            expect(result).to.not.be.an.error()
+          })
+        })
+      })
     })
 
     describe('when the data is not valid', () => {
@@ -225,15 +240,17 @@ describe('Calculate Charge translator', () => {
         })
       })
 
-      describe("because 'eiucSource' is empty when 'compensationCharge' is true", () => {
-        it('throws an error', async () => {
-          const invalidPayload = {
-            ...payload,
-            compensationCharge: true,
-            eiucSource: ''
-          }
+      describe("because 'compensationCharge' is true", () => {
+        describe("and 'eiucSource' is empty", () => {
+          it('throws an error', async () => {
+            const invalidPayload = {
+              ...payload,
+              compensationCharge: true,
+              eiucSource: ''
+            }
 
-          expect(() => new CalculateChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+            expect(() => new CalculateChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+          })
         })
       })
 

--- a/test/translators/calculate_charge.translator.test.js
+++ b/test/translators/calculate_charge.translator.test.js
@@ -11,7 +11,7 @@ const { ValidationError } = require('joi')
 // Thing under test
 const { CalculateChargeTranslator } = require('../../app/translators')
 
-describe.only('Calculate Charge translator', () => {
+describe('Calculate Charge translator', () => {
   const payload = {
     periodStart: '01-APR-2020',
     periodEnd: '31-MAR-2021',
@@ -200,7 +200,7 @@ describe.only('Calculate Charge translator', () => {
         expect(result).to.not.be.an.error()
       })
 
-      describe.only("if 'compensationCharge' is true", () => {
+      describe("if 'compensationCharge' is true", () => {
         describe("and 'eiucSource' is missing", () => {
           it('still does not throw an error', async () => {
             const validPayload = {

--- a/test/translators/calculate_charge.translator.test.js
+++ b/test/translators/calculate_charge.translator.test.js
@@ -254,13 +254,13 @@ describe('Calculate Charge translator', () => {
       })
 
       describe("because 'compensationCharge' is true", () => {
-        describe("and 'eiucSource' is empty", () => {
+        describe("and 'eiucSource' is missing", () => {
           it('throws an error', async () => {
             const invalidPayload = {
               ...payload,
-              compensationCharge: true,
-              eiucSource: ''
+              compensationCharge: true
             }
+            delete invalidPayload.eiucSource
 
             expect(() => new CalculateChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
           })

--- a/test/translators/calculate_charge.translator.test.js
+++ b/test/translators/calculate_charge.translator.test.js
@@ -200,14 +200,15 @@ describe.only('Calculate Charge translator', () => {
         expect(result).to.not.be.an.error()
       })
 
-      describe("if 'compensationCharge' is true", () => {
-        describe("and 'eiucSource' is empty", () => {
+      describe.only("if 'compensationCharge' is true", () => {
+        describe("and 'eiucSource' is missing", () => {
           it('still does not throw an error', async () => {
             const validPayload = {
               ...payload,
-              compensationCharge: false,
-              eiucSource: ''
+              compensationCharge: false
             }
+            delete validPayload.eiucSource
+
             const result = new CalculateChargeTranslator(data(validPayload))
 
             expect(result).to.not.be.an.error()

--- a/test/translators/calculate_charge.translator.test.js
+++ b/test/translators/calculate_charge.translator.test.js
@@ -241,6 +241,18 @@ describe('Calculate Charge translator', () => {
         })
       })
 
+      describe("because 'periodStart' and 'periodEnd' are not in the same financial year", () => {
+        it('throws an error', async () => {
+          const invalidPayload = {
+            ...payload,
+            periodStart: '01-APR-2021',
+            periodEnd: '01-APR-2022'
+          }
+
+          expect(() => new CalculateChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+        })
+      })
+
       describe("because 'compensationCharge' is true", () => {
         describe("and 'eiucSource' is empty", () => {
           it('throws an error', async () => {
@@ -252,18 +264,6 @@ describe('Calculate Charge translator', () => {
 
             expect(() => new CalculateChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
           })
-        })
-      })
-
-      describe("because 'periodStart' and 'periodEnd' are not in the same financial year", () => {
-        it('throws an error', async () => {
-          const invalidPayload = {
-            ...payload,
-            periodStart: '01-APR-2021',
-            periodEnd: '01-APR-2022'
-          }
-
-          expect(() => new CalculateChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
         })
       })
     })

--- a/test/translators/calculate_charge.translator.test.js
+++ b/test/translators/calculate_charge.translator.test.js
@@ -214,6 +214,20 @@ describe('Calculate Charge translator', () => {
             expect(result).to.not.be.an.error()
           })
         })
+
+        describe("and 'waterUndertaker' is missing", () => {
+          it('still does not throw an error', async () => {
+            const validPayload = {
+              ...payload,
+              compensationCharge: false
+            }
+            delete validPayload.waterUndertaker
+
+            const result = new CalculateChargeTranslator(data(validPayload))
+
+            expect(result).to.not.be.an.error()
+          })
+        })
       })
     })
 
@@ -261,6 +275,18 @@ describe('Calculate Charge translator', () => {
               compensationCharge: true
             }
             delete invalidPayload.eiucSource
+
+            expect(() => new CalculateChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+          })
+        })
+
+        describe("and 'waterUndertaker' is missing", () => {
+          it('throws an error', async () => {
+            const invalidPayload = {
+              ...payload,
+              compensationCharge: true
+            }
+            delete invalidPayload.waterUndertaker
 
             expect(() => new CalculateChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
           })


### PR DESCRIPTION
https://trello.com/c/xoHCMKqf

When we first implemented the validation for a charge (the data we send to the rules service to calculate a charge) we simply copied what [version 1](https://github.com/defra/charging-module-api) does.

It has a validation rule which requires `eiucSource` be populated if `compensationCharge` is `true`. For `waterUndertaker`, the rule is simply that it is mandatory.

In fact, the business rule is

> `EIUC Source` and `Water Undertaker` are mandatory for a compensation charge only (i.e. only where `Compensation Charge` is set to TRUE)

Our QA @anwarisse1 spotted during the testing of both version 1 and version 2 this oversight in the validation rules.

This change fixes the issue in this version.