### PR TITLE
Fix admin requests to regime paths return 500

### DIFF
--- a/app/services/authorisation.service.js
+++ b/app/services/authorisation.service.js
@@ -39,7 +39,7 @@
 class AuthorisationService {
   static async go (user = null, regimeSlug = null) {
     const result = { authorised: false, regime: null }
-    if (this._endpointHasNoRegime(regimeSlug) || this._userIsAnAdmin(user)) {
+    if (this._endpointHasNoRegime(regimeSlug)) {
       result.authorised = true
     } else {
       const regime = await this._userAuthorisedRegime(user, regimeSlug)

--- a/db/seeds/02_authorised_systems.js
+++ b/db/seeds/02_authorised_systems.js
@@ -6,6 +6,9 @@ exports.seed = async function (knex) {
   await knex('authorised_systems').del()
   await knex('authorised_systems_regimes').del()
 
+  // Utilized by PostgreSQL, the returning method specifies which column should be returned by the insert method.
+  // It always returns an array which is way we return it to `result` before then setting `adminUserId` to `result[0]`.
+  // http://knexjs.org/#Builder-returning
   const result = await knex('authorised_systems')
     .returning('id')
     .insert({

--- a/db/seeds/02_authorised_systems.js
+++ b/db/seeds/02_authorised_systems.js
@@ -4,13 +4,27 @@ const config = require('../../config/authentication.config')
 
 exports.seed = async function (knex) {
   await knex('authorised_systems').del()
+  await knex('authorised_systems_regimes').del()
 
-  await knex('authorised_systems').insert(
-    {
+  const result = await knex('authorised_systems')
+    .returning('id')
+    .insert({
       client_id: config.adminClientId,
       name: 'admin',
       admin: true,
       status: 'active'
-    }
-  )
+    })
+
+  const adminUserId = result[0]
+
+  // Get all regimes for their ID's
+  const regimes = await knex.select().from('regimes')
+
+  // Authorise the admin user for all regimes
+  for (const regime of regimes) {
+    await knex('authorised_systems_regimes').insert({
+      authorised_system_id: adminUserId,
+      regime_id: regime.id
+    })
+  }
 }

--- a/test/controllers/admin/regimes.controller.test.js
+++ b/test/controllers/admin/regimes.controller.test.js
@@ -66,20 +66,14 @@ describe('Regimes controller', () => {
 
         const payload = JSON.parse(response.payload)
 
+        // In order to authenticate we need to have an admin authorised system so we call
+        // `AuthorisedSystemHelper.addAdminSystem()` in the `beforeEach` block. To reflect the fact an admin user will
+        // always be seeded with authorisations for the existing regimes the helper automatically creates 'wrls' and
+        // links the admin user to it. This is why though it looks like only 3 have been added, we get 4 regimes back
+        // the first of which is 'wrls'
         expect(response.statusCode).to.equal(200)
-        expect(payload.length).to.equal(3)
-        expect(payload[0].slug).to.equal('ice')
-      })
-    })
-
-    describe('When there are no regimes', () => {
-      it('returns an empty list', async () => {
-        const response = await server.inject(options(authToken))
-
-        const payload = JSON.parse(response.payload)
-
-        expect(response.statusCode).to.equal(200)
-        expect(payload.length).to.equal(0)
+        expect(payload.length).to.equal(4)
+        expect(payload[1].slug).to.equal('ice')
       })
     })
   })

--- a/test/services/authorisation.service.test.js
+++ b/test/services/authorisation.service.test.js
@@ -57,12 +57,12 @@ describe('Authorisation service', () => {
     })
 
     describe("and an 'admin' user", () => {
-      it("returns 'authorised' with no regime", async () => {
+      it("returns 'authorised' with a regime", async () => {
         const user = await AuthorisedSystemHelper.addAdminSystem()
         const result = await AuthorisationService.go(user, 'wrls')
 
         expect(result.authorised).to.equal(true)
-        expect(result.regime).to.equal(null)
+        expect(result.regime).to.contain('id')
       })
     })
 

--- a/test/services/show_authorised_system.service.test.js
+++ b/test/services/show_authorised_system.service.test.js
@@ -22,14 +22,16 @@ describe('Show Authorised System service', () => {
 
   describe('When there is a matching authorised system', () => {
     describe("and it's the 'admin'", () => {
-      it('returns a result with no related regimes', async () => {
-        // Add a regime to give assurance the result is not based on the table being empty
-        await RegimeHelper.addRegime('ice', 'Ice')
+      it('returns a result that includes a list of related regimes', async () => {
         const authorisedSystem = await AuthorisedSystemHelper.addAdminSystem()
 
         const result = await ShowAuthorisedSystemService.go(authorisedSystem.id)
 
-        expect(result.regimes.length).to.equal(0)
+        // The admin user's authorisations are created when it's seeded into the db. So, the AuthorisedSystemHelper
+        // automatically handles creating the regime as part of `addAdminSystem()` to replicate how the system would
+        // be setup.
+        expect(result.regimes.length).to.equal(1)
+        expect(result.regimes[0].slug).to.equal('wrls')
       })
     })
 

--- a/test/support/helpers/authorised_system.helper.js
+++ b/test/support/helpers/authorised_system.helper.js
@@ -3,6 +3,8 @@
 const { AuthenticationConfig } = require('../../../config')
 const { AuthorisedSystemModel } = require('../../../app/models')
 
+const RegimeHelper = require('./regime.helper')
+
 /**
  * Use to help with creating `AuthorisedSystem` records
  *
@@ -24,8 +26,9 @@ class AuthorisedSystemHelper {
    */
   static async addAdminSystem (clientId, name = 'admin', status = 'active') {
     const systemId = clientId || AuthenticationConfig.adminClientId
+    const regime = await RegimeHelper.addRegime('wrls', 'water')
 
-    return this._insertSystem(systemId, name, true, status)
+    return this._insertSystem(systemId, name, true, status, [regime])
   }
 
   /**

--- a/test/support/helpers/route.helper.js
+++ b/test/support/helpers/route.helper.js
@@ -84,8 +84,8 @@ class RouteHelper {
     server.route({
       method: 'GET',
       path: '/test/{regimeId}/system',
-      handler: (_request, _h) => {
-        return { type: 'wrls' }
+      handler: (request, _h) => {
+        return { type: request.app.regime.slug }
       },
       options: {
         auth: {


### PR DESCRIPTION
> The short version! If you are an admin user, the regime doesn't get populated so lots of functionality goes 'pop'!

It was spotted during testing that if an attempt is made, for example, to create a bill run for a regime but the client ID used is an `admin` then a `500` response is returned and the request fails.

We've quickly spotted the issue. All `admin` authorised systems are automatically granted access to all regimes. So, when we first implemented authorisations we didn't see the need to link `admin` users to regimes within the database. Our `AuthorisationService` would see an `admin` and respond with ***go!***.

As we have iterated, we've added functionality that determines the regime for paths where its required and adds it to `request.app`, the place recommended by Hapi to store data for the life of a request. But that functionality has mistakenly assumed all requests will be with 'non-admin' authorised system credentials. In these cases, we grab the regime as part of the authorisation process.

We have come to the decision that admin users should be set up in the DB the same way as non-admins. The regimes are rarely if ever going to change. And if we did add one, it's likely we'd be knee-deep in other changes so adding an authorisation to it for the admin users would be a minor thing. Plus it keeps things consistent and means we can keep our authorisation logic as simple as possible.