### PR TITLE
Add stand-in bill run /status endpoint

### DIFF
--- a/app/controllers/presroc/bill_runs.controller.js
+++ b/app/controllers/presroc/bill_runs.controller.js
@@ -26,6 +26,12 @@ class BillRunsController {
 
     return h.response().code(204)
   }
+
+  static async status (_req, h) {
+    const result = { status: 'endpoint not implemented' }
+
+    return h.response(result).code(200)
+  }
 }
 
 module.exports = BillRunsController

--- a/app/routes/bill_run.routes.js
+++ b/app/routes/bill_run.routes.js
@@ -30,6 +30,11 @@ const routes = [
     method: 'POST',
     path: '/v2/{regimeId}/bill-runs/{billRunId}/generate',
     handler: PresrocBillRunsController.generate
+  },
+  {
+    method: 'GET',
+    path: '/v2/{regimeId}/bill-runs/{billRunId}/status',
+    handler: PresrocBillRunsController.status
   }
 ]
 

--- a/test/controllers/presroc/bill_runs.controller.test.js
+++ b/test/controllers/presroc/bill_runs.controller.test.js
@@ -228,14 +228,12 @@ describe('Presroc Bill Runs controller', () => {
     })
 
     describe('When the request is valid', () => {
-      describe('because the summary has not yet been generated', () => {
-        it("returns success status 200 and 'endpoint not implemented'", async () => {
-          const response = await server.inject(options(authToken, billRun.id))
-          const responsePayload = JSON.parse(response.payload)
+      it("returns success status 200 and 'endpoint not implemented'", async () => {
+        const response = await server.inject(options(authToken, billRun.id))
+        const responsePayload = JSON.parse(response.payload)
 
-          expect(response.statusCode).to.equal(200)
-          expect(responsePayload.status).to.equal('endpoint not implemented')
-        })
+        expect(response.statusCode).to.equal(200)
+        expect(responsePayload.status).to.equal('endpoint not implemented')
       })
     })
   })

--- a/test/controllers/presroc/bill_runs.controller.test.js
+++ b/test/controllers/presroc/bill_runs.controller.test.js
@@ -213,4 +213,30 @@ describe('Presroc Bill Runs controller', () => {
       })
     })
   })
+
+  describe('Get bill run status: GET /v2/{regimeId}/bill-runs/{billRunId}/status', () => {
+    const options = (token, billRunId) => {
+      return {
+        method: 'GET',
+        url: `/v2/wrls/bill-runs/${billRunId}/status`,
+        headers: { authorization: `Bearer ${token}` }
+      }
+    }
+
+    beforeEach(async () => {
+      billRun = await BillRunHelper.addBillRun(authorisedSystem.id, regime.id)
+    })
+
+    describe('When the request is valid', () => {
+      describe('because the summary has not yet been generated', () => {
+        it("returns success status 200 and 'endpoint not implemented'", async () => {
+          const response = await server.inject(options(authToken, billRun.id))
+          const responsePayload = JSON.parse(response.payload)
+
+          expect(response.statusCode).to.equal(200)
+          expect(responsePayload.status).to.equal('endpoint not implemented')
+        })
+      })
+    })
+  })
 })


### PR DESCRIPTION
https://trello.com/c/XNqxpZto

This is the first step in adding a `GET /v2/{regime}/bill-run/{id}/status` endpoint to the API.

Before a client system can perform certain actions, the bill run needs to be in the correct state. This endpoint will allow a client system to quickly check just the status of the endpoint, rather than use an endpoint like `GET /v2/{regime}/bill-run/{id}` and all the extra data it pulls through.

There are also actions which are not instantaneous like `/generate`. This endpoint will be more suitable for client systems to 'poll' in order to confirm if the action has completed.

This change does not include logic. It simply adds the controller, route and a basic test. We can then use this as a base to build on.