### PR TITLE
Add bill run status service

### DIFF
--- a/app/services/bill_run_status.service.js
+++ b/app/services/bill_run_status.service.js
@@ -1,0 +1,38 @@
+'use strict'
+
+/**
+ * @module BillRunStatusService
+ */
+
+const { BillRunModel } = require('../models')
+
+/**
+ * Use to locate a bill run, grab its status and return a simple response that contains it.
+ */
+class BillRunStatusService {
+  /**
+   * Initiator method of the service. When called the service will take the bill run id, locate the matching bill run
+   * and return a very simple JSON object that just contains it's status.
+   *
+   * @param {string} billRunId The ID of the bill run to get the status for
+   *
+   * @returns {Object} A JSON object that holds the status of the bill run
+   */
+  static async go (billRunId) {
+    const billRun = await this._billRun(billRunId)
+
+    return this._response(billRun)
+  }
+
+  static async _billRun (billRunId) {
+    return BillRunModel.query().findById(billRunId)
+  }
+
+  static _response (billRun) {
+    return {
+      status: billRun.status
+    }
+  }
+}
+
+module.exports = BillRunStatusService

--- a/app/services/bill_run_status.service.js
+++ b/app/services/bill_run_status.service.js
@@ -4,6 +4,8 @@
  * @module BillRunStatusService
  */
 
+const Boom = require('@hapi/boom')
+
 const { BillRunModel } = require('../models')
 
 /**
@@ -25,7 +27,13 @@ class BillRunStatusService {
   }
 
   static async _billRun (billRunId) {
-    return BillRunModel.query().findById(billRunId)
+    const billRun = await BillRunModel.query().findById(billRunId)
+
+    if (billRun) {
+      return billRun
+    }
+
+    throw Boom.notFound(`Bill run ${billRunId} is unknown.`)
   }
 
   static _response (billRun) {

--- a/app/services/index.js
+++ b/app/services/index.js
@@ -2,6 +2,7 @@
 
 const AuthorisationService = require('./authorisation.service')
 const BillRunService = require('./bill_run.service')
+const BillRunStatusService = require('./bill_run_status.service')
 const CalculateChargeService = require('./calculate_charge.service')
 const CalculateMinimumChargeService = require('./calculate_minimum_charge.service')
 const CognitoJwtToPemService = require('./cognito_jwt_to_pem.service')
@@ -26,6 +27,7 @@ const ValidateBillRunService = require('./validate_bill_run.service')
 module.exports = {
   AuthorisationService,
   BillRunService,
+  BillRunStatusService,
   CalculateChargeService,
   CalculateMinimumChargeService,
   CognitoJwtToPemService,

--- a/test/services/bill_run_status.service.test.js
+++ b/test/services/bill_run_status.service.test.js
@@ -31,4 +31,14 @@ describe('Bill run status service', () => {
       expect(result.status).to.equal(billRun.status)
     })
   })
+
+  describe("When there is no matching 'bill run'", () => {
+    it('throws an error', async () => {
+      const unknownBillRunId = GeneralHelper.uuid4()
+      const err = await BillRunStatusService.go(unknownBillRunId)
+
+      expect(err).to.be.an.error()
+      expect(err.output.payload.message).to.equal(`Bill run ${unknownBillRunId} is unknown.`)
+    })
+  })
 })

--- a/test/services/bill_run_status.service.test.js
+++ b/test/services/bill_run_status.service.test.js
@@ -35,7 +35,7 @@ describe('Bill run status service', () => {
   describe("When there is no matching 'bill run'", () => {
     it('throws an error', async () => {
       const unknownBillRunId = GeneralHelper.uuid4()
-      const err = await BillRunStatusService.go(unknownBillRunId)
+      const err = await expect(BillRunStatusService.go(unknownBillRunId)).to.reject()
 
       expect(err).to.be.an.error()
       expect(err.output.payload.message).to.equal(`Bill run ${unknownBillRunId} is unknown.`)

--- a/test/services/bill_run_status.service.test.js
+++ b/test/services/bill_run_status.service.test.js
@@ -1,0 +1,34 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const { BillRunHelper, DatabaseHelper, GeneralHelper } = require('../support/helpers')
+
+// Thing under test
+const { BillRunStatusService } = require('../../app/services')
+
+describe('Bill run status service', () => {
+  let billRun
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+  })
+
+  describe("When there is a matching 'bill run'", () => {
+    beforeEach(async () => {
+      billRun = await BillRunHelper.addBillRun(GeneralHelper.uuid4(), GeneralHelper.uuid4())
+    })
+
+    it("returns the 'status' for it", async () => {
+      const result = await BillRunStatusService.go(billRun.id)
+
+      expect(result.status).to.equal(billRun.status)
+    })
+  })
+})


### PR DESCRIPTION
https://trello.com/c/XNqxpZto

This is the second step in adding a `GET /v2/{regime}/bill-run/{id}/status` endpoint to the API.

Our convention is to do all work in a service rather than directly in the controller. So, even though it's not the largest of tasks, this change adds a `BillRunStatusService` to the project.