### PR TITLE
Fix bill runs credit and invoice count column type

### DIFF
--- a/db/migrations/20210131154912_alter_bill_runs.js
+++ b/db/migrations/20210131154912_alter_bill_runs.js
@@ -7,9 +7,9 @@ exports.up = async function (knex) {
     .schema
     .alterTable(tableName, table => {
       // Add minimum charge credit and debit value columns
-      table.bigInteger('credit_note_count').notNullable().defaultTo(0)
+      table.integer('credit_note_count').notNullable().defaultTo(0)
       table.bigInteger('credit_note_value').notNullable().defaultTo(0)
-      table.bigInteger('invoice_count').notNullable().defaultTo(0)
+      table.integer('invoice_count').notNullable().defaultTo(0)
       table.bigInteger('invoice_value').notNullable().defaultTo(0)
     })
 }


### PR DESCRIPTION
https://trello.com/c/Z6bexoqw

As part of the **Generate bill summary** work we need to calculate the total number of credit notes and invoices for a particular bill run.

We know that the invoice and credit values need to be `bigint` thanks to userability tests on [version 1](https://github.com/defra/charging-module-api). But we didn't spot when we wrote the migrations that the count columns are also set to `bigint`.

Put simply, we've not really designed and architected this project for handling more than 2147483647 invoices in a single bill run!

So, to make the count columns consistent with what we have done on the `invoice` and `licence` tables this change fixes the migration that added them to the bill runs table.