### PR TITLE
Add bill run status presenter

### DIFF
--- a/app/presenters/bill_run_status.presenter.js
+++ b/app/presenters/bill_run_status.presenter.js
@@ -1,0 +1,20 @@
+'use strict'
+
+/**
+ * @module BillRunStatusPresenter
+ */
+
+const BasePresenter = require('./base.presenter')
+
+/**
+ * Handles formatting the data into the response we send to clients after a bill run status request.
+ */
+class BillRunStatusPresenter extends BasePresenter {
+  _presentation (data) {
+    return {
+      status: data.status
+    }
+  }
+}
+
+module.exports = BillRunStatusPresenter

--- a/app/presenters/index.js
+++ b/app/presenters/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const BasePresenter = require('./base.presenter')
+const BillRunStatusPresenter = require('./bill_run_status.presenter')
 const CalculateChargePresenter = require('./calculate_charge.presenter')
 const CreateBillRunPresenter = require('./create_bill_run.presenter')
 const CreateTransactionPresenter = require('./create_transaction.presenter')
@@ -9,6 +10,7 @@ const RulesServicePresenter = require('./rules_service.presenter')
 
 module.exports = {
   BasePresenter,
+  BillRunStatusPresenter,
   CalculateChargePresenter,
   CreateBillRunPresenter,
   CreateTransactionPresenter,

--- a/app/services/bill_run_status.service.js
+++ b/app/services/bill_run_status.service.js
@@ -7,6 +7,7 @@
 const Boom = require('@hapi/boom')
 
 const { BillRunModel } = require('../models')
+const { BillRunStatusPresenter } = require('../presenters')
 
 /**
  * Use to locate a bill run, grab its status and return a simple response that contains it.
@@ -37,9 +38,9 @@ class BillRunStatusService {
   }
 
   static _response (billRun) {
-    return {
-      status: billRun.status
-    }
+    const presenter = new BillRunStatusPresenter(billRun)
+
+    return presenter.go()
   }
 }
 

--- a/test/presenters/bill_run_status.presenter.test.js
+++ b/test/presenters/bill_run_status.presenter.test.js
@@ -1,0 +1,31 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const { GeneralHelper } = require('../support/helpers')
+
+// Thing under test
+const { BillRunStatusPresenter } = require('../../app/presenters')
+
+describe('Bill run status Presenter', () => {
+  it("returns the 'status' of the bill run", () => {
+    const data = {
+      id: GeneralHelper.uuid4(),
+      region: 'A',
+      bill_run_number: 100001,
+      status: 'intialised'
+    }
+
+    const presenter = new BillRunStatusPresenter(data)
+
+    expect(presenter.go()).to.equal({
+      status: data.status
+    })
+  })
+})


### PR DESCRIPTION
https://trello.com/c/XNqxpZto

This is the third step in adding a `GET /v2/{regime}/bill-run/{id}/status` endpoint to the API.

Our convention is to use a **presenter** to convert data from the service into a response client systems expect. So, even though it's the simplest of conversions, this change adds a `BillRunStatusPresenter` to the project.