### PR TITLE
Fix section126Factor in CalculateChargeTranslator

### DIFF
--- a/app/translators/calculate_charge.translator.js
+++ b/app/translators/calculate_charge.translator.js
@@ -17,6 +17,8 @@ class CalculateChargeTranslator extends BaseTranslator {
 
     // Additional post-getter validation to ensure periodStart and periodEnd are in the same financial year
     this._validateFinancialYear()
+
+    this._validateSection126Factor()
   }
 
   _validateFinancialYear () {
@@ -32,6 +34,19 @@ class CalculateChargeTranslator extends BaseTranslator {
 
     if (error) {
       throw Boom.badData(error)
+    }
+  }
+
+  _validateSection126Factor () {
+    // The property defaults to 1.0 if not set in the request. There is no point converting the object to a string and
+    // then testing it if the value matches the default.
+    if (this.regimeValue11 !== 1.0) {
+      const valueAsString = this.regimeValue11.toString()
+      const regex = new RegExp(/^\d+\.\d{0,3}$/)
+
+      if (!regex.test(valueAsString)) {
+        throw Boom.badData(`section126Factor value of ${valueAsString} has a precision greater than 3`)
+      }
     }
   }
 

--- a/app/translators/calculate_charge.translator.js
+++ b/app/translators/calculate_charge.translator.js
@@ -38,15 +38,18 @@ class CalculateChargeTranslator extends BaseTranslator {
   }
 
   _validateSection126Factor () {
-    // The property defaults to 1.0 if not set in the request. There is no point converting the object to a string and
-    // then testing it if the value matches the default.
-    if (this.regimeValue11 !== 1.0) {
-      const valueAsString = this.regimeValue11.toString()
-      const regex = new RegExp(/^\d+\.\d{0,3}$/)
+    const schema = Joi.object({
+      section126Factor: Joi.number().precision(3)
+    })
 
-      if (!regex.test(valueAsString)) {
-        throw Boom.badData(`section126Factor value of ${valueAsString} has a precision greater than 3`)
-      }
+    const data = {
+      section126Factor: this.regimeValue11
+    }
+
+    const { error } = schema.validate(data, { convert: false })
+
+    if (error) {
+      throw Boom.badData(error)
     }
   }
 

--- a/test/translators/calculate_charge.translator.test.js
+++ b/test/translators/calculate_charge.translator.test.js
@@ -297,7 +297,7 @@ describe('Calculate Charge translator', () => {
         it('throws an error', async () => {
           const invalidPayload = {
             ...payload,
-            section126Factor: 1.1234
+            section126Factor: 1.1239
           }
 
           expect(() => new CalculateChargeTranslator(data(invalidPayload))).to.throw(ValidationError)

--- a/test/translators/calculate_charge.translator.test.js
+++ b/test/translators/calculate_charge.translator.test.js
@@ -292,6 +292,17 @@ describe('Calculate Charge translator', () => {
           })
         })
       })
+
+      describe("because 'section126Factor' has more than 3 decimal places", () => {
+        it('throws an error', async () => {
+          const invalidPayload = {
+            ...payload,
+            section126Factor: 1.1234
+          }
+
+          expect(() => new CalculateChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+        })
+      })
     })
   })
 })


### PR DESCRIPTION
Our business rules state that some values should only have a maximum of 3 decimal places. When we re-tested [Version 1](https://github.com/defra/charging-module-api) we found it wasn't doing this validation so we double-checked if it is necessary.

In the case of `section126Factor` it does need to be validated to 3 decimal places. The rules service can handle up to 15. But the transaction file we generate and export has a hard limit of 3 decimal places for this field. So, that is why we are forced to limit the level of precision.

`volume` was the other case. It has a limit of 150 characters in the file and no fixed format!. The rules service's 15 decimal limit still applies but we are happy to let it do the validation.

So, this change fixes the validation for `section126Factor`.