### PR TITLE
Hook bill run status service to controller

### DIFF
--- a/app/controllers/presroc/bill_runs.controller.js
+++ b/app/controllers/presroc/bill_runs.controller.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const {
+  BillRunStatusService,
   CreateBillRunService,
   CreateTransactionService,
   GenerateBillRunService,
@@ -27,8 +28,8 @@ class BillRunsController {
     return h.response().code(204)
   }
 
-  static async status (_req, h) {
-    const result = { status: 'endpoint not implemented' }
+  static async status (req, h) {
+    const result = await BillRunStatusService.go(req.params.billRunId)
 
     return h.response(result).code(200)
   }

--- a/test/controllers/presroc/bill_runs.controller.test.js
+++ b/test/controllers/presroc/bill_runs.controller.test.js
@@ -223,17 +223,28 @@ describe('Presroc Bill Runs controller', () => {
       }
     }
 
-    beforeEach(async () => {
-      billRun = await BillRunHelper.addBillRun(authorisedSystem.id, regime.id)
-    })
-
     describe('When the request is valid', () => {
-      it("returns success status 200 and 'endpoint not implemented'", async () => {
+      it('returns success status 200', async () => {
+        billRun = await BillRunHelper.addBillRun(authorisedSystem.id, regime.id)
+
         const response = await server.inject(options(authToken, billRun.id))
         const responsePayload = JSON.parse(response.payload)
 
         expect(response.statusCode).to.equal(200)
-        expect(responsePayload.status).to.equal('endpoint not implemented')
+        expect(responsePayload.status).to.equal(billRun.status)
+      })
+    })
+
+    describe('When the request is invalid', () => {
+      describe('because the bill run does not exist', () => {
+        it('returns error status 404', async () => {
+          const unknownBillRunId = GeneralHelper.uuid4()
+          const response = await server.inject(options(authToken, unknownBillRunId))
+          const responsePayload = JSON.parse(response.payload)
+
+          expect(response.statusCode).to.equal(404)
+          expect(responsePayload.message).to.equal(`Bill run ${unknownBillRunId} is unknown.`)
+        })
       })
     })
   })


### PR DESCRIPTION
https://trello.com/c/XNqxpZto

This is the final step in adding a `GET /v2/{regime}/bill-run/{id}/status` endpoint to the API.

In this change we hook the `BillRunStatusService` we created to the new `/status` controller we added in the first step.