### PR TITLE
Fix bill run generate request type (PATCH vs POST)

### DIFF
--- a/app/routes/bill_run.routes.js
+++ b/app/routes/bill_run.routes.js
@@ -27,7 +27,7 @@ const routes = [
     handler: PresrocBillRunsController.createTransaction
   },
   {
-    method: 'POST',
+    method: 'PATCH',
     path: '/v2/{regimeId}/bill-runs/{billRunId}/generate',
     handler: PresrocBillRunsController.generate
   },

--- a/test/controllers/presroc/bill_runs.controller.test.js
+++ b/test/controllers/presroc/bill_runs.controller.test.js
@@ -166,15 +166,14 @@ describe('Presroc Bill Runs controller', () => {
     })
   })
 
-  describe('Generate a bill run summary: POST /v2/{regimeId}/bill-runs/{billRunId}/generate', () => {
+  describe('Generate a bill run summary: PATCH /v2/{regimeId}/bill-runs/{billRunId}/generate', () => {
     let payload
 
-    const options = (token, payload, billRunId) => {
+    const options = (token, billRunId) => {
       return {
-        method: 'POST',
+        method: 'PATCH',
         url: `/v2/wrls/bill-runs/${billRunId}/generate`,
-        headers: { authorization: `Bearer ${token}` },
-        payload: payload
+        headers: { authorization: `Bearer ${token}` }
       }
     }
 
@@ -192,7 +191,7 @@ describe('Presroc Bill Runs controller', () => {
           const requestPayload = GeneralHelper.cloneObject(requestFixtures.simple)
           await CreateTransactionService.go(requestPayload, billRun.id, authorisedSystem, regime)
 
-          const response = await server.inject(options(authToken, requestPayload, billRun.id))
+          const response = await server.inject(options(authToken, billRun.id))
 
           expect(response.statusCode).to.equal(204)
         })
@@ -204,7 +203,7 @@ describe('Presroc Bill Runs controller', () => {
         it('returns error status 409', async () => {
           const generatingBillRun = await BillRunHelper.addBillRun(authorisedSystem.id, regime.id, payload.region, 'generating')
 
-          const response = await server.inject(options(authToken, payload, generatingBillRun.id))
+          const response = await server.inject(options(authToken, generatingBillRun.id))
           const responsePayload = JSON.parse(response.payload)
 
           expect(response.statusCode).to.equal(409)


### PR DESCRIPTION
Clearly, @cruikshanks was not paying attention when he reviewed and approved [Create Generate Bill Run Summary endpoint](https://github.com/DEFRA/sroc-charging-module-api/pull/151). The endpoint has been added as a `POST` request when it should have been a `PATCH`.

We are trying to stick to a convention of

- `GET` for any request to view data. The request should also result in no action or changes to the data
- `POST` for any request to create a new record
- `PATCH` for any request which requires no payload, and initiates an action in the service

The `../bill-runs/{id}/generate` meets the criteria for a `PATCH` and we should have added it as such. This change fixes the mistake @cruikshanks let through 😱🤦