### PR TITLE
Fix Invoice deminimis query modifier

### DIFF
--- a/app/models/invoice.model.js
+++ b/app/models/invoice.model.js
@@ -68,8 +68,10 @@ class InvoiceModel extends BaseModel {
        */
       deminimis (query) {
         query
-          .whereRaw('credit_value - debit_value > 0')
-          .whereRaw('credit_value - debit_value < ?', DEMINIMIS_LIMIT)
+          .whereRaw('debit_value - credit_value > 0')
+          .whereRaw('debit_value - credit_value < ?', DEMINIMIS_LIMIT)
+          .whereRaw('subject_to_minimum_charge_credit_value = 0')
+          .whereRaw('subject_to_minimum_charge_debit_value = 0')
       },
 
       /**

--- a/app/models/invoice.model.js
+++ b/app/models/invoice.model.js
@@ -70,8 +70,8 @@ class InvoiceModel extends BaseModel {
         query
           .whereRaw('debit_value - credit_value > 0')
           .whereRaw('debit_value - credit_value < ?', DEMINIMIS_LIMIT)
-          .whereRaw('subject_to_minimum_charge_credit_value = 0')
-          .whereRaw('subject_to_minimum_charge_debit_value = 0')
+          .where('subjectToMinimumChargeCreditValue', '=', 0)
+          .where('subjectToMinimumChargeDebitValue', '=', 0)
       },
 
       /**

--- a/test/models/invoice.model.test.js
+++ b/test/models/invoice.model.test.js
@@ -1,0 +1,64 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const {
+  DatabaseHelper,
+  GeneralHelper,
+  InvoiceHelper
+} = require('../support/helpers')
+
+// Thing under test
+const { InvoiceModel } = require('../../app/models')
+
+describe.only('Invoice Model', () => {
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+  })
+
+  describe('Query modifiers', () => {
+    const billRunId = GeneralHelper.uuid4()
+
+    describe('#Deminimis', () => {
+      describe('when there is a mix of invoices', () => {
+        let deminimisInvoice
+
+        beforeEach(async () => {
+          deminimisInvoice = await InvoiceHelper.addInvoice(billRunId, 'CMA0000001', 2020, 0, 0, 1, 350, 0)
+          await InvoiceHelper.addInvoice(billRunId, 'CMA0000002', 2020, 0, 0, 1, 501, 0)
+          await InvoiceHelper.addInvoice(billRunId, 'CMA0000003', 2020, 1, 350, 0, 0, 0)
+          await InvoiceHelper.addInvoice(billRunId, 'CMA0000004', 2020, 1, 501, 0, 0, 0)
+          await InvoiceHelper.addInvoice(billRunId, 'CMA0000005', 2020, 0, 0, 0, 0, 1)
+        })
+
+        it("only returns those which are 'deminimis'", async () => {
+          const results = await InvoiceModel.query().modify('deminimis')
+
+          expect(results.length).to.equal(1)
+          expect(results[0].id).to.equal(deminimisInvoice.id)
+        })
+      })
+
+      describe('when there no matching invoices', () => {
+        beforeEach(async () => {
+          await InvoiceHelper.addInvoice(billRunId, 'CMA0000002', 2020, 0, 0, 1, 501, 0)
+          await InvoiceHelper.addInvoice(billRunId, 'CMA0000003', 2020, 1, 350, 0, 0, 0)
+          await InvoiceHelper.addInvoice(billRunId, 'CMA0000004', 2020, 1, 501, 0, 0, 0)
+          await InvoiceHelper.addInvoice(billRunId, 'CMA0000005', 2020, 0, 0, 0, 0, 1)
+        })
+
+        it('returns nothing', async () => {
+          const results = await InvoiceModel.query().modify('deminimis')
+
+          expect(results.length).to.equal(0)
+        })
+      })
+    })
+  })
+})

--- a/test/models/invoice.model.test.js
+++ b/test/models/invoice.model.test.js
@@ -31,10 +31,10 @@ describe.only('Invoice Model', () => {
 
         beforeEach(async () => {
           deminimisInvoice = await InvoiceHelper.addInvoice(billRunId, 'CMA0000001', 2020, 0, 0, 1, 350, 0)
-          await InvoiceHelper.addInvoice(billRunId, 'CMA0000002', 2020, 0, 0, 1, 501, 0)
-          await InvoiceHelper.addInvoice(billRunId, 'CMA0000003', 2020, 1, 350, 0, 0, 0)
-          await InvoiceHelper.addInvoice(billRunId, 'CMA0000004', 2020, 1, 501, 0, 0, 0)
-          await InvoiceHelper.addInvoice(billRunId, 'CMA0000005', 2020, 0, 0, 0, 0, 1)
+          await InvoiceHelper.addInvoice(billRunId, 'CMA0000002', 2020, 0, 0, 1, 501, 0) // debit more than 500
+          await InvoiceHelper.addInvoice(billRunId, 'CMA0000003', 2020, 1, 350, 0, 0, 0) // credit less than 500
+          await InvoiceHelper.addInvoice(billRunId, 'CMA0000004', 2020, 1, 501, 0, 0, 0) // credit more than 500
+          await InvoiceHelper.addInvoice(billRunId, 'CMA0000005', 2020, 0, 0, 0, 0, 1) // zero value invoice
         })
 
         it("only returns those which are 'deminimis'", async () => {
@@ -47,10 +47,10 @@ describe.only('Invoice Model', () => {
 
       describe('when there no matching invoices', () => {
         beforeEach(async () => {
-          await InvoiceHelper.addInvoice(billRunId, 'CMA0000002', 2020, 0, 0, 1, 501, 0)
-          await InvoiceHelper.addInvoice(billRunId, 'CMA0000003', 2020, 1, 350, 0, 0, 0)
-          await InvoiceHelper.addInvoice(billRunId, 'CMA0000004', 2020, 1, 501, 0, 0, 0)
-          await InvoiceHelper.addInvoice(billRunId, 'CMA0000005', 2020, 0, 0, 0, 0, 1)
+          await InvoiceHelper.addInvoice(billRunId, 'CMA0000002', 2020, 0, 0, 1, 501, 0) // debit more than 500
+          await InvoiceHelper.addInvoice(billRunId, 'CMA0000003', 2020, 1, 350, 0, 0, 0) // credit less than 500
+          await InvoiceHelper.addInvoice(billRunId, 'CMA0000004', 2020, 1, 501, 0, 0, 0) // credit more than 500
+          await InvoiceHelper.addInvoice(billRunId, 'CMA0000005', 2020, 0, 0, 0, 0, 1) // zero value invoice
         })
 
         it('returns nothing', async () => {

--- a/test/models/invoice.model.test.js
+++ b/test/models/invoice.model.test.js
@@ -17,7 +17,7 @@ const {
 // Thing under test
 const { InvoiceModel } = require('../../app/models')
 
-describe.only('Invoice Model', () => {
+describe('Invoice Model', () => {
   beforeEach(async () => {
     await DatabaseHelper.clean()
   })
@@ -34,7 +34,8 @@ describe.only('Invoice Model', () => {
           await InvoiceHelper.addInvoice(billRunId, 'CMA0000002', 2020, 0, 0, 1, 501, 0) // debit more than 500
           await InvoiceHelper.addInvoice(billRunId, 'CMA0000003', 2020, 1, 350, 0, 0, 0) // credit less than 500
           await InvoiceHelper.addInvoice(billRunId, 'CMA0000004', 2020, 1, 501, 0, 0, 0) // credit more than 500
-          await InvoiceHelper.addInvoice(billRunId, 'CMA0000005', 2020, 0, 0, 0, 0, 1) // zero value invoice
+          await InvoiceHelper.addInvoice(billRunId, 'CMA0000005', 2020, 0, 0, 0, 0, 1) // zero value
+          await InvoiceHelper.addInvoice(billRunId, 'CMA0000006', 2020, 0, 0, 1, 350, 0, 1, 0, 350) // minimum charge
         })
 
         it("only returns those which are 'deminimis'", async () => {
@@ -50,7 +51,24 @@ describe.only('Invoice Model', () => {
           await InvoiceHelper.addInvoice(billRunId, 'CMA0000002', 2020, 0, 0, 1, 501, 0) // debit more than 500
           await InvoiceHelper.addInvoice(billRunId, 'CMA0000003', 2020, 1, 350, 0, 0, 0) // credit less than 500
           await InvoiceHelper.addInvoice(billRunId, 'CMA0000004', 2020, 1, 501, 0, 0, 0) // credit more than 500
-          await InvoiceHelper.addInvoice(billRunId, 'CMA0000005', 2020, 0, 0, 0, 0, 1) // zero value invoice
+          await InvoiceHelper.addInvoice(billRunId, 'CMA0000005', 2020, 0, 0, 0, 0, 1) // zero value
+          await InvoiceHelper.addInvoice(billRunId, 'CMA0000006', 2020, 0, 0, 1, 350, 0, 1, 0, 350) // minimum charge
+        })
+
+        it('returns nothing', async () => {
+          const results = await InvoiceModel.query().modify('deminimis')
+
+          expect(results.length).to.equal(0)
+        })
+      })
+
+      describe("when there are only 'minimum charge' invoices", () => {
+        beforeEach(async () => {
+          // Minimum charge debit invoice
+          await InvoiceHelper.addInvoice(billRunId, 'CMA0000001', 2020, 0, 0, 1, 350, 0, 1, 0, 350)
+
+          // Minimum charge credit invoice
+          await InvoiceHelper.addInvoice(billRunId, 'CMA0000002', 2020, 1, 350, 0, 0, 0, 1, 350, 0)
         })
 
         it('returns nothing', async () => {

--- a/test/services/generate_bill_run.service.test.js
+++ b/test/services/generate_bill_run.service.test.js
@@ -166,7 +166,8 @@ describe('Generate Bill Run Summary service', () => {
 
     describe('When deminimis applies', () => {
       it("sets the 'deminimisInvoice' flag to true", async () => {
-        payload.volume = '1.22' // should result in a charge of 223
+        rulesServiceStub.restore()
+        RulesServiceHelper.mockValue(Sinon, RulesService, rulesServiceResponse, 499)
         let result = await CreateTransactionService.go(payload, billRun.id, authorisedSystem, regime)
         await GenerateBillRunService.go(billRun.id)
 

--- a/test/services/generate_bill_run.service.test.js
+++ b/test/services/generate_bill_run.service.test.js
@@ -19,7 +19,7 @@ const {
   RulesServiceHelper
 } = require('../support/helpers')
 
-const { BillRunModel, InvoiceModel } = require('../../app/models')
+const { BillRunModel, InvoiceModel, TransactionModel } = require('../../app/models')
 
 const { CreateTransactionService } = require('../../app/services')
 
@@ -166,38 +166,53 @@ describe('Generate Bill Run Summary service', () => {
 
     describe('When deminimis applies', () => {
       it("sets the 'deminimisInvoice' flag to true", async () => {
-        await CreateTransactionService.go(payload, billRun.id, authorisedSystem, regime)
-        const invoice = await InvoiceHelper.addInvoice(billRun.id, customerReference, 2021, 1, 600, 1, 300, 0)
+        payload.volume = '1.22' // should result in a charge of 223
+        let result = await CreateTransactionService.go(payload, billRun.id, authorisedSystem, regime)
         await GenerateBillRunService.go(billRun.id)
 
-        const result = await InvoiceModel.query().findById(invoice.id)
+        result = await TransactionModel.query().select('invoiceId').findById(result.transaction.id)
+        const invoice = await InvoiceModel.query().findById(result.invoiceId)
 
-        expect(result.deminimisInvoice).to.equal(true)
+        expect(invoice.deminimisInvoice).to.equal(true)
       })
     })
 
     describe('When deminimis does not apply', () => {
-      describe('Because the invoice net value is over 500', () => {
+      describe('because the invoice net value is over 500', () => {
         it("leaves the 'deminimisInvoice' flag as false", async () => {
-          await CreateTransactionService.go(payload, billRun.id, authorisedSystem, regime)
-          const invoice = await InvoiceHelper.addInvoice(billRun.id, customerReference, 2021, 1, 900, 1, 300, 0)
+          let result = await CreateTransactionService.go(payload, billRun.id, authorisedSystem, regime)
           await GenerateBillRunService.go(billRun.id)
 
-          const result = await InvoiceModel.query().findById(invoice.id)
+          result = await TransactionModel.query().select('invoiceId').findById(result.transaction.id)
+          const invoice = await InvoiceModel.query().findById(result.invoiceId)
 
-          expect(result.deminimisInvoice).to.equal(false)
+          expect(invoice.deminimisInvoice).to.equal(false)
         })
       })
 
-      describe('Because the invoice net value is under 0', () => {
+      describe('because the invoice net value is under 0', () => {
         it("leaves the 'deminimisInvoice' flag as false", async () => {
-          await CreateTransactionService.go(payload, billRun.id, authorisedSystem, regime)
-          const invoice = await InvoiceHelper.addInvoice(billRun.id, customerReference, 2021, 1, 100, 1, 300, 0)
+          payload.credit = true
+          let result = await CreateTransactionService.go(payload, billRun.id, authorisedSystem, regime)
           await GenerateBillRunService.go(billRun.id)
 
-          const result = await InvoiceModel.query().findById(invoice.id)
+          result = await TransactionModel.query().select('invoiceId').findById(result.transaction.id)
+          const invoice = await InvoiceModel.query().findById(result.invoiceId)
 
-          expect(result.deminimisInvoice).to.equal(false)
+          expect(invoice.deminimisInvoice).to.equal(false)
+        })
+      })
+
+      describe('because the invoice is subject to minimum charge', () => {
+        it("leaves the 'deminimisInvoice' flag as false", async () => {
+          payload.subjectToMinimumCharge = true
+          let result = await CreateTransactionService.go(payload, billRun.id, authorisedSystem, regime)
+          await GenerateBillRunService.go(billRun.id)
+
+          result = await TransactionModel.query().select('invoiceId').findById(result.transaction.id)
+          const invoice = await InvoiceModel.query().findById(result.invoiceId)
+
+          expect(invoice.deminimisInvoice).to.equal(false)
         })
       })
     })

--- a/test/support/helpers/invoice.helper.js
+++ b/test/support/helpers/invoice.helper.js
@@ -14,6 +14,11 @@ class InvoiceHelper {
    * @param {integer} [debitCount] Number of debits in the invoice.
    * @param {integer} [debitValue] Total value of debits in the invoice.
    * @param {integer} [zeroCount] Number of zero value transactions in the invoice.
+   * @param {integer} [subjectToMinimumChargeCount] Number of transactions flagged as 'miniumum charge' in the invoice.
+   * @param {integer} [subjectToMinimumChargeCreditValue] Total value of minimum charge credit transactions in the
+   *  invoice.
+   * @param {integer} [subjectToMinimumChargeDebitValue] Total value of minimum charge debit transactions in the
+   *  invoice.
    *
    * @returns {module:InvoiceModel} The newly created instance of `InvoiceModel`.
    */
@@ -25,7 +30,10 @@ class InvoiceHelper {
     creditValue = 0,
     debitCount = 0,
     debitValue = 0,
-    zeroCount = 0
+    zeroCount = 0,
+    subjectToMinimumChargeCount = 0,
+    subjectToMinimumChargeCreditValue = 0,
+    subjectToMinimumChargeDebitValue = 0
   ) {
     return InvoiceModel.query()
       .insert({
@@ -36,7 +44,10 @@ class InvoiceHelper {
         creditValue,
         debitCount,
         debitValue,
-        zeroCount
+        zeroCount,
+        subjectToMinimumChargeCount,
+        subjectToMinimumChargeCreditValue,
+        subjectToMinimumChargeDebitValue
       })
       .returning('*')
   }


### PR DESCRIPTION
We spotted during testing that the deminimis Objection query modifier in the `InvoiceModel` was not behaving as expected.

The scenario was we had added 3 transactions for the same invoice, all with a value of £1.26. The net value is £3.78 so it should be subject to deminimis. However, the `GenerateBillRunService` didn't pick it up because the modifier included the clause `credit_value - debit_value > 0`. In this scenario that would be

```
  ((0 - 378) = -378) > 0
```

By reversing the calculation, the modifier should behave as expected

```
  ((378 - 0) = 378) > 0
```

This change applies the update and looks at some tests to cover this in future.