### PR TITLE
Fix minimum charge issues in generate bill run

### DIFF
--- a/app/models/invoice.model.js
+++ b/app/models/invoice.model.js
@@ -77,8 +77,14 @@ class InvoiceModel extends BaseModel {
        */
       minimumCharge (query) {
         query
-          .where('subjectToMinimumChargeCreditValue', '<', MINIMUM_CHARGE_LIMIT)
-          .orWhere('subjectToMinimumChargeDebitValue', '<', MINIMUM_CHARGE_LIMIT)
+          .where(() => {
+            this.where('subjectToMinimumChargeCreditValue', '>', 0)
+              .where('subjectToMinimumChargeCreditValue', '<', MINIMUM_CHARGE_LIMIT)
+          })
+          .orWhere(() => {
+            this.where('subjectToMinimumChargeDebitValue', '>', 0)
+              .where('subjectToMinimumChargeDebitValue', '<', MINIMUM_CHARGE_LIMIT)
+          })
       },
 
       /**

--- a/app/services/calculate_minimum_charge.service.js
+++ b/app/services/calculate_minimum_charge.service.js
@@ -56,7 +56,7 @@ class CalculateMinimumChargeService {
     const adjustments = []
 
     // Generate credit and debit adjustments if needed and add them to the adjustments array.
-    // In some scenarios null be added to the array -- we will filter these out before we return.
+    // In some scenarios null will be added to the array -- we will filter these out before we return.
     for (const licence of licences) {
       if (licence.subjectToMinimumChargeCreditValue) {
         adjustments.push(await this._adjustment(licence, licence.creditValue, true))

--- a/app/services/calculate_minimum_charge.service.js
+++ b/app/services/calculate_minimum_charge.service.js
@@ -55,15 +55,19 @@ class CalculateMinimumChargeService {
   static async _createAdjustmentTransactions (licences) {
     const adjustments = []
 
-    /**
-     * Generate credit and debit adjustments and add them to the adjustments array.
-     * If no adjustment is needed then null will be added -- we will filter these out before we return.
-     */
+    // Generate credit and debit adjustments if needed and add them to the adjustments array.
+    // In some scenarios null be added to the array -- we will filter these out before we return.
     for (const licence of licences) {
-      adjustments.push(await this._adjustment(licence, licence.creditValue, true))
-      adjustments.push(await this._adjustment(licence, licence.debitValue, false))
+      if (licence.subjectToMinimumChargeCreditValue) {
+        adjustments.push(await this._adjustment(licence, licence.creditValue, true))
+      }
+
+      if (licence.subjectToMinimumChargeDebitValue) {
+        adjustments.push(await this._adjustment(licence, licence.debitValue, false))
+      }
     }
 
+    // Filter null from the adjustments array and return
     return adjustments.filter(transaction => transaction)
   }
 

--- a/app/services/generate_bill_run.service.js
+++ b/app/services/generate_bill_run.service.js
@@ -27,10 +27,10 @@ class GenerateBillRunService {
   static async _generateBillRun (billRun) {
     await this._setGeneratingStatus(billRun)
 
-    const minimumValueAdjustments = await CalculateMinimumChargeService.go(billRun)
+    const minimumChargeAdjustments = await CalculateMinimumChargeService.go(billRun)
 
     await BillRunModel.transaction(async trx => {
-      await this._saveTransactions(minimumValueAdjustments, trx)
+      await this._saveTransactions(minimumChargeAdjustments, trx)
       await this._summariseBillRun(billRun, trx)
     })
   }

--- a/test/services/calculate_minimum_charge.service.test.js
+++ b/test/services/calculate_minimum_charge.service.test.js
@@ -134,7 +134,7 @@ describe('Calculate Minimum Charge service', () => {
       })
     })
 
-    describe('because minimum charge doesn\'t apply to this transaction', () => {
+    describe("because minimum charge doesn't apply to this transaction", () => {
       it('returns an empty array', async () => {
         await CreateTransactionService.go({ ...payload, subjectToMinimumCharge: false }, billRun.id, authorisedSystem, regime)
 

--- a/test/services/calculate_minimum_charge.service.test.js
+++ b/test/services/calculate_minimum_charge.service.test.js
@@ -4,7 +4,6 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
-const Nock = require('nock')
 
 const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
 const { expect } = Code
@@ -27,6 +26,9 @@ const { presroc: chargeFixtures } = require('../support/fixtures/calculate_charg
 
 const { rulesService: rulesServiceResponse } = chargeFixtures.simple
 
+// Things we need to stub
+const { RulesService } = require('../../app/services')
+
 const MINIMUM_CHARGE_LIMIT = 2500
 
 // Thing under test
@@ -36,27 +38,24 @@ describe('Calculate Minimum Charge service', () => {
   let authorisedSystem
   let regime
   let payload
+  let rulesServiceStub
 
   beforeEach(async () => {
-    // Intercept all requests in this test suite as we don't actually want to call the service. Tell Nock to persist()
-    // the interception rather than remove it after the first request
-    Nock(RulesServiceHelper.url)
-      .post(() => true)
-      .reply(200, rulesServiceResponse)
-      .persist()
+    rulesServiceStub = RulesServiceHelper.mockValue(Sinon, RulesService, rulesServiceResponse, 500)
 
     await DatabaseHelper.clean()
     regime = await RegimeHelper.addRegime('wrls', 'WRLS')
     authorisedSystem = await AuthorisedSystemHelper.addSystem('1234546789', 'system1', [regime])
 
-    // We clone the request fixture as our payload so we have it available for modification in the invalid tests. For
-    // the valid tests we can use it straight as
-    payload = GeneralHelper.cloneObject(requestFixtures.simple)
+    // Clone the request fixture and add subjectToMinimumCharge: true to reduce setup in tests
+    payload = {
+      ...GeneralHelper.cloneObject(requestFixtures.simple),
+      subjectToMinimumCharge: true
+    }
   })
 
   afterEach(async () => {
     Sinon.restore()
-    Nock.cleanAll()
   })
 
   describe('When a minimum charge adjustment is required', () => {
@@ -120,29 +119,30 @@ describe('Calculate Minimum Charge service', () => {
 
     beforeEach(async () => {
       billRun = await BillRunHelper.addBillRun(authorisedSystem.id, regime.id)
-      payload.subjectToMinimumCharge = true
-
-      // We change the rules service mocking so that a large transaction value is returned.
-      Nock.cleanAll()
-      Nock(RulesServiceHelper.url)
-        .post(() => true)
-        .reply(200, {
-          ...rulesServiceResponse,
-          WRLSChargingResponse: {
-            ...rulesServiceResponse.WRLSChargingResponse,
-            chargeValue: 5000
-          }
-        })
-        .persist()
     })
 
-    it('returns an empty array', async () => {
-      await CreateTransactionService.go(payload, billRun.id, authorisedSystem, regime)
+    describe('because the value is over the minimum charge limit', () => {
+      it('returns an empty array', async () => {
+        rulesServiceStub.restore()
+        RulesServiceHelper.mockValue(Sinon, RulesService, rulesServiceResponse, 5000)
+        await CreateTransactionService.go(payload, billRun.id, authorisedSystem, regime)
 
-      const calculatedMinimumCharges = await CalculateMinimumChargeService.go(billRun)
+        const calculatedMinimumCharges = await CalculateMinimumChargeService.go(billRun)
 
-      expect(calculatedMinimumCharges).to.be.be.an.instanceof(Array)
-      expect(calculatedMinimumCharges).to.be.empty()
+        expect(calculatedMinimumCharges).to.be.be.an.instanceof(Array)
+        expect(calculatedMinimumCharges).to.be.empty()
+      })
+    })
+
+    describe('because minimum charge doesn\'t apply to this transaction', () => {
+      it('returns an empty array', async () => {
+        await CreateTransactionService.go({ ...payload, subjectToMinimumCharge: false }, billRun.id, authorisedSystem, regime)
+
+        const calculatedMinimumCharges = await CalculateMinimumChargeService.go(billRun)
+
+        expect(calculatedMinimumCharges).to.be.be.an.instanceof(Array)
+        expect(calculatedMinimumCharges).to.be.empty()
+      })
     })
   })
 

--- a/test/services/generate_bill_run.service.test.js
+++ b/test/services/generate_bill_run.service.test.js
@@ -204,7 +204,7 @@ describe('Generate Bill Run Summary service', () => {
 
     describe('When minimum charge applies', () => {
       it('saves the adjustment transaction to the db', async () => {
-        await CreateTransactionService.go(payload, billRun.id, authorisedSystem, regime)
+        await CreateTransactionService.go({ ...payload, subjectToMinimumCharge: true }, billRun.id, authorisedSystem, regime)
         await GenerateBillRunService.go(billRun.id)
 
         const { transactions } = await BillRunModel.query()

--- a/test/services/generate_bill_run.service.test.js
+++ b/test/services/generate_bill_run.service.test.js
@@ -99,7 +99,7 @@ describe('Generate Bill Run Summary service', () => {
 
     it('correctly summarises debit invoices', async () => {
       rulesServiceStub.restore()
-      RulesServiceHelper.mockValue(Sinon, RulesService, rulesServiceResponse, 500)
+      RulesServiceHelper.mockValue(Sinon, RulesService, rulesServiceResponse, 50000)
       await CreateTransactionService.go(payload, billRun.id, authorisedSystem, regime)
 
       await GenerateBillRunService.go(billRun.id)
@@ -112,7 +112,7 @@ describe('Generate Bill Run Summary service', () => {
 
     it('correctly summarises credit invoices', async () => {
       rulesServiceStub.restore()
-      RulesServiceHelper.mockValue(Sinon, RulesService, rulesServiceResponse, 500)
+      RulesServiceHelper.mockValue(Sinon, RulesService, rulesServiceResponse, 50000)
       await CreateTransactionService.go({ ...payload, credit: true }, billRun.id, authorisedSystem, regime)
 
       await GenerateBillRunService.go(billRun.id)

--- a/test/support/helpers/rules_service.helper.js
+++ b/test/support/helpers/rules_service.helper.js
@@ -27,14 +27,16 @@ class RulesServiceHelper {
    *
    * @param {object} Sinon The instance of Sinon used in test.
    * @param {object} rulesServiceResponse The rules service response fixture used in test.
-   * @param {integer} chargeValue The charge value to be returned from the rules service.
+   * @param {integer} chargeValue The charge value in pence to be returned from the rules service.
+   *
+   * @returns {module:Sinon} A Sinon stub object
    */
   static mockValue (Sinon, RulesService, rulesServiceResponse, chargeValue) {
-    Sinon.stub(RulesService, 'go').returns({
+    return Sinon.stub(RulesService, 'go').returns({
       ...rulesServiceResponse,
       WRLSChargingResponse: {
         ...rulesServiceResponse.WRLSChargingResponse,
-        chargeValue
+        chargeValue: chargeValue / 100
       }
     })
   }


### PR DESCRIPTION
It was found during testing that invoices were being flagged up as minimum charge when they shouldn't have been. This change aims to resolve this:

- We add additional checks to the `InvoiceModel.minimumCharge` modifier to ensure that a minimum credit or debit value does exist;
- We test that a minimum charge value is required before attempting to create a minimum charge transaction.

Note that `rulesServiceHelper.mockValue` has been amended as part of this to help with test -- it now accepts values in pence for consistency (with affected tests changed to reflect this), and it returns a Sinon stub that we can use to `.restore()` the original behaviour before we stub it again (otherwise, we'd need to `Sinon.restore()` which would revert _all_ stub behaviour -- not an issue at present but it could be in future if other things are stubbed).

Also, `minimumValueAdjustments` in `GenerateBillRunService` was renamed to `minimumChargeAdjustments`, as "minimum value" isn't the terminology we use elsewhere.