### PR TITLE
Output generate bill run timing

### DIFF
--- a/app/controllers/presroc/bill_runs.controller.js
+++ b/app/controllers/presroc/bill_runs.controller.js
@@ -22,7 +22,7 @@ class BillRunsController {
 
   static async generate (req, h) {
     await ValidateBillRunService.go(req.params.billRunId)
-    GenerateBillRunService.go(req.params.billRunId)
+    GenerateBillRunService.go(req.params.billRunId, req.server.logger)
 
     return h.response().code(204)
   }

--- a/app/services/generate_bill_run.service.js
+++ b/app/services/generate_bill_run.service.js
@@ -27,12 +27,16 @@ class GenerateBillRunService {
     const billRun = await BillRunModel.query().findById(billRunId)
     await this._generateBillRun(billRun)
 
-    // If a logger object was passed in, measure how long we took and use it to log the time
+    // If a logger object was passed in, calculate the time taken and log it
     if (logger) {
-      const endTime = process.hrtime(startTime)
-      const timeInMs = this._formatTime(endTime)
-      this._logTime(timeInMs, logger)
+      await this._calculateAndLogTime(startTime, logger)
     }
+  }
+
+  static async _calculateAndLogTime (startTime, logger) {
+    const endTime = process.hrtime(startTime)
+    const timeInMs = this._formatTime(endTime)
+    this._logTime(timeInMs, logger)
   }
 
   /**

--- a/test/services/generate_bill_run.service.test.js
+++ b/test/services/generate_bill_run.service.test.js
@@ -219,5 +219,14 @@ describe('Generate Bill Run Summary service', () => {
         expect(adjustmentTransactions.length).to.equal(1)
       })
     })
+
+    it.only('calls the info method of the provided logger', async () => {
+      const loggerFake = { info: Sinon.fake() }
+      await CreateTransactionService.go(payload, billRun.id, authorisedSystem, regime)
+
+      await GenerateBillRunService.go(billRun.id, loggerFake)
+
+      expect(loggerFake.info.callCount).to.equal(1)
+    })
   })
 })

--- a/test/services/generate_bill_run.service.test.js
+++ b/test/services/generate_bill_run.service.test.js
@@ -220,7 +220,7 @@ describe('Generate Bill Run Summary service', () => {
       })
     })
 
-    it.only('calls the info method of the provided logger', async () => {
+    it('calls the info method of the provided logger', async () => {
       const loggerFake = { info: Sinon.fake() }
       await CreateTransactionService.go(payload, billRun.id, authorisedSystem, regime)
 


### PR DESCRIPTION
To help monitor the time taken to generate a bill run, we're adding a feature to log the time it takes.

`GenerateBillRunService` now takes an optional `logger`, intended to be the server `logger` object. If it's present, the service will use the logger's `info` method to log the time taken to generate the bill run.