### PR TITLE
Validate water undertaker is boolean in charge

### DIFF
--- a/app/translators/calculate_charge.translator.js
+++ b/app/translators/calculate_charge.translator.js
@@ -96,7 +96,7 @@ class CalculateChargeTranslator extends BaseTranslator {
       source: Joi.string().required(), // validated in rules service
       twoPartTariff: Joi.boolean().required(),
       volume: Joi.number().min(0).required(),
-      waterUndertaker: Joi.when('compensationCharge', { is: true, then: Joi.boolean().required() }),
+      waterUndertaker: Joi.boolean().when('compensationCharge', { is: true, then: Joi.required() }),
       regime: Joi.string().required() // needed to determine which endpoints to call in the rules service
     })
   }

--- a/test/translators/calculate_charge.translator.test.js
+++ b/test/translators/calculate_charge.translator.test.js
@@ -293,6 +293,18 @@ describe('Calculate Charge translator', () => {
         })
       })
 
+      describe("because 'waterUndertaker' is not a boolean", () => {
+        it('throws an error', async () => {
+          const invalidPayload = {
+            ...payload,
+            compensationCharge: false,
+            waterUndertaker: 'boom'
+          }
+
+          expect(() => new CalculateChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+        })
+      })
+
       describe("because 'section126Factor' has more than 3 decimal places", () => {
         it('throws an error', async () => {
           const invalidPayload = {


### PR DESCRIPTION
The rules around `waterUndertaker` in the create transaction and calculate charge requests are a bit complex. If `compensationCharge` is `true` then `waterUndertaker` must be present and a boolean.

If `compensationCharge` is false, we don't really care. However, it seems the rules service does. Even though it's not needed for the calculation if we send anything other than a boolean value the rules service throws a 500.

That wouldn't be too bad if it also had a useful error message that highlighted `waterUndertaker` as the problem. But it doesn't. 😩

So, we want to avoid our client systems getting any error where the cause is unclear. This change adds validation for `waterUndertaker` so that if present it at least ensures its a boolean.