### PR TITLE
Create View Bill Run Service

### DIFF
--- a/app/models/bill_run.model.js
+++ b/app/models/bill_run.model.js
@@ -78,6 +78,13 @@ class BillRunModel extends BaseModel {
   $empty () {
     return (this.creditCount === 0 && this.debitCount === 0 && this.zeroCount === 0)
   }
+
+  /**
+   * netTotal method provides the net total of the invoice (debit value - credit value)
+   */
+  $netTotal () {
+    return this.debitValue - this.creditValue
+  }
 }
 
 module.exports = BillRunModel

--- a/app/presenters/index.js
+++ b/app/presenters/index.js
@@ -7,6 +7,7 @@ const CreateBillRunPresenter = require('./create_bill_run.presenter')
 const CreateTransactionPresenter = require('./create_transaction.presenter')
 const JsonPresenter = require('./json.presenter')
 const RulesServicePresenter = require('./rules_service.presenter')
+const ViewBillRunPresenter = require('./view_bill_run.presenter')
 
 module.exports = {
   BasePresenter,
@@ -15,5 +16,6 @@ module.exports = {
   CreateBillRunPresenter,
   CreateTransactionPresenter,
   JsonPresenter,
-  RulesServicePresenter
+  RulesServicePresenter,
+  ViewBillRunPresenter
 }

--- a/app/presenters/view_bill_run.presenter.js
+++ b/app/presenters/view_bill_run.presenter.js
@@ -19,6 +19,10 @@ class ViewBillRunPresenter extends BasePresenter {
         status: data.status,
         approvedForBilling: false,
         ruleset: 'presroc',
+        creditNoteCount: data.creditNoteCount,
+        creditNoteValue: data.creditNoteValue,
+        invoiceCount: data.invoiceCount,
+        invoiceValue: data.invoiceValue,
         creditLineCount: data.creditCount,
         creditLineValue: data.creditValue,
         debitLineCount: data.debitCount,
@@ -26,11 +30,7 @@ class ViewBillRunPresenter extends BasePresenter {
         zeroValueLineCount: data.zeroCount,
         netTotal: data.netTotal,
         transactionFileReference: '',
-        invoices: data.invoices,
-        creditNoteCount: data.creditNoteCount,
-        creditNoteValue: data.creditNoteValue,
-        invoiceCount: data.invoiceCount,
-        invoiceValue: data.invoiceValue
+        invoices: data.invoices
       }
     }
   }

--- a/app/presenters/view_bill_run.presenter.js
+++ b/app/presenters/view_bill_run.presenter.js
@@ -11,47 +11,28 @@ const BasePresenter = require('./base.presenter')
  */
 class ViewBillRunPresenter extends BasePresenter {
   _presentation (data) {
-    // TODO: Check about approvedForBilling, preSroc, transactionFileReference
-
-    // Return a combination of _billRun (the 'main' bill run info) and _generated (the invoice-level stats)
-    // _generated will only return the required stats if the bill run stats is 'generated'
     return {
       billRun: {
-        ...this._billRun(data),
-        ...this._generated(data)
-      }
-    }
-  }
-
-  _billRun (data) {
-    return {
-      id: data.id,
-      billRunNumber: data.billRunNumber,
-      region: data.region,
-      status: data.status,
-      approvedForBilling: '???',
-      preSroc: '???',
-      creditLineCount: data.creditCount,
-      creditLineValue: data.creditValue,
-      debitLineCount: data.debitCount,
-      debitLineValue: data.debitValue,
-      zeroValueLineCount: data.zeroCount,
-      netTotal: data.netTotal,
-      transactionFileReference: '???',
-      invoices: data.invoices
-    }
-  }
-
-  _generated (data) {
-    // If the bill run status is 'generated' then we return invoice-level stats to add to the bill run view
-    return data.status === 'generated'
-      ? {
+        id: data.id,
+        billRunNumber: data.billRunNumber,
+        region: data.region,
+        status: data.status,
+        approvedForBilling: false,
+        ruleset: 'presroc',
+        creditLineCount: data.creditCount,
+        creditLineValue: data.creditValue,
+        debitLineCount: data.debitCount,
+        debitLineValue: data.debitValue,
+        zeroValueLineCount: data.zeroCount,
+        netTotal: data.netTotal,
+        transactionFileReference: '',
+        invoices: data.invoices,
         creditNoteCount: data.creditNoteCount,
         creditNoteValue: data.creditNoteValue,
         invoiceCount: data.invoiceCount,
         invoiceValue: data.invoiceValue
       }
-      : {}
+    }
   }
 }
 

--- a/app/presenters/view_bill_run.presenter.js
+++ b/app/presenters/view_bill_run.presenter.js
@@ -51,7 +51,7 @@ class ViewBillRunPresenter extends BasePresenter {
         invoiceCount: data.invoiceCount,
         invoiceValue: data.invoiceValue
       }
-      : ''
+      : {}
   }
 }
 

--- a/app/presenters/view_bill_run.presenter.js
+++ b/app/presenters/view_bill_run.presenter.js
@@ -1,0 +1,58 @@
+'use strict'
+
+/**
+ * @module ViewBillRunPresenter
+ */
+
+const BasePresenter = require('./base.presenter')
+
+/**
+ * Formats the data into the response we send after a view bill run request
+ */
+class ViewBillRunPresenter extends BasePresenter {
+  _presentation (data) {
+    // TODO: Check about approvedForBilling, preSroc, transactionFileReference
+
+    // Return a combination of _billRun (the 'main' bill run info) and _generated (the invoice-level stats)
+    // _generated will only return the required stats if the bill run stats is 'generated'
+    return {
+      billRun: {
+        ...this._billRun(data),
+        ...this._generated(data)
+      }
+    }
+  }
+
+  _billRun (data) {
+    return {
+      id: data.id,
+      billRunNumber: data.billRunNumber,
+      region: data.region,
+      status: data.status,
+      approvedForBilling: '???',
+      preSroc: '???',
+      creditLineCount: data.creditCount,
+      creditLineValue: data.creditValue,
+      debitLineCount: data.debitCount,
+      debitLineValue: data.debitValue,
+      zeroValueLineCount: data.zeroCount,
+      netTotal: data.netTotal,
+      transactionFileReference: '???',
+      invoices: data.invoices
+    }
+  }
+
+  _generated (data) {
+    // If the bill run status is 'generated' then we return invoice-level stats to add to the bill run view
+    return data.status === 'generated'
+      ? {
+        creditNoteCount: data.creditNoteCount,
+        creditNoteValue: data.creditNoteValue,
+        invoiceCount: data.invoiceCount,
+        invoiceValue: data.invoiceValue
+      }
+      : ''
+  }
+}
+
+module.exports = ViewBillRunPresenter

--- a/app/services/index.js
+++ b/app/services/index.js
@@ -23,6 +23,7 @@ const RulesService = require('./rules.service')
 const ShowAuthorisedSystemService = require('./show_authorised_system.service')
 const ShowRegimeService = require('./show_regime.service')
 const ValidateBillRunService = require('./validate_bill_run.service')
+const ViewBillRunService = require('./view_bill_run.service')
 
 module.exports = {
   AuthorisationService,
@@ -47,5 +48,6 @@ module.exports = {
   NextBillRunNumberService,
   ShowAuthorisedSystemService,
   ShowRegimeService,
-  ValidateBillRunService
+  ValidateBillRunService,
+  ViewBillRunService
 }

--- a/app/services/view_bill_run.service.js
+++ b/app/services/view_bill_run.service.js
@@ -10,18 +10,17 @@ const { BillRunModel } = require('../models')
 const { ViewBillRunPresenter } = require('../presenters')
 
 /**
- * Locates a bill run and returns the available details.
+ * Locates a bill run and returns the available details
  */
 class ViewBillRunService {
   /**
-   *
+   * Fetches a bill run based on its id and returns the data needed by the View Bill Run endpoint
    *
    * @param {string} billRunId The id of the bill run we want to view
    *
-   * @returns {Object}
+   * @returns {Object} The requested bill run data
    */
   static async go (billRunId) {
-    // TODO: Create test for the presenter
     const billRun = await this._billRun(billRunId)
 
     return this._billRunResponse(billRun)
@@ -32,6 +31,7 @@ class ViewBillRunService {
       .findById(billRunId)
       .withGraphFetched('invoices')
 
+    // The net total is not persisted in the db so we add in the result of the BillRunModel.$netTotal() method
     if (billRun) {
       return {
         ...billRun,

--- a/app/services/view_bill_run.service.js
+++ b/app/services/view_bill_run.service.js
@@ -21,6 +21,7 @@ class ViewBillRunService {
    * @returns {Object}
    */
   static async go (billRunId) {
+    // TODO: Create test for the presenter
     const billRun = await this._billRun(billRunId)
 
     return this._billRunResponse(billRun)

--- a/app/services/view_bill_run.service.js
+++ b/app/services/view_bill_run.service.js
@@ -29,7 +29,10 @@ class ViewBillRunService {
   static async _billRun (billRunId) {
     const billRun = await BillRunModel.query()
       .findById(billRunId)
-      .withGraphFetched('invoices')
+      .withGraphFetched('invoices.licences')
+      .modifyGraph('invoices.licences', (builder) => {
+        builder.select('id', 'licenceNumber')
+      })
 
     // The net total is not persisted in the db so we add in the result of the BillRunModel.$netTotal() method
     if (billRun) {

--- a/app/services/view_bill_run.service.js
+++ b/app/services/view_bill_run.service.js
@@ -1,0 +1,51 @@
+'use strict'
+
+/**
+ * @module ViewBillRunService
+ */
+
+const Boom = require('@hapi/boom')
+
+const { BillRunModel } = require('../models')
+const { ViewBillRunPresenter } = require('../presenters')
+
+/**
+ * Locates a bill run and returns the available details.
+ */
+class ViewBillRunService {
+  /**
+   *
+   *
+   * @param {string} billRunId The id of the bill run we want to view
+   *
+   * @returns {Object}
+   */
+  static async go (billRunId) {
+    const billRun = await this._billRun(billRunId)
+
+    return this._billRunResponse(billRun)
+  }
+
+  static async _billRun (billRunId) {
+    const billRun = await BillRunModel.query()
+      .findById(billRunId)
+      .withGraphFetched('invoices')
+
+    if (billRun) {
+      return {
+        ...billRun,
+        netTotal: billRun.$netTotal()
+      }
+    }
+
+    throw Boom.notFound(`Bill run ${billRunId} is unknown.`)
+  }
+
+  static _billRunResponse (billRun) {
+    const presenter = new ViewBillRunPresenter(billRun)
+
+    return presenter.go()
+  }
+}
+
+module.exports = ViewBillRunService

--- a/app/services/view_bill_run.service.js
+++ b/app/services/view_bill_run.service.js
@@ -47,7 +47,7 @@ class ViewBillRunService {
         'invoiceCount',
         'invoiceValue'
       )
-      .withGraphFetched('invoices')
+      .withGraphFetched('invoices.licences')
       .modifyGraph('invoices', (builder) => {
         builder.select(
           'id',
@@ -62,7 +62,6 @@ class ViewBillRunService {
           'zeroValueInvoice'
         )
       })
-      .withGraphFetched('invoices.licences')
       .modifyGraph('invoices.licences', (builder) => {
         builder.select(
           'id',

--- a/test/services/view_bill_run.service.test.js
+++ b/test/services/view_bill_run.service.test.js
@@ -1,0 +1,127 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { afterEach, describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const {
+  AuthorisedSystemHelper,
+  BillRunHelper,
+  DatabaseHelper,
+  GeneralHelper,
+  RegimeHelper,
+  RulesServiceHelper
+} = require('../support/helpers')
+
+const { CreateTransactionService } = require('../../app/services')
+
+const { presroc: requestFixtures } = require('../support/fixtures/create_transaction')
+const { presroc: chargeFixtures } = require('../support/fixtures/calculate_charge')
+
+const { rulesService: rulesServiceResponse } = chargeFixtures.simple
+
+// Things we need to stub
+const { RulesService } = require('../../app/services')
+
+// Thing under test
+const { ViewBillRunService } = require('../../app/services')
+
+describe.only('View bill run service', () => {
+  let billRun
+  let payload
+  let regime
+  let authorisedSystem
+  let rulesServiceStub
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+
+    regime = await RegimeHelper.addRegime('wrls', 'WRLS')
+    authorisedSystem = await AuthorisedSystemHelper.addSystem('1234546789', 'system1', [regime])
+
+    // We clone the request fixture as our payload so we have it available for modification in the invalid tests. For
+    // the valid tests we can use it straight as
+    payload = GeneralHelper.cloneObject(requestFixtures.simple)
+  })
+
+  afterEach(async () => {
+    Sinon.restore()
+  })
+
+  describe('When there is a matching bill run', () => {
+    beforeEach(async () => {
+      rulesServiceStub = Sinon.stub(RulesService, 'go').returns(rulesServiceResponse)
+      billRun = await BillRunHelper.addBillRun(GeneralHelper.uuid4(), GeneralHelper.uuid4())
+    })
+
+    it('returns the correct basic info', async () => {
+      const result = await ViewBillRunService.go(billRun.id)
+
+      expect(result.billRun.id).to.equal(billRun.id)
+      expect(result.billRun.region).to.equal(billRun.region)
+      expect(result.billRun.status).to.equal(billRun.status)
+    })
+
+    it('returns correct credit/debit values', async () => {
+      const creditValue = 1000
+      const debitValue = 5000
+
+      rulesServiceStub.restore()
+      RulesServiceHelper.mockValue(Sinon, RulesService, rulesServiceResponse, creditValue)
+      await CreateTransactionService.go({ ...payload, credit: true }, billRun.id, authorisedSystem, regime)
+
+      rulesServiceStub.restore()
+      RulesServiceHelper.mockValue(Sinon, RulesService, rulesServiceResponse, debitValue)
+      await CreateTransactionService.go(payload, billRun.id, authorisedSystem, regime)
+
+      const result = await ViewBillRunService.go(billRun.id)
+
+      expect(result.billRun.creditLineCount).to.equal(1)
+      expect(result.billRun.creditLineValue).to.equal(creditValue)
+      expect(result.billRun.debitLineCount).to.equal(1)
+      expect(result.billRun.debitLineValue).to.equal(debitValue)
+      expect(result.billRun.netTotal).to.equal(debitValue - creditValue)
+    })
+
+    describe('When the bill run has not been generated', () => {
+      it("doesn't return invoice-level info", async () => {
+        const generatingBillRun = await BillRunHelper.addBillRun(authorisedSystem.id, regime.id, payload.region, 'NOT_GENERATED')
+
+        const result = await ViewBillRunService.go(generatingBillRun.id)
+
+        expect(result.billRun.creditNoteCount).to.not.exist()
+        expect(result.billRun.creditNoteValue).to.not.exist()
+        expect(result.billRun.invoiceCount).to.not.exist()
+        expect(result.billRun.invoiceValue).to.not.exist()
+      })
+    })
+
+    describe('When the bill run has been generated', () => {
+      it('returns invoice-level info', async () => {
+        const generatingBillRun = await BillRunHelper.addBillRun(authorisedSystem.id, regime.id, payload.region, 'generated')
+
+        const result = await ViewBillRunService.go(generatingBillRun.id)
+
+        expect(result.billRun.creditNoteCount).to.exist()
+        expect(result.billRun.creditNoteValue).to.exist()
+        expect(result.billRun.invoiceCount).to.exist()
+        expect(result.billRun.invoiceValue).to.exist()
+      })
+    })
+  })
+
+  describe('When there is no matching bill run', () => {
+    it('throws an error', async () => {
+      const unknownBillRunId = GeneralHelper.uuid4()
+      const err = await expect(ViewBillRunService.go(unknownBillRunId)).to.reject()
+
+      expect(err).to.be.an.error()
+      expect(err.output.payload.message).to.equal(`Bill run ${unknownBillRunId} is unknown.`)
+    })
+  })
+})

--- a/test/services/view_bill_run.service.test.js
+++ b/test/services/view_bill_run.service.test.js
@@ -31,7 +31,7 @@ const { RulesService } = require('../../app/services')
 // Thing under test
 const { ViewBillRunService } = require('../../app/services')
 
-describe.only('View bill run service', () => {
+describe('View bill run service', () => {
   let billRun
   let payload
   let regime

--- a/test/services/view_bill_run.service.test.js
+++ b/test/services/view_bill_run.service.test.js
@@ -87,32 +87,6 @@ describe('View bill run service', () => {
       expect(result.billRun.debitLineValue).to.equal(debitValue)
       expect(result.billRun.netTotal).to.equal(debitValue - creditValue)
     })
-
-    describe('When the bill run has not been generated', () => {
-      it("doesn't return invoice-level info", async () => {
-        const generatingBillRun = await BillRunHelper.addBillRun(authorisedSystem.id, regime.id, payload.region, 'NOT_GENERATED')
-
-        const result = await ViewBillRunService.go(generatingBillRun.id)
-
-        expect(result.billRun.creditNoteCount).to.not.exist()
-        expect(result.billRun.creditNoteValue).to.not.exist()
-        expect(result.billRun.invoiceCount).to.not.exist()
-        expect(result.billRun.invoiceValue).to.not.exist()
-      })
-    })
-
-    describe('When the bill run has been generated', () => {
-      it('returns invoice-level info', async () => {
-        const generatingBillRun = await BillRunHelper.addBillRun(authorisedSystem.id, regime.id, payload.region, 'generated')
-
-        const result = await ViewBillRunService.go(generatingBillRun.id)
-
-        expect(result.billRun.creditNoteCount).to.exist()
-        expect(result.billRun.creditNoteValue).to.exist()
-        expect(result.billRun.invoiceCount).to.exist()
-        expect(result.billRun.invoiceValue).to.exist()
-      })
-    })
   })
 
   describe('When there is no matching bill run', () => {

--- a/test/services/view_bill_run.service.test.js
+++ b/test/services/view_bill_run.service.test.js
@@ -114,6 +114,24 @@ describe('View bill run service', () => {
         expect(result.billRun.invoices.length).to.equal(3)
       })
 
+      it('returns the licences under the invoices', async () => {
+        const result = await ViewBillRunService.go(billRun.id)
+
+        const licences = result.billRun.invoices.map(invoice => invoice.licences).flat()
+
+        expect(licences.length).to.equal(3)
+      })
+
+      it('only returns the licence id and number', async () => {
+        const result = await ViewBillRunService.go(billRun.id)
+
+        const licences = result.billRun.invoices.map(invoice => invoice.licences).flat()
+
+        licences.forEach(licence => {
+          expect(licence).to.only.include(['id', 'licenceNumber'])
+        })
+      })
+
       describe('when the bill run is generated', () => {
         it('returns correct invoice-level values', async () => {
           await GenerateBillRunService.go(billRun.id)


### PR DESCRIPTION
We want to set up a 'View Bill Run' endpoint, and the first stage of this is setting up `ViewBillRunService`. This accepts a bill run id and returns the data ready to be returned to the requesting user.