### PR TITLE
Add test only bill run generator

### DIFF
--- a/app/controllers/admin/test/test_bill_run.controller.js
+++ b/app/controllers/admin/test/test_bill_run.controller.js
@@ -11,10 +11,7 @@ class TestBillRunController {
   static async generate (req, h) {
     const result = await CreateBillRunService.go(req.payload, req.auth.credentials.user, req.app.regime)
     const invoiceMix = [
-      {
-        type: 'mixed',
-        count: 2
-      }
+      { type: 'mixed-invoice', count: 2 }
     ]
 
     TestBillRunController._generateBillRun(
@@ -62,18 +59,12 @@ class TestBillRunController {
 
   static async _invoiceEngine (invoice, authorisedSystem, regime) {
     const invoiceData = {
-      data: null,
       invoice,
       authorisedSystem,
       regime
     }
-    if (invoice.type === 'mixed') {
-      invoiceData.data = TestBillRunController._simpleDebitTransaction(invoice)
-      await TestBillRunController._addTransaction(invoiceData)
-      await TestBillRunController._addTransaction(invoiceData)
-
-      invoiceData.data = TestBillRunController._simpleCreditTransaction(invoice)
-      await TestBillRunController._addTransaction(invoiceData)
+    if (invoice.type === 'mixed-invoice') {
+      await TestBillRunController._mixedInvoice(invoiceData)
     }
   }
 
@@ -94,6 +85,15 @@ class TestBillRunController {
     } finally {
       Nock.cleanAll()
     }
+  }
+
+  static async _mixedInvoice (invoiceData) {
+    invoiceData.data = TestBillRunController._simpleDebitTransaction(invoiceData.invoice)
+    await TestBillRunController._addTransaction(invoiceData)
+    await TestBillRunController._addTransaction(invoiceData)
+
+    invoiceData.data = TestBillRunController._simpleCreditTransaction(invoiceData.invoice)
+    await TestBillRunController._addTransaction(invoiceData)
   }
 
   static _simpleDebitTransaction (invoice) {

--- a/app/controllers/admin/test/test_bill_run.controller.js
+++ b/app/controllers/admin/test/test_bill_run.controller.js
@@ -11,23 +11,29 @@ class TestBillRunController {
   static async generate (req, h) {
     const result = await CreateBillRunService.go(req.payload, req.auth.credentials.user, req.app.regime)
 
-    TestBillRunController._generateBillRun(result.billRun.id, req.payload.region, req.auth.credentials.user, req.app.regime)
+    TestBillRunController._generateBillRun(
+      result.billRun.id,
+      req.payload.region,
+      req.auth.credentials.user,
+      req.app.regime,
+      2
+    )
     return h.response(result).code(201)
   }
 
-  static async _generateBillRun (billRunId, region, user, regime) {
-    const invoices = await TestBillRunController._invoiceGenerator(billRunId, region)
+  static async _generateBillRun (billRunId, region, user, regime, invoiceCount) {
+    const invoices = await TestBillRunController._invoiceGenerator(billRunId, region, invoiceCount)
 
     for (let i = 0; i < invoices.length; i++) {
       await TestBillRunController._invoiceEngine(invoices[i], user, regime)
     }
   }
 
-  static _invoiceGenerator (billRunId, region) {
+  static _invoiceGenerator (billRunId, region, invoiceCount) {
     const invoices = []
     let customerIndex = 0
 
-    for (let i = 0; i < 2; i++) {
+    for (let i = 0; i < invoiceCount; i++) {
       customerIndex += 1
       const customerReference = `CM${customerIndex.toString().padStart(9, '0')}`
       const licenceReference = `SROC/TF${i.toString().padStart(4, '0')}`

--- a/app/controllers/admin/test/test_bill_run.controller.js
+++ b/app/controllers/admin/test/test_bill_run.controller.js
@@ -1,14 +1,28 @@
 'use strict'
 
 const { RegimeModel } = require('../../../models')
-const { CreateBillRunService } = require('../../../services')
+const { CreateBillRunService, CreateTransactionService } = require('../../../services')
+
+const Nock = require('nock')
+const { RulesServiceHelper } = require('../../../../test/support/helpers')
+const { presroc: requestFixtures } = require('../../../../test/support/fixtures/create_transaction')
+const { presroc: chargeFixtures } = require('../../../../test/support/fixtures/calculate_charge')
 
 class TestBillRunController {
   static async generate (req, h) {
     const regime = await TestBillRunController._findRegime(req.params.regimeId)
     const result = await CreateBillRunService.go(req.payload, req.auth.credentials.user, regime)
 
+    TestBillRunController._generateBillRun(result.billRun.id, req.payload.region, req.auth.credentials.user, regime)
     return h.response(result).code(201)
+  }
+
+  static async _generateBillRun (billRunId, region, user, regime) {
+    const invoices = await TestBillRunController._invoiceGenerator(billRunId, region)
+
+    for (let i = 0; i < invoices.length; i++) {
+      await TestBillRunController._invoiceEngine(invoices[i], user, regime)
+    }
   }
 
   /**
@@ -26,6 +40,97 @@ class TestBillRunController {
    */
   static _findRegime (regimeSlug) {
     return RegimeModel.query().findOne({ slug: regimeSlug })
+  }
+
+  static _invoiceGenerator (billRunId, region) {
+    const invoices = []
+
+    for (let i = 1; i <= 2; i++) {
+      invoices.push({
+        billRunId,
+        region,
+        customerReference: `CM${i.toString().padStart(9, '0')}`,
+        periodStart: '01-APR-2017',
+        periodEnd: '31-MAR-2018',
+        licences: [
+          {
+            licenceNumber: `SROC/TF${i.toString().padStart(4, '0')}/01`,
+            type: 'mixed'
+          },
+          {
+            licenceNumber: `SROC/TF${i.toString().padStart(4, '0')}/02`,
+            type: 'mixed'
+          }
+        ]
+      })
+      invoices.push({
+        billRunId,
+        region,
+        customerReference: `CM${i.toString().padStart(9, '0')}`,
+        periodStart: '01-APR-2018',
+        periodEnd: '31-MAR-2019',
+        licences: [
+          {
+            licenceNumber: `SROC/TF${i.toString().padStart(4, '0')}/01`,
+            type: 'mixed'
+          },
+          {
+            licenceNumber: `SROC/TF${i.toString().padStart(4, '0')}/02`,
+            type: 'mixed'
+          }
+        ]
+      })
+    }
+
+    return invoices
+  }
+
+  static async _invoiceEngine (invoice, authorisedSystem, regime) {
+    for (let i = 0; i < invoice.licences.length; i++) {
+      const licence = invoice.licences[i]
+      if (licence.type === 'mixed') {
+        const data = TestBillRunController._debitTransaction(invoice, licence)
+        await TestBillRunController._addTransaction(invoice.billRunId, authorisedSystem, regime, data)
+      }
+    }
+  }
+
+  static async _addTransaction (billRunId, authorisedSystem, regime, data) {
+    try {
+      // Intercept all requests in this test suite as we don't actually want to call the service. Tell Nock to persist()
+      // the interception rather than remove it after the first request
+      Nock(RulesServiceHelper.url)
+        .post(() => true)
+        .reply(200, data.response)
+        .persist()
+      await CreateTransactionService.go(data.payload, billRunId, authorisedSystem, regime)
+    } finally {
+      Nock.cleanAll()
+    }
+  }
+
+  static _debitTransaction (invoice, licence) {
+    const result = {
+      payload: {
+        ...requestFixtures.simple,
+        region: invoice.region,
+        customerReference: invoice.customerReference,
+        periodStart: invoice.periodStart,
+        periodEnd: invoice.periodEnd,
+        chargePeriod: `${invoice.periodStart} - ${invoice.periodEnd}`,
+        licenceNumber: licence.licenceNumber,
+        volume: '50.22'
+      },
+      response: {
+        ...chargeFixtures.simple.rulesService,
+        WRLSChargingResponse: {
+          ...chargeFixtures.simple.rulesService.WRLSChargingResponse,
+          chargeValue: 91.82
+        }
+      }
+    }
+
+    return result
   }
 }
 

--- a/app/controllers/admin/test/test_bill_run.controller.js
+++ b/app/controllers/admin/test/test_bill_run.controller.js
@@ -13,7 +13,8 @@ class TestBillRunController {
     const result = await CreateBillRunService.go(req.payload, req.auth.credentials.user, req.app.regime)
     const invoiceMix = [
       { type: 'mixed-invoice', count: 2 },
-      { type: 'mixed-credit', count: 2 }
+      { type: 'mixed-credit', count: 2 },
+      { type: 'zero-value', count: 2 }
     ]
 
     TestBillRunController._generateBillRun(
@@ -73,6 +74,9 @@ class TestBillRunController {
       case 'mixed-credit':
         await TestBillRunController._mixedCredit(invoiceData)
         break
+      case 'zero-value':
+        await TestBillRunController._zeroValueInvoice(invoiceData)
+        break
       default:
         throw Boom.badRequest(`Unknown invoice type '${invoice.type}'`)
     }
@@ -95,6 +99,19 @@ class TestBillRunController {
     } finally {
       Nock.cleanAll()
     }
+  }
+
+  static async _zeroValueInvoice (invoiceData) {
+    const transactionData = [
+      invoiceData.invoice,
+      '0',
+      0
+    ]
+
+    invoiceData.data = TestBillRunController._transactionData(...transactionData, false)
+    await TestBillRunController._addTransaction(invoiceData)
+    await TestBillRunController._addTransaction(invoiceData)
+    await TestBillRunController._addTransaction(invoiceData)
   }
 
   static async _mixedInvoice (invoiceData) {

--- a/app/controllers/admin/test/test_bill_run.controller.js
+++ b/app/controllers/admin/test/test_bill_run.controller.js
@@ -51,10 +51,8 @@ class TestBillRunController {
           customerReference: customerReference,
           periodStart: '01-APR-2018',
           periodEnd: '31-MAR-2019',
-          licences: [{
-            licenceNumber: licenceNumber,
-            type: options.type
-          }]
+          licenceNumber: licenceNumber,
+          type: options.type
         })
       }
     })
@@ -63,16 +61,13 @@ class TestBillRunController {
   }
 
   static async _invoiceEngine (invoice, authorisedSystem, regime) {
-    for (let i = 0; i < invoice.licences.length; i++) {
-      const licence = invoice.licences[i]
-      if (licence.type === 'mixed') {
-        let data = TestBillRunController._simpleDebitTransaction(invoice, licence)
-        await TestBillRunController._addTransaction(invoice.billRunId, authorisedSystem, regime, data)
-        await TestBillRunController._addTransaction(invoice.billRunId, authorisedSystem, regime, data)
+    if (invoice.type === 'mixed') {
+      let data = TestBillRunController._simpleDebitTransaction(invoice)
+      await TestBillRunController._addTransaction(invoice.billRunId, authorisedSystem, regime, data)
+      await TestBillRunController._addTransaction(invoice.billRunId, authorisedSystem, regime, data)
 
-        data = TestBillRunController._simpleCreditTransaction(invoice, licence)
-        await TestBillRunController._addTransaction(invoice.billRunId, authorisedSystem, regime, data)
-      }
+      data = TestBillRunController._simpleCreditTransaction(invoice)
+      await TestBillRunController._addTransaction(invoice.billRunId, authorisedSystem, regime, data)
     }
   }
 
@@ -90,18 +85,18 @@ class TestBillRunController {
     }
   }
 
-  static _simpleDebitTransaction (invoice, licence) {
-    return TestBillRunController._baseTransaction(invoice, licence, '50.22', 91.82)
+  static _simpleDebitTransaction (invoice) {
+    return TestBillRunController._baseTransaction(invoice, '50.22', 91.82)
   }
 
-  static _simpleCreditTransaction (invoice, licence) {
-    return TestBillRunController._baseTransaction(invoice, licence, '20.5865', 44.32, true)
+  static _simpleCreditTransaction (invoice) {
+    return TestBillRunController._baseTransaction(invoice, '20.5865', 44.32, true)
   }
 
-  static _baseTransaction (invoice, licence, volume, chargeValue, credit = false) {
+  static _baseTransaction (invoice, volume, chargeValue, credit = false) {
     const result = {
       payload: {
-        ...TestBillRunController._basePayload(invoice, licence),
+        ...TestBillRunController._basePayload(invoice),
         credit,
         volume
       },
@@ -114,7 +109,7 @@ class TestBillRunController {
     return result
   }
 
-  static _basePayload (invoice, licence) {
+  static _basePayload (invoice) {
     return {
       ...requestFixtures.simple,
       region: invoice.region,
@@ -122,7 +117,7 @@ class TestBillRunController {
       periodStart: invoice.periodStart,
       periodEnd: invoice.periodEnd,
       chargePeriod: `${invoice.periodStart} - ${invoice.periodEnd}`,
-      licenceNumber: licence.licenceNumber
+      licenceNumber: invoice.licenceNumber
     }
   }
 

--- a/app/controllers/admin/test/test_bill_run.controller.js
+++ b/app/controllers/admin/test/test_bill_run.controller.js
@@ -1,0 +1,32 @@
+'use strict'
+
+const { RegimeModel } = require('../../../models')
+const { CreateBillRunService } = require('../../../services')
+
+class TestBillRunController {
+  static async generate (req, h) {
+    const regime = await TestBillRunController._findRegime(req.params.regimeId)
+    const result = await CreateBillRunService.go(req.payload, req.auth.credentials.user, regime)
+
+    return h.response(result).code(201)
+  }
+
+  /**
+   * Find the regime based on regime 'slug' used in request path
+   *
+   * For our normal endpoints the regime is pre-loaded into Hapi's `request.app` space by the `AuthorisationPlugin`. But
+   * this endpoint is only acessible by an `admin` user who is not linked to any regimes, as it can access them all.
+   *
+   * So, the request will be authorised but the authorisation plugin won't have returned a regime. This is why we need
+   * to find it within the controller as part of the request.
+   *
+   * @param {string} regimeSlug The regime 'slug' used in the request path
+   *
+   * @returns {module:RegimeModel} An instance of `RegimeModel` for the matching regime
+   */
+  static _findRegime (regimeSlug) {
+    return RegimeModel.query().findOne({ slug: regimeSlug })
+  }
+}
+
+module.exports = TestBillRunController

--- a/app/controllers/admin/test/test_bill_run.controller.js
+++ b/app/controllers/admin/test/test_bill_run.controller.js
@@ -98,28 +98,36 @@ class TestBillRunController {
   }
 
   static async _mixedInvoice (invoiceData) {
-    invoiceData.data = TestBillRunController._simpleTransaction(invoiceData.invoice)
+    const transactionData = [
+      invoiceData.invoice,
+      '50.22',
+      91.82
+    ]
+
+    invoiceData.data = TestBillRunController._transactionData(...transactionData, false)
     await TestBillRunController._addTransaction(invoiceData)
     await TestBillRunController._addTransaction(invoiceData)
 
-    invoiceData.data = TestBillRunController._simpleTransaction(invoiceData.invoice, true)
+    invoiceData.data = TestBillRunController._transactionData(...transactionData, true)
     await TestBillRunController._addTransaction(invoiceData)
   }
 
   static async _mixedCredit (invoiceData) {
-    invoiceData.data = TestBillRunController._simpleTransaction(invoiceData.invoice, true)
+    const transactionData = [
+      invoiceData.invoice,
+      '50.22',
+      91.82
+    ]
+
+    invoiceData.data = TestBillRunController._transactionData(...transactionData, true)
     await TestBillRunController._addTransaction(invoiceData)
     await TestBillRunController._addTransaction(invoiceData)
 
-    invoiceData.data = TestBillRunController._simpleTransaction(invoiceData.invoice)
+    invoiceData.data = TestBillRunController._transactionData(...transactionData, false)
     await TestBillRunController._addTransaction(invoiceData)
   }
 
-  static _simpleTransaction (invoice, credit = false) {
-    return TestBillRunController._baseTransaction(invoice, '50.22', 91.82, credit)
-  }
-
-  static _baseTransaction (invoice, volume, chargeValue, credit = false) {
+  static _transactionData (invoice, volume, chargeValue, credit) {
     const result = {
       payload: {
         ...TestBillRunController._basePayload(invoice),

--- a/app/controllers/admin/test/test_bill_run.controller.js
+++ b/app/controllers/admin/test/test_bill_run.controller.js
@@ -5,21 +5,14 @@ const { BillRunGenerator } = require('../../../../test/support/generators')
 
 class TestBillRunController {
   static async generate (req, h) {
-    const result = await CreateBillRunService.go(req.payload, req.auth.credentials.user, req.app.regime)
-
-    const payload = {
-      region: req.payload.region,
-      mix: [
-        { type: 'mixed-invoice', count: 2 },
-        { type: 'mixed-credit', count: 2 },
-        { type: 'zero-value', count: 2 },
-        { type: 'deminimis', count: 2 },
-        { type: 'minimum-charge', count: 2 }
-      ]
-    }
+    const result = await CreateBillRunService.go(
+      { region: req.payload.region },
+      req.auth.credentials.user,
+      req.app.regime
+    )
 
     BillRunGenerator.go(
-      payload,
+      req.payload,
       result.billRun.id,
       req.auth.credentials.user,
       req.app.regime,

--- a/app/controllers/admin/test/test_bill_run.controller.js
+++ b/app/controllers/admin/test/test_bill_run.controller.js
@@ -14,7 +14,8 @@ class TestBillRunController {
     const invoiceMix = [
       { type: 'mixed-invoice', count: 2 },
       { type: 'mixed-credit', count: 2 },
-      { type: 'zero-value', count: 2 }
+      { type: 'zero-value', count: 2 },
+      { type: 'deminimis', count: 2 }
     ]
 
     TestBillRunController._generateBillRun(
@@ -77,6 +78,9 @@ class TestBillRunController {
       case 'zero-value':
         await TestBillRunController._zeroValueInvoice(invoiceData)
         break
+      case 'deminimis':
+        await TestBillRunController._deminimisInvoice(invoiceData)
+        break
       default:
         throw Boom.badRequest(`Unknown invoice type '${invoice.type}'`)
     }
@@ -106,6 +110,19 @@ class TestBillRunController {
       invoiceData.invoice,
       '0',
       0
+    ]
+
+    invoiceData.data = TestBillRunController._transactionData(...transactionData, false)
+    await TestBillRunController._addTransaction(invoiceData)
+    await TestBillRunController._addTransaction(invoiceData)
+    await TestBillRunController._addTransaction(invoiceData)
+  }
+
+  static async _deminimisInvoice (invoiceData) {
+    const transactionData = [
+      invoiceData.invoice,
+      '0.5865',
+      1.26
     ]
 
     invoiceData.data = TestBillRunController._transactionData(...transactionData, false)

--- a/app/controllers/admin/test/test_bill_run.controller.js
+++ b/app/controllers/admin/test/test_bill_run.controller.js
@@ -1,235 +1,32 @@
 'use strict'
 
-const { CreateBillRunService, CreateTransactionService } = require('../../../services')
-
-const Boom = require('@hapi/boom')
-const Nock = require('nock')
-const { RulesServiceHelper } = require('../../../../test/support/helpers')
-const { presroc: requestFixtures } = require('../../../../test/support/fixtures/create_transaction')
-const { presroc: chargeFixtures } = require('../../../../test/support/fixtures/calculate_charge')
+const { CreateBillRunService } = require('../../../services')
+const { BillRunGenerator } = require('../../../../test/support/generators')
 
 class TestBillRunController {
   static async generate (req, h) {
     const result = await CreateBillRunService.go(req.payload, req.auth.credentials.user, req.app.regime)
-    const invoiceMix = [
-      { type: 'mixed-invoice', count: 2 },
-      { type: 'mixed-credit', count: 2 },
-      { type: 'zero-value', count: 2 },
-      { type: 'deminimis', count: 2 },
-      { type: 'minimum-charge', count: 2 }
-    ]
 
-    TestBillRunController._generateBillRun(
+    const payload = {
+      region: req.payload.region,
+      mix: [
+        { type: 'mixed-invoice', count: 2 },
+        { type: 'mixed-credit', count: 2 },
+        { type: 'zero-value', count: 2 },
+        { type: 'deminimis', count: 2 },
+        { type: 'minimum-charge', count: 2 }
+      ]
+    }
+
+    BillRunGenerator.go(
+      payload,
       result.billRun.id,
-      req.payload.region,
       req.auth.credentials.user,
       req.app.regime,
-      invoiceMix,
       req.server.logger
     )
+
     return h.response(result).code(201)
-  }
-
-  static async _generateBillRun (billRunId, region, user, regime, invoiceMix, logger) {
-    // Mark the start time for later logging
-    const startTime = process.hrtime.bigint()
-
-    const invoices = await TestBillRunController._invoiceGenerator(billRunId, region, invoiceMix)
-
-    for (let i = 0; i < invoices.length; i++) {
-      await TestBillRunController._invoiceEngine(invoices[i], user, regime)
-    }
-
-    await this._calculateAndLogTime(logger, billRunId, startTime)
-  }
-
-  static async _calculateAndLogTime (logger, billRunId, startTime) {
-    const endTime = process.hrtime.bigint()
-    const timeTakenNs = endTime - startTime
-    const timeTakenMs = timeTakenNs / 1000000n
-
-    logger.info(`Time taken to auto-create bill run '${billRunId}': ${timeTakenMs}ms`)
-  }
-
-  static _invoiceGenerator (billRunId, region, invoiceMix) {
-    const invoices = []
-    let customerIndex = 0
-
-    invoiceMix.forEach(options => {
-      for (let i = 0; i < options.count; i++) {
-        customerIndex += 1
-        const customerReference = `CM${customerIndex.toString().padStart(9, '0')}`
-        const licenceNumber = `SROC/TF${customerIndex.toString().padStart(4, '0')}/01`
-
-        invoices.push({
-          billRunId,
-          region,
-          customerReference: customerReference,
-          periodStart: '01-APR-2018',
-          periodEnd: '31-MAR-2019',
-          licenceNumber: licenceNumber,
-          type: options.type
-        })
-      }
-    })
-
-    return invoices
-  }
-
-  static async _invoiceEngine (invoice, authorisedSystem, regime) {
-    const invoiceData = {
-      invoice,
-      authorisedSystem,
-      regime
-    }
-
-    switch (invoice.type) {
-      case 'mixed-invoice':
-        await TestBillRunController._mixedInvoice(invoiceData)
-        break
-      case 'mixed-credit':
-        await TestBillRunController._mixedCredit(invoiceData)
-        break
-      case 'zero-value':
-        await TestBillRunController._zeroValueInvoice(invoiceData)
-        break
-      case 'deminimis':
-        await TestBillRunController._deminimisInvoice(invoiceData)
-        break
-      case 'minimum-charge':
-        await TestBillRunController._minimumChargeInvoice(invoiceData)
-        break
-      default:
-        throw Boom.badRequest(`Unknown invoice type '${invoice.type}'`)
-    }
-  }
-
-  static async _addTransaction (invoiceData) {
-    try {
-      // Intercept all requests in this test suite as we don't actually want to call the service. Tell Nock to persist()
-      // the interception rather than remove it after the first request
-      Nock(RulesServiceHelper.url)
-        .post(() => true)
-        .reply(200, invoiceData.data.response)
-        .persist()
-      await CreateTransactionService.go(
-        invoiceData.data.payload,
-        invoiceData.invoice.billRunId,
-        invoiceData.authorisedSystem,
-        invoiceData.regime
-      )
-    } finally {
-      Nock.cleanAll()
-    }
-  }
-
-  static async _zeroValueInvoice (invoiceData) {
-    const transactionData = [
-      invoiceData.invoice,
-      '0',
-      0
-    ]
-
-    invoiceData.data = TestBillRunController._transactionData(...transactionData, false, false)
-    await TestBillRunController._addTransaction(invoiceData)
-    await TestBillRunController._addTransaction(invoiceData)
-    await TestBillRunController._addTransaction(invoiceData)
-  }
-
-  static async _deminimisInvoice (invoiceData) {
-    const transactionData = [
-      invoiceData.invoice,
-      '0.5865',
-      1.26
-    ]
-
-    invoiceData.data = TestBillRunController._transactionData(...transactionData, false, false)
-    await TestBillRunController._addTransaction(invoiceData)
-    await TestBillRunController._addTransaction(invoiceData)
-    await TestBillRunController._addTransaction(invoiceData)
-  }
-
-  static async _minimumChargeInvoice (invoiceData) {
-    const transactionData = [
-      invoiceData.invoice,
-      '0.5865',
-      1.26
-    ]
-
-    invoiceData.data = TestBillRunController._transactionData(...transactionData, false, true)
-    await TestBillRunController._addTransaction(invoiceData)
-    await TestBillRunController._addTransaction(invoiceData)
-
-    invoiceData.data = TestBillRunController._transactionData(...transactionData, true, true)
-    await TestBillRunController._addTransaction(invoiceData)
-  }
-
-  static async _mixedInvoice (invoiceData) {
-    const transactionData = [
-      invoiceData.invoice,
-      '50.22',
-      91.82
-    ]
-
-    invoiceData.data = TestBillRunController._transactionData(...transactionData, false, false)
-    await TestBillRunController._addTransaction(invoiceData)
-    await TestBillRunController._addTransaction(invoiceData)
-
-    invoiceData.data = TestBillRunController._transactionData(...transactionData, true, false)
-    await TestBillRunController._addTransaction(invoiceData)
-  }
-
-  static async _mixedCredit (invoiceData) {
-    const transactionData = [
-      invoiceData.invoice,
-      '50.22',
-      91.82
-    ]
-
-    invoiceData.data = TestBillRunController._transactionData(...transactionData, true, false)
-    await TestBillRunController._addTransaction(invoiceData)
-    await TestBillRunController._addTransaction(invoiceData)
-
-    invoiceData.data = TestBillRunController._transactionData(...transactionData, false, false)
-    await TestBillRunController._addTransaction(invoiceData)
-  }
-
-  static _transactionData (invoice, volume, chargeValue, credit, subjectToMinimumCharge) {
-    const result = {
-      payload: {
-        ...TestBillRunController._basePayload(invoice),
-        credit,
-        volume,
-        subjectToMinimumCharge
-      },
-      response: {
-        ...TestBillRunController._baseResponse()
-      }
-    }
-    result.response.WRLSChargingResponse.chargeValue = chargeValue
-
-    return result
-  }
-
-  static _basePayload (invoice) {
-    return {
-      ...requestFixtures.simple,
-      region: invoice.region,
-      customerReference: invoice.customerReference,
-      periodStart: invoice.periodStart,
-      periodEnd: invoice.periodEnd,
-      chargePeriod: `${invoice.periodStart} - ${invoice.periodEnd}`,
-      licenceNumber: invoice.licenceNumber
-    }
-  }
-
-  static _baseResponse () {
-    return {
-      ...chargeFixtures.simple.rulesService,
-      WRLSChargingResponse: {
-        ...chargeFixtures.simple.rulesService.WRLSChargingResponse
-      }
-    }
   }
 }
 

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -6,6 +6,7 @@ const RegimesController = require('./admin/regimes.controller')
 const AuthorisedSystemsController = require('./admin/authorised_systems.controller')
 const AirbrakeController = require('./admin/health/airbrake.controller')
 const DatabaseController = require('./admin/health/database.controller')
+const TestBillRunController = require('./admin/test/test_bill_run.controller')
 const NotSupportedController = require('./not_supported.controller')
 const PresrocBillRunsController = require('./presroc/bill_runs.controller')
 const PresrocCalculateChargeController = require('./presroc/calculate_charge.controller')
@@ -16,6 +17,7 @@ module.exports = {
   AirbrakeController,
   AuthorisedSystemsController,
   DatabaseController,
+  TestBillRunController,
   PresrocBillRunsController,
   PresrocCalculateChargeController,
   NotSupportedController

--- a/app/plugins/router.plugin.js
+++ b/app/plugins/router.plugin.js
@@ -18,6 +18,7 @@ const {
   DatabaseRoutes,
   RegimeRoutes,
   RootRoutes,
+  TestRoutes,
   TransactionRoutes,
   CalculateChargeRoutes
 } = require('../routes')
@@ -28,6 +29,7 @@ const routes = [
   ...AuthorisedSystemRoutes,
   ...BillRunRoutes,
   ...DatabaseRoutes,
+  ...TestRoutes,
   ...TransactionRoutes,
   ...RegimeRoutes,
   ...CalculateChargeRoutes

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -6,6 +6,7 @@ const BillRunRoutes = require('./bill_run.routes')
 const DatabaseRoutes = require('./database.routes')
 const RegimeRoutes = require('./regime.routes')
 const RootRoutes = require('./root.routes')
+const TestRoutes = require('./test.routes')
 const TransactionRoutes = require('./transaction.routes')
 const CalculateChargeRoutes = require('./calculate_charge.routes')
 
@@ -16,6 +17,7 @@ module.exports = {
   DatabaseRoutes,
   RegimeRoutes,
   RootRoutes,
+  TestRoutes,
   TransactionRoutes,
   CalculateChargeRoutes
 }

--- a/app/routes/test.routes.js
+++ b/app/routes/test.routes.js
@@ -1,0 +1,21 @@
+'use strict'
+
+const {
+  TestBillRunController
+} = require('../controllers')
+
+const routes = [
+  {
+    method: 'POST',
+    path: '/admin/test/{regimeId}/bill-runs/generate',
+    handler: TestBillRunController.generate,
+    options: {
+      description: 'Used by the delivery team to automatically generate bill runs for testing.',
+      auth: {
+        scope: ['admin']
+      }
+    }
+  }
+]
+
+module.exports = routes

--- a/test/controllers/admin/test/test_bill_run.controller.test.js
+++ b/test/controllers/admin/test/test_bill_run.controller.test.js
@@ -84,20 +84,11 @@ describe('Test Bill Run Controller', () => {
       // them
       //
       // So, the only way we could see to keep a test for this endpoint was to add in an arbitrary delay. In this case
-      // we keep querying the bill run record until its numbers tell us all transactions have been added. Just in case,
-      // we also have a quit control to kill the loop should something go wrong.
-      let finished = false
-      let quitCount = 0
-      let billRun
-      do {
-        billRun = await BillRunModel.query().findById(responsePayload.billRun.id)
-        if (billRun.debitCount + billRun.creditCount + billRun.zeroCount === 15) {
-          finished = true
-        }
-        quitCount += 1
-      } while (!finished || quitCount > 1000)
+      // we 'sleep' for 1 second (the generate process takes approx 300ms) and then continue. It seems any larger sleep
+      // value causes the tests to through a timeout error.
+      await sleep(1000)
 
-      billRun = await BillRunModel.query().findById(responsePayload.billRun.id)
+      const billRun = await BillRunModel.query().findById(responsePayload.billRun.id)
       const invoices = await billRun.$relatedQuery('invoices')
       const transactions = await billRun.$relatedQuery('transactions')
 
@@ -111,4 +102,8 @@ describe('Test Bill Run Controller', () => {
       expect(transactions.filter(tran => tran.subjectToMinimumCharge).length).to.equal(3)
     })
   })
+
+  function sleep (ms) {
+    return new Promise(resolve => setTimeout(resolve, ms))
+  }
 })

--- a/test/controllers/admin/test/test_bill_run.controller.test.js
+++ b/test/controllers/admin/test/test_bill_run.controller.test.js
@@ -1,0 +1,114 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, before, beforeEach, after } = exports.lab = Lab.script()
+const { expect } = Code
+
+// For running our service
+const { deployment } = require('../../../../server')
+
+// Test helpers
+const {
+  AuthorisationHelper,
+  AuthorisedSystemHelper,
+  DatabaseHelper,
+  SequenceCounterHelper
+} = require('../../../support/helpers')
+const { BillRunModel } = require('../../../../app/models')
+
+// Things we need to stub
+const JsonWebToken = require('jsonwebtoken')
+
+describe('Test Bill Run Controller', () => {
+  let server
+  let authToken
+
+  before(async () => {
+    server = await deployment()
+    authToken = AuthorisationHelper.adminToken()
+
+    Sinon
+      .stub(JsonWebToken, 'verify')
+      .returns(AuthorisationHelper.decodeToken(authToken))
+  })
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+    // This endpoint relies on creating a bill run, which relies on generating a bill run number. So, to support it we
+    // need to ensure there is a sequence counter entry for the matching regime and region.
+    const authSystem = await AuthorisedSystemHelper.addAdminSystem()
+    const regimes = await authSystem.$relatedQuery('regimes')
+    const regime = regimes.filter(r => r.slug === 'wrls')[0]
+    await SequenceCounterHelper.addSequenceCounter(regime.id, 'A')
+  })
+
+  after(async () => {
+    Sinon.restore()
+  })
+
+  describe('Generating a test bill run: POST /admin/test/{regimeId}/bill-runs/generate', () => {
+    const options = (token, payload) => {
+      return {
+        method: 'POST',
+        url: '/admin/test/wrls/bill-runs/generate',
+        headers: { authorization: `Bearer ${token}` },
+        payload: payload
+      }
+    }
+
+    it('creates a bill run with expected invoices and transactions', async () => {
+      const requestPayload = {
+        region: 'A',
+        mix: [
+          { type: 'mixed-invoice', count: 1 },
+          { type: 'mixed-credit', count: 1 },
+          { type: 'zero-value', count: 1 },
+          { type: 'deminimis', count: 1 },
+          { type: 'minimum-charge', count: 1 }
+        ]
+      }
+
+      const response = await server.inject(options(authToken, requestPayload))
+      const responsePayload = JSON.parse(response.payload)
+
+      // This endpoint immediately responds with details of the bill run created. But behind the scenes it continues
+      // adding transactions to it. When trying to run unit tests we found 2 issues
+      //
+      // - attempting to interrogate bill run, invoice and transaction details would always fail because it takes a few
+      // hundred milliseconds for the process to complete
+      // - other tests would start failing because the data the process was adding in the background interfered with
+      // them
+      //
+      // So, the only way we could see to keep a test for this endpoint was to add in an arbitrary delay. In this case
+      // we keep querying the bill run record until its numbers tell us all transactions have been added. Just in case,
+      // we also have a quit control to kill the loop should something go wrong.
+      let finished = false
+      let quitCount = 0
+      let billRun
+      do {
+        billRun = await BillRunModel.query().findById(responsePayload.billRun.id)
+        if (billRun.debitCount + billRun.creditCount + billRun.zeroCount === 15) {
+          finished = true
+        }
+        quitCount += 1
+      } while (!finished || quitCount > 1000)
+
+      billRun = await BillRunModel.query().findById(responsePayload.billRun.id)
+      const invoices = await billRun.$relatedQuery('invoices')
+      const transactions = await billRun.$relatedQuery('transactions')
+
+      expect(response.statusCode).to.equal(201)
+      expect(responsePayload.billRun.id).to.exist()
+
+      expect(invoices.length).to.equal(5)
+
+      expect(transactions.length).to.equal(15)
+      expect(transactions.filter(tran => tran.chargeCredit).length).to.equal(4)
+      expect(transactions.filter(tran => tran.subjectToMinimumCharge).length).to.equal(3)
+    })
+  })
+})

--- a/test/support/generators/README.md
+++ b/test/support/generators/README.md
@@ -1,0 +1,14 @@
+# Generators
+
+> Currently, only a bill run generator is provided but there is scope to add more if needed
+
+We use generators as part of our testing of the API. To assess performance of actions, and to give us realistic volumes of data for our views we need a way to generate large bill runs. We know the largest can have in excess of 9,000 transactions and 2,500 invoices.
+
+Generators allow us to create this volume of data quickly and avoid
+
+- the overhead of sending thousands of transaction requests across the network
+- 'spamming' the rules service just for testing purposes
+
+They follow the convention of [services](/app/services) being `static` and with a single `go()` method to initate the action. But unlike the main application code, we are comfortable with these not having specific unit tests. Integration tests through the `/admin/test/{regimeId}/bill-runs/generate` is sufficient.
+
+They also rely heavily on test helpers and libraries. It's for these reasons they sit here in `/test/support/generators'.

--- a/test/support/generators/bill_run.generator.js
+++ b/test/support/generators/bill_run.generator.js
@@ -20,7 +20,7 @@ class BillRunGenerator {
 
     const invoices = await this._invoiceGenerator(billRunId, payload)
 
-    for (let i = 0; i < invoices.length; i++) {
+    for (const i in invoices) {
       await this._invoiceEngine(invoices[i], authorisedSystem, regime)
     }
 

--- a/test/support/generators/bill_run.generator.js
+++ b/test/support/generators/bill_run.generator.js
@@ -1,0 +1,220 @@
+'use strict'
+
+/**
+ * @module BillRunGenerator
+ */
+
+const Boom = require('@hapi/boom')
+const Nock = require('nock')
+
+const { CreateTransactionService } = require('../../../app/services')
+
+const { RulesServiceHelper } = require('../helpers')
+const { presroc: requestFixtures } = require('../fixtures/create_transaction')
+const { presroc: chargeFixtures } = require('../fixtures/calculate_charge')
+
+class BillRunGenerator {
+  static async go (payload, billRunId, authorisedSystem, regime, logger) {
+    // Mark the start time for later logging
+    const startTime = process.hrtime.bigint()
+
+    const invoices = await this._invoiceGenerator(billRunId, payload)
+
+    for (let i = 0; i < invoices.length; i++) {
+      await this._invoiceEngine(invoices[i], authorisedSystem, regime)
+    }
+
+    await this._calculateAndLogTime(logger, billRunId, startTime)
+  }
+
+  static _invoiceGenerator (billRunId, payload) {
+    const invoices = []
+    let customerIndex = 0
+
+    payload.mix.forEach(options => {
+      for (let i = 0; i < options.count; i++) {
+        customerIndex += 1
+        const customerReference = `CM${customerIndex.toString().padStart(9, '0')}`
+        const licenceNumber = `SROC/TF${customerIndex.toString().padStart(4, '0')}/01`
+
+        invoices.push({
+          billRunId,
+          region: payload.region,
+          customerReference: customerReference,
+          periodStart: '01-APR-2018',
+          periodEnd: '31-MAR-2019',
+          licenceNumber: licenceNumber,
+          type: options.type
+        })
+      }
+    })
+
+    return invoices
+  }
+
+  static async _invoiceEngine (invoice, authorisedSystem, regime) {
+    const invoiceData = {
+      invoice,
+      authorisedSystem,
+      regime
+    }
+
+    switch (invoice.type) {
+      case 'mixed-invoice':
+        await this._mixedInvoice(invoiceData)
+        break
+      case 'mixed-credit':
+        await this._mixedCredit(invoiceData)
+        break
+      case 'zero-value':
+        await this._zeroValueInvoice(invoiceData)
+        break
+      case 'deminimis':
+        await this._deminimisInvoice(invoiceData)
+        break
+      case 'minimum-charge':
+        await this._minimumChargeInvoice(invoiceData)
+        break
+      default:
+        throw Boom.badRequest(`Unknown invoice type '${invoice.type}'`)
+    }
+  }
+
+  static async _addTransaction (invoiceData) {
+    try {
+      // Intercept all requests in this test suite as we don't actually want to call the service. Tell Nock to persist()
+      // the interception rather than remove it after the first request
+      Nock(RulesServiceHelper.url)
+        .post(() => true)
+        .reply(200, invoiceData.data.response)
+        .persist()
+      await CreateTransactionService.go(
+        invoiceData.data.payload,
+        invoiceData.invoice.billRunId,
+        invoiceData.authorisedSystem,
+        invoiceData.regime
+      )
+    } finally {
+      Nock.cleanAll()
+    }
+  }
+
+  static async _zeroValueInvoice (invoiceData) {
+    const transactionData = [
+      invoiceData.invoice,
+      '0',
+      0
+    ]
+
+    invoiceData.data = this._transactionData(...transactionData, false, false)
+    await this._addTransaction(invoiceData)
+    await this._addTransaction(invoiceData)
+    await this._addTransaction(invoiceData)
+  }
+
+  static async _deminimisInvoice (invoiceData) {
+    const transactionData = [
+      invoiceData.invoice,
+      '0.5865',
+      1.26
+    ]
+
+    invoiceData.data = this._transactionData(...transactionData, false, false)
+    await this._addTransaction(invoiceData)
+    await this._addTransaction(invoiceData)
+    await this._addTransaction(invoiceData)
+  }
+
+  static async _minimumChargeInvoice (invoiceData) {
+    const transactionData = [
+      invoiceData.invoice,
+      '0.5865',
+      1.26
+    ]
+
+    invoiceData.data = this._transactionData(...transactionData, false, true)
+    await this._addTransaction(invoiceData)
+    await this._addTransaction(invoiceData)
+
+    invoiceData.data = this._transactionData(...transactionData, true, true)
+    await this._addTransaction(invoiceData)
+  }
+
+  static async _mixedInvoice (invoiceData) {
+    const transactionData = [
+      invoiceData.invoice,
+      '50.22',
+      91.82
+    ]
+
+    invoiceData.data = this._transactionData(...transactionData, false, false)
+    await this._addTransaction(invoiceData)
+    await this._addTransaction(invoiceData)
+
+    invoiceData.data = this._transactionData(...transactionData, true, false)
+    await this._addTransaction(invoiceData)
+  }
+
+  static async _mixedCredit (invoiceData) {
+    const transactionData = [
+      invoiceData.invoice,
+      '50.22',
+      91.82
+    ]
+
+    invoiceData.data = this._transactionData(...transactionData, true, false)
+    await this._addTransaction(invoiceData)
+    await this._addTransaction(invoiceData)
+
+    invoiceData.data = this._transactionData(...transactionData, false, false)
+    await this._addTransaction(invoiceData)
+  }
+
+  static _transactionData (invoice, volume, chargeValue, credit, subjectToMinimumCharge) {
+    const result = {
+      payload: {
+        ...this._basePayload(invoice),
+        credit,
+        volume,
+        subjectToMinimumCharge
+      },
+      response: {
+        ...this._baseResponse()
+      }
+    }
+    result.response.WRLSChargingResponse.chargeValue = chargeValue
+
+    return result
+  }
+
+  static _basePayload (invoice) {
+    return {
+      ...requestFixtures.simple,
+      region: invoice.region,
+      customerReference: invoice.customerReference,
+      periodStart: invoice.periodStart,
+      periodEnd: invoice.periodEnd,
+      chargePeriod: `${invoice.periodStart} - ${invoice.periodEnd}`,
+      licenceNumber: invoice.licenceNumber
+    }
+  }
+
+  static _baseResponse () {
+    return {
+      ...chargeFixtures.simple.rulesService,
+      WRLSChargingResponse: {
+        ...chargeFixtures.simple.rulesService.WRLSChargingResponse
+      }
+    }
+  }
+
+  static async _calculateAndLogTime (logger, billRunId, startTime) {
+    const endTime = process.hrtime.bigint()
+    const timeTakenNs = endTime - startTime
+    const timeTakenMs = timeTakenNs / 1000000n
+
+    logger.info(`Time taken to auto-create bill run '${billRunId}': ${timeTakenMs}ms`)
+  }
+}
+
+module.exports = BillRunGenerator

--- a/test/support/generators/bill_run.generator.js
+++ b/test/support/generators/bill_run.generator.js
@@ -14,7 +14,7 @@ const { presroc: requestFixtures } = require('../fixtures/create_transaction')
 const { presroc: chargeFixtures } = require('../fixtures/calculate_charge')
 
 class BillRunGenerator {
-  static async go (payload, billRunId, authorisedSystem, regime, logger) {
+  static async go (payload, billRunId, authorisedSystem, regime, logger = null) {
     // Mark the start time for later logging
     const startTime = process.hrtime.bigint()
 
@@ -209,6 +209,10 @@ class BillRunGenerator {
   }
 
   static async _calculateAndLogTime (logger, billRunId, startTime) {
+    if (!logger) {
+      return
+    }
+
     const endTime = process.hrtime.bigint()
     const timeTakenNs = endTime - startTime
     const timeTakenMs = timeTakenNs / 1000000n

--- a/test/support/generators/bill_run.generator.js
+++ b/test/support/generators/bill_run.generator.js
@@ -82,7 +82,7 @@ class BillRunGenerator {
 
   static async _addTransaction (invoiceData) {
     try {
-      // Intercept all requests in this test suite as we don't actually want to call the service. Tell Nock to persist()
+      // Intercept all requests in this generator as we don't actually want to call the service. Tell Nock to persist()
       // the interception rather than remove it after the first request
       Nock(RulesServiceHelper.url)
         .post(() => true)

--- a/test/support/generators/index.js
+++ b/test/support/generators/index.js
@@ -1,0 +1,7 @@
+'use strict'
+
+const BillRunGenerator = require('./bill_run.generator')
+
+module.exports = {
+  BillRunGenerator
+}

--- a/test/support/helpers/route.helper.js
+++ b/test/support/helpers/route.helper.js
@@ -1,6 +1,14 @@
 'use strict'
 
-const { NotSupportedController } = require('../../../app/controllers')
+// We don't know why but when we added `TestBillRunController` and specifically added it to `app/controllers/index` this
+// require started failing. After some investigation we tracked it down to the controller's `require BillRunGenerator`
+// call. Take that out and all is well. Leave it in and
+// `const { NotSupportedController } = require('../../../app/controllers')` would fail. Requiring the
+// NotSupportedController directly resolves the issue.
+//
+// We suspect it's a circular dependency where something in the chain is requiring RouteHelper causing it to cycle back
+// again. TLDR; you need to NotSupportedController in this way to avoid an error
+const NotSupportedController = require('../../../app/controllers/not_supported.controller')
 
 /**
  * A helper that provides test routes.


### PR DESCRIPTION
There are times we need to check the performance of certain actions on large data sets, for example, how long the generate process takes.
    
We have external tests that can create bill runs and the associated transactions but they are either limited in how many they can add, or where they can be used. They also come with the overhead of waiting for each transaction request to be sent and completed.
    
Ideally, we could do with a way of creating a bill run without the overhead of sending requests across the network. This new endpoint does exactly that. When called, it will generate bill runs that feature a mix of invoices and licences, plus ones that will be identified as zero value, deminimis, and minimum charge. We can then test and assess viewing, generating, approving, and sending bill runs more easily.
