### PR TITLE
Fix update of invoice for minimum charge

### DIFF
--- a/app/services/create_minimum_charge_adjustment.service.js
+++ b/app/services/create_minimum_charge_adjustment.service.js
@@ -28,7 +28,8 @@ class CreateMinimumChargeAdjustmentService {
         'lineDescription',
         'ruleset',
         'chargeFinancialYear',
-        'invoiceId')
+        'invoiceId',
+        'licenceId')
       .limit(1)
       .first()
 

--- a/app/services/create_minimum_charge_adjustment.service.js
+++ b/app/services/create_minimum_charge_adjustment.service.js
@@ -27,7 +27,8 @@ class CreateMinimumChargeAdjustmentService {
         'lineAttr2',
         'lineDescription',
         'ruleset',
-        'chargeFinancialYear')
+        'chargeFinancialYear',
+        'invoiceId')
       .limit(1)
       .first()
 

--- a/app/services/generate_bill_run.service.js
+++ b/app/services/generate_bill_run.service.js
@@ -66,7 +66,7 @@ class GenerateBillRunService {
 
   static async _saveTransactions (transactions, trx) {
     for (const transaction of transactions) {
-      const billRunPatch = await this._billRunPatch(transaction)
+      const minimumChargePatch = await this._minimumChargePatch(transaction)
       const invoice = await this._invoice(transaction)
       const licence = await this._licence({ ...transaction, invoiceId: invoice.id })
 
@@ -79,11 +79,11 @@ class GenerateBillRunService {
 
       await invoice.$query(trx).patch()
       await licence.$query(trx).patch()
-      await BillRunModel.query(trx).findById(transaction.billRunId).patch(billRunPatch)
+      await BillRunModel.query(trx).findById(transaction.billRunId).patch(minimumChargePatch)
     }
   }
 
-  static async _billRunPatch (translator) {
+  static async _minimumChargePatch (translator) {
     let update = {
       subjectToMinimumChargeCount: raw('subject_to_minimum_charge_count + 1')
     }

--- a/test/services/bill_run.service.test.js
+++ b/test/services/bill_run.service.test.js
@@ -179,32 +179,4 @@ describe('Bill Run service', () => {
       })
     })
   })
-
-  describe("When the bill run status is 'generating'", () => {
-    let transaction
-
-    beforeEach(async () => {
-      billRun = await BillRunHelper.addBillRun(authorisedSystemId, regimeId, 'A', 'generating')
-      transaction = { ...dummyTransaction, billRunId: billRun.id }
-    })
-
-    describe('and the service is called from within bill run generation', () => {
-      it('allows the bill run to be generated', async () => {
-        const result = await BillRunService.go(transaction, true)
-
-        expect(result.id).to.equal(billRun.id)
-      })
-    })
-
-    describe('and the service is called from outside bill run generation', () => {
-      it('throws an error', async () => {
-        const err = await expect(BillRunService.go(transaction)).to.reject()
-
-        expect(err).to.be.an.error()
-        expect(err.output.payload.message)
-          .to
-          .equal(`Bill run ${billRun.id} cannot be edited because its status is generating.`)
-      })
-    })
-  })
 })

--- a/test/services/generate_bill_run.service.test.js
+++ b/test/services/generate_bill_run.service.test.js
@@ -260,7 +260,7 @@ describe('Generate Bill Run Summary service', () => {
 
           expect(minimumChargeBill.debitCount).to.equal(2)
           expect(minimumChargeBill.creditCount).to.equal(2)
-          expect(minimumChargeBill.subjectToMinimumChargeCount).to.equal(2)
+          expect(minimumChargeBill.subjectToMinimumChargeCount).to.equal(4)
           expect(minimumChargeBill.subjectToMinimumChargeDebitValue).to.equal(2500)
           expect(minimumChargeBill.subjectToMinimumChargeCreditValue).to.equal(2500)
 

--- a/test/services/generate_bill_run.service.test.js
+++ b/test/services/generate_bill_run.service.test.js
@@ -253,10 +253,12 @@ describe('Generate Bill Run Summary service', () => {
           expect(adjustmentTransactions.length).to.equal(2)
         })
 
-        it('updates the bill run and invoice as expected', async () => {
+        it('updates the bill run, invoice and licence as expected', async () => {
           const minimumChargeBill = await BillRunModel.query().findById(billRun.id)
           const invoices = await minimumChargeBill.$relatedQuery('invoices')
+          const licences = await minimumChargeBill.$relatedQuery('licences')
           const minimumChargeInvoice = invoices[0]
+          const minimumChargeLicence = licences[0]
 
           expect(minimumChargeBill.debitCount).to.equal(2)
           expect(minimumChargeBill.creditCount).to.equal(2)
@@ -269,6 +271,12 @@ describe('Generate Bill Run Summary service', () => {
           expect(minimumChargeInvoice.subjectToMinimumChargeCount).to.equal(4)
           expect(minimumChargeInvoice.subjectToMinimumChargeDebitValue).to.equal(2500)
           expect(minimumChargeInvoice.subjectToMinimumChargeCreditValue).to.equal(2500)
+
+          expect(minimumChargeLicence.debitCount).to.equal(2)
+          expect(minimumChargeLicence.creditCount).to.equal(2)
+          expect(minimumChargeLicence.subjectToMinimumChargeCount).to.equal(4)
+          expect(minimumChargeLicence.subjectToMinimumChargeDebitValue).to.equal(2500)
+          expect(minimumChargeLicence.subjectToMinimumChargeCreditValue).to.equal(2500)
         })
       })
 

--- a/test/services/generate_bill_run.service.test.js
+++ b/test/services/generate_bill_run.service.test.js
@@ -123,6 +123,15 @@ describe('Generate Bill Run Summary service', () => {
       expect(result.creditNoteValue).to.equal(50000)
     })
 
+    it('calls the info method of the provided logger', async () => {
+      const loggerFake = { info: Sinon.fake() }
+      await CreateTransactionService.go(payload, billRun.id, authorisedSystem, regime)
+
+      await GenerateBillRunService.go(billRun.id, loggerFake)
+
+      expect(loggerFake.info.callCount).to.equal(1)
+    })
+
     describe('When there are zero value invoices', () => {
       it("sets the 'zeroValueInvoice' flag to true", async () => {
         await CreateTransactionService.go(payload, billRun.id, authorisedSystem, regime)
@@ -219,30 +228,150 @@ describe('Generate Bill Run Summary service', () => {
     })
 
     describe('When minimum charge applies', () => {
-      it('saves the adjustment transaction to the db', async () => {
-        await CreateTransactionService.go({ ...payload, subjectToMinimumCharge: true }, billRun.id, authorisedSystem, regime)
-        await GenerateBillRunService.go(billRun.id)
-
-        const { transactions } = await BillRunModel.query()
-          .findById(billRun.id)
-          .withGraphFetched('invoices')
-          .withGraphFetched('transactions')
-
-        const adjustmentTransactions = transactions.filter((transaction) => {
-          return transaction.minimumChargeAdjustment
+      describe("and both a 'credit' and 'debit' adjustment transaction is needed", () => {
+        beforeEach(async () => {
+          const minimumChargePayload = {
+            ...payload,
+            subjectToMinimumCharge: true
+          }
+          await CreateTransactionService.go(minimumChargePayload, billRun.id, authorisedSystem, regime)
+          minimumChargePayload.credit = true
+          await CreateTransactionService.go(minimumChargePayload, billRun.id, authorisedSystem, regime)
+          await GenerateBillRunService.go(billRun.id)
         })
 
-        expect(adjustmentTransactions.length).to.equal(1)
+        it('saves both adjustment transactions to the db', async () => {
+          const { transactions } = await BillRunModel.query()
+            .findById(billRun.id)
+            .withGraphFetched('invoices')
+            .withGraphFetched('transactions')
+
+          const adjustmentTransactions = transactions.filter((transaction) => {
+            return transaction.minimumChargeAdjustment
+          })
+
+          expect(adjustmentTransactions.length).to.equal(2)
+        })
+
+        it('updates the bill run and invoice as expected', async () => {
+          const minimumChargeBill = await BillRunModel.query().findById(billRun.id)
+          const invoices = await minimumChargeBill.$relatedQuery('invoices')
+          const minimumChargeInvoice = invoices[0]
+
+          expect(minimumChargeBill.debitCount).to.equal(2)
+          expect(minimumChargeBill.creditCount).to.equal(2)
+          expect(minimumChargeBill.subjectToMinimumChargeCount).to.equal(2)
+          expect(minimumChargeBill.subjectToMinimumChargeDebitValue).to.equal(2500)
+          expect(minimumChargeBill.subjectToMinimumChargeCreditValue).to.equal(2500)
+
+          expect(minimumChargeInvoice.debitCount).to.equal(2)
+          expect(minimumChargeInvoice.creditCount).to.equal(2)
+          expect(minimumChargeInvoice.subjectToMinimumChargeCount).to.equal(2)
+          expect(minimumChargeInvoice.subjectToMinimumChargeDebitValue).to.equal(2500)
+          expect(minimumChargeInvoice.subjectToMinimumChargeCreditValue).to.equal(2500)
+        })
       })
-    })
 
-    it('calls the info method of the provided logger', async () => {
-      const loggerFake = { info: Sinon.fake() }
-      await CreateTransactionService.go(payload, billRun.id, authorisedSystem, regime)
+      describe("and only a 'credit' transaction is needed", () => {
+        beforeEach(async () => {
+          const minimumChargePayload = {
+            ...payload,
+            credit: true,
+            subjectToMinimumCharge: true
+          }
 
-      await GenerateBillRunService.go(billRun.id, loggerFake)
+          await CreateTransactionService.go(minimumChargePayload, billRun.id, authorisedSystem, regime)
 
-      expect(loggerFake.info.callCount).to.equal(1)
+          rulesServiceStub.restore()
+          RulesServiceHelper.mockValue(Sinon, RulesService, rulesServiceResponse, 2501)
+          minimumChargePayload.credit = false
+          await CreateTransactionService.go(minimumChargePayload, billRun.id, authorisedSystem, regime)
+
+          await GenerateBillRunService.go(billRun.id)
+        })
+
+        it("saves just a 'credit' adjustment transaction to the db", async () => {
+          const { transactions } = await BillRunModel.query()
+            .findById(billRun.id)
+            .withGraphFetched('invoices')
+            .withGraphFetched('transactions')
+
+          const adjustmentTransactions = transactions.filter((transaction) => {
+            return transaction.minimumChargeAdjustment
+          })
+
+          expect(adjustmentTransactions.length).to.equal(1)
+          expect(adjustmentTransactions[0].chargeCredit).to.be.true()
+        })
+
+        it('updates the bill run and invoice as expected', async () => {
+          const minimumChargeBill = await BillRunModel.query().findById(billRun.id)
+          const invoices = await minimumChargeBill.$relatedQuery('invoices')
+          const minimumChargeInvoice = invoices[0]
+
+          expect(minimumChargeBill.debitCount).to.equal(1)
+          expect(minimumChargeBill.creditCount).to.equal(2)
+          expect(minimumChargeBill.subjectToMinimumChargeCount).to.equal(3)
+          expect(minimumChargeBill.subjectToMinimumChargeDebitValue).to.equal(2501)
+          expect(minimumChargeBill.subjectToMinimumChargeCreditValue).to.equal(2500)
+
+          expect(minimumChargeInvoice.debitCount).to.equal(1)
+          expect(minimumChargeInvoice.creditCount).to.equal(2)
+          expect(minimumChargeInvoice.subjectToMinimumChargeCount).to.equal(3)
+          expect(minimumChargeInvoice.subjectToMinimumChargeDebitValue).to.equal(2501)
+          expect(minimumChargeInvoice.subjectToMinimumChargeCreditValue).to.equal(2500)
+        })
+      })
+
+      describe("and only a 'debit' transaction is needed", () => {
+        beforeEach(async () => {
+          const minimumChargePayload = {
+            ...payload,
+            subjectToMinimumCharge: true
+          }
+
+          await CreateTransactionService.go(minimumChargePayload, billRun.id, authorisedSystem, regime)
+
+          rulesServiceStub.restore()
+          RulesServiceHelper.mockValue(Sinon, RulesService, rulesServiceResponse, 2501)
+          minimumChargePayload.credit = true
+          await CreateTransactionService.go(minimumChargePayload, billRun.id, authorisedSystem, regime)
+
+          await GenerateBillRunService.go(billRun.id)
+        })
+
+        it("saves just a 'debit' adjustment transaction to the db", async () => {
+          const { transactions } = await BillRunModel.query()
+            .findById(billRun.id)
+            .withGraphFetched('invoices')
+            .withGraphFetched('transactions')
+
+          const adjustmentTransactions = transactions.filter((transaction) => {
+            return transaction.minimumChargeAdjustment
+          })
+
+          expect(adjustmentTransactions.length).to.equal(1)
+          expect(adjustmentTransactions[0].chargeCredit).to.be.false()
+        })
+
+        it('updates the bill run and invoice as expected', async () => {
+          const minimumChargeBill = await BillRunModel.query().findById(billRun.id)
+          const invoices = await minimumChargeBill.$relatedQuery('invoices')
+          const minimumChargeInvoice = invoices[0]
+
+          expect(minimumChargeBill.debitCount).to.equal(2)
+          expect(minimumChargeBill.creditCount).to.equal(1)
+          expect(minimumChargeBill.subjectToMinimumChargeCount).to.equal(3)
+          expect(minimumChargeBill.subjectToMinimumChargeDebitValue).to.equal(2500)
+          expect(minimumChargeBill.subjectToMinimumChargeCreditValue).to.equal(2501)
+
+          expect(minimumChargeInvoice.debitCount).to.equal(2)
+          expect(minimumChargeInvoice.creditCount).to.equal(1)
+          expect(minimumChargeInvoice.subjectToMinimumChargeCount).to.equal(3)
+          expect(minimumChargeInvoice.subjectToMinimumChargeDebitValue).to.equal(2500)
+          expect(minimumChargeInvoice.subjectToMinimumChargeCreditValue).to.equal(2501)
+        })
+      })
     })
   })
 })

--- a/test/services/generate_bill_run.service.test.js
+++ b/test/services/generate_bill_run.service.test.js
@@ -266,7 +266,7 @@ describe('Generate Bill Run Summary service', () => {
 
           expect(minimumChargeInvoice.debitCount).to.equal(2)
           expect(minimumChargeInvoice.creditCount).to.equal(2)
-          expect(minimumChargeInvoice.subjectToMinimumChargeCount).to.equal(2)
+          expect(minimumChargeInvoice.subjectToMinimumChargeCount).to.equal(4)
           expect(minimumChargeInvoice.subjectToMinimumChargeDebitValue).to.equal(2500)
           expect(minimumChargeInvoice.subjectToMinimumChargeCreditValue).to.equal(2500)
         })

--- a/test/services/generate_bill_run.service.test.js
+++ b/test/services/generate_bill_run.service.test.js
@@ -253,24 +253,32 @@ describe('Generate Bill Run Summary service', () => {
           expect(adjustmentTransactions.length).to.equal(2)
         })
 
-        it('updates the bill run, invoice and licence as expected', async () => {
+        it('updates the bill run as expected', async () => {
           const minimumChargeBill = await BillRunModel.query().findById(billRun.id)
-          const invoices = await minimumChargeBill.$relatedQuery('invoices')
-          const licences = await minimumChargeBill.$relatedQuery('licences')
-          const minimumChargeInvoice = invoices[0]
-          const minimumChargeLicence = licences[0]
 
           expect(minimumChargeBill.debitCount).to.equal(2)
           expect(minimumChargeBill.creditCount).to.equal(2)
           expect(minimumChargeBill.subjectToMinimumChargeCount).to.equal(4)
           expect(minimumChargeBill.subjectToMinimumChargeDebitValue).to.equal(2500)
           expect(minimumChargeBill.subjectToMinimumChargeCreditValue).to.equal(2500)
+        })
+
+        it('updates the invoice as expected', async () => {
+          const minimumChargeBill = await BillRunModel.query().findById(billRun.id)
+          const invoices = await minimumChargeBill.$relatedQuery('invoices')
+          const minimumChargeInvoice = invoices[0]
 
           expect(minimumChargeInvoice.debitCount).to.equal(2)
           expect(minimumChargeInvoice.creditCount).to.equal(2)
           expect(minimumChargeInvoice.subjectToMinimumChargeCount).to.equal(4)
           expect(minimumChargeInvoice.subjectToMinimumChargeDebitValue).to.equal(2500)
           expect(minimumChargeInvoice.subjectToMinimumChargeCreditValue).to.equal(2500)
+        })
+
+        it('updates the licence as expected', async () => {
+          const minimumChargeBill = await BillRunModel.query().findById(billRun.id)
+          const licences = await minimumChargeBill.$relatedQuery('licences')
+          const minimumChargeLicence = licences[0]
 
           expect(minimumChargeLicence.debitCount).to.equal(2)
           expect(minimumChargeLicence.creditCount).to.equal(2)


### PR DESCRIPTION
During the bill run generate process if an invoice is subject to minimum charge and either its debit or credit value is below £25 we add an additional transaction to make the value up to £25.

The thing to note is we do this for _both sides_ if there is a credit and a debit value. This means we also need to update the debit and credit counts and values in the invoice and bill run record to reflect the new transactions we created.

In testing, though we have found only one side will be updated, dependent on whichever minimum charge transaction is created last.

The cause is a mix of needing to do things within a transaction and attempting to patch an instance of each record type (bill run, invoice, licence).

Currently, the order of events is

- create the minimum charge transactions
- iterate through the transactions
  - first transaction, call the bill run, invoice and licence services passing in the transaction
  - each service gets a copy of the current record in the DB and updates its values based on the transaction
  - returns an instance of the thing ready for updating
- insert the new transaction
- call `patch()` on each instance returned from the services

The problem is, we are doing this in a database transaction. So, the call to `patch()` after the first transaction has not actually happened. This means, for example, when the invoice service gets a copy of the invoice from the DB for the second transaction it still has the original values. Assuming the first transaction was a credit, on the second pass we only update the debit count and values.

- first instance of `InvoiceModel` has only credit values updated. `patch()` updates everything
- second instance of `InvoiceModel` has only debit values updated but also the original credit values (not updated ones). `patch()` updates everything, overwriting the previous change to the credit values

This change fixes the issue. It drops the use of the services which rely on getting the current instance of a record. Instead, we will use the static model classes to generate an update query. As well as solving the problem this has 2 benefits

- it drops the need for querying the DB for copies of the existing data
- each update query is smaller and focused only on updating the relevant fields
