### PR TITLE
Title case loss, season & source values in charge

### DIFF
--- a/app/translators/calculate_charge.translator.js
+++ b/app/translators/calculate_charge.translator.js
@@ -20,6 +20,11 @@ class CalculateChargeTranslator extends BaseTranslator {
 
     // Additional post-getter validation to ensure section126Factor has no more than 3 decimal places
     this._validateSection126Factor()
+
+    // Additional post-getter parser to ensure that loss, season and source are all in the right 'case'
+    this.regimeValue6 = this._titleCaseStringValue(this.regimeValue6)
+    this.regimeValue7 = this._titleCaseStringValue(this.regimeValue7)
+    this.regimeValue8 = this._titleCaseStringValue(this.regimeValue8)
   }
 
   _validateFinancialYear () {
@@ -69,6 +74,30 @@ class CalculateChargeTranslator extends BaseTranslator {
     if (error) {
       throw Boom.badData(error)
     }
+  }
+
+  /**
+   * Use to title case a string value
+   *
+   * Title case is where the first character is a capital and the rest is lower case. Our testing of the rules service
+   * has highlighted that it will only calculate the charge correctly if the values for the `loss`, `season`, and
+   * `source` in the request are in title case. Anything else and it fails to match them to resulting in a 0 charge.
+   *
+   * Note, it is assumed this method will only be used for parsing those fields, and they are only expected to contain
+   * single words. It won't fail if you pass in more than one word, but it would only do the following
+   *
+   * ```javascript
+   *  this._titleCaseStringValue('heLLo, World') // Hello, world
+   * ```
+   *
+   * @param {string} value String value to be converted to title case
+   *
+   * @returns {string} The string value converted to title case
+   */
+  _titleCaseStringValue (value) {
+    const lowerCase = value.toLowerCase()
+
+    return lowerCase[0].toUpperCase() + lowerCase.substring(1)
   }
 
   _schema () {

--- a/test/translators/calculate_charge.translator.test.js
+++ b/test/translators/calculate_charge.translator.test.js
@@ -192,6 +192,25 @@ describe('Calculate Charge translator', () => {
     })
   })
 
+  describe('handling of strings not in correct case', () => {
+    describe("when 'loss', 'season' and 'source' are not sent as title case", () => {
+      it('automatically converts them to title case', () => {
+        const lowercasePayload = {
+          ...payload,
+          loss: 'lOw',
+          season: 'sumMer',
+          source: 'supPorTed'
+        }
+
+        const result = new CalculateChargeTranslator(data(lowercasePayload))
+
+        expect(result.regimeValue8).to.equal('Loss')
+        expect(result.regimeValue7).to.equal('Summer')
+        expect(result.regimeValue6).to.equal('Supported')
+      })
+    })
+  })
+
   describe('Validation', () => {
     describe('when the data is valid', () => {
       it('does not throw an error', async () => {

--- a/test/translators/calculate_charge.translator.test.js
+++ b/test/translators/calculate_charge.translator.test.js
@@ -204,7 +204,7 @@ describe('Calculate Charge translator', () => {
 
         const result = new CalculateChargeTranslator(data(lowercasePayload))
 
-        expect(result.regimeValue8).to.equal('Loss')
+        expect(result.regimeValue8).to.equal('Low')
         expect(result.regimeValue7).to.equal('Summer')
         expect(result.regimeValue6).to.equal('Supported')
       })


### PR DESCRIPTION
Whilst testing the `/generate` bill run endpoint we came across a situation where the `source`, `season`, and `loss` values were found to be invalid. Yet the rules service still returned a 'valid' result. Hidden away in the response was a message telling us that the values we had sent through did not match those in the rules service.

After some investigation, we found it was purely the 'case' of the strings that were used causing the problem. The values were fine.

So, we are doing 2 things

- we are updating the [SROC Charging Module API](https://github.com/defra/sroc-charging-module-api) to automatically 'title case' any values sent through
- we are also updating it to check for messages from the rules service and respond appropriately

This change covers the first point; converting the `loss`, `season` and `source` values in the request to title case automatically.