### PR TITLE
Fix missing bill run to licence relationship

### DIFF
--- a/app/models/bill_run.model.js
+++ b/app/models/bill_run.model.js
@@ -30,6 +30,14 @@ class BillRunModel extends BaseModel {
           to: 'invoices.billRunId'
         }
       },
+      licences: {
+        relation: Model.HasManyRelation,
+        modelClass: 'licence.model',
+        join: {
+          from: 'billRuns.id',
+          to: 'licences.billRunId'
+        }
+      },
       regime: {
         relation: Model.BelongsToOneRelation,
         modelClass: 'regime.model',


### PR DESCRIPTION
Whilst working on [Fix update of invoice for minimum charge](https://github.com/DEFRA/sroc-charging-module-api/pull/200) we spotted that the bill run and licence are not being properly updated either.

Having created and generated a bill run in our tests, we need to grab the related invoices, licences and transactions so we can test our assertions. But we currently cannot do this for licences because there does not appear to be an Objection relationship setup between the 2.

This change fixes the issue.