### PR TITLE
Minimum charge invoice flag

### DIFF
--- a/app/services/generate_bill_run.service.js
+++ b/app/services/generate_bill_run.service.js
@@ -99,13 +99,6 @@ class GenerateBillRunService {
     return update
   }
 
-  static _invoicePatch (minimumChargePatch) {
-    return {
-      ...minimumChargePatch,
-      minimumChargeInvoice: true
-    }
-  }
-
   static async _summariseBillRun (billRun, trx) {
     await this._summariseDebitInvoices(billRun, trx)
     await this._summariseCreditInvoices(billRun, trx)

--- a/app/services/view_bill_run.service.js
+++ b/app/services/view_bill_run.service.js
@@ -59,7 +59,8 @@ class ViewBillRunService {
           'debitValue',
           'zeroCount',
           'deminimisInvoice',
-          'zeroValueInvoice'
+          'zeroValueInvoice',
+          'minimumChargeInvoice'
         )
       })
       .modifyGraph('invoices.licences', (builder) => {

--- a/db/migrations/20210212160135_alter_invoices.js
+++ b/db/migrations/20210212160135_alter_invoices.js
@@ -1,0 +1,21 @@
+'use strict'
+
+const tableName = 'invoices'
+
+exports.up = async function (knex) {
+  await knex
+    .schema
+    .alterTable(tableName, table => {
+      // Add new column
+      table.boolean('minimum_charge_invoice').notNullable().defaultTo(false)
+    })
+}
+
+exports.down = async function (knex) {
+  await knex
+    .schema
+    .alterTable(tableName, table => {
+      // Drop the column we added
+      table.dropColumn('minimum_charge_invoice')
+    })
+}

--- a/test/services/generate_bill_run.service.test.js
+++ b/test/services/generate_bill_run.service.test.js
@@ -223,6 +223,9 @@ describe('Generate Bill Run Summary service', () => {
         await CreateTransactionService.go({ ...payload, subjectToMinimumCharge: true }, billRun.id, authorisedSystem, regime)
         await GenerateBillRunService.go(billRun.id)
 
+        // Note that we would normally use .withGraphFetched('invoices.transactions') to pull the invoices and nested
+        // transactions from the bill run. However this way of doing it makes it easier to get to the transaction we
+        // want to test without having to dig through the object.
         const { transactions } = await BillRunModel.query()
           .findById(billRun.id)
           .withGraphFetched('invoices')
@@ -233,6 +236,49 @@ describe('Generate Bill Run Summary service', () => {
         })
 
         expect(adjustmentTransactions.length).to.equal(1)
+      })
+
+      it('sets the minimumChargeInvoice flag', async () => {
+        await CreateTransactionService.go({ ...payload, subjectToMinimumCharge: true }, billRun.id, authorisedSystem, regime)
+        await GenerateBillRunService.go(billRun.id)
+
+        const { invoices } = await BillRunModel.query()
+          .findById(billRun.id)
+          .withGraphFetched('invoices')
+
+        expect(invoices[0].minimumChargeInvoice).to.equal(true)
+      })
+    })
+
+    describe('When minimum charge does not apply', () => {
+      it('does not save an adjustment transaction to the db', async () => {
+        await CreateTransactionService.go(payload, billRun.id, authorisedSystem, regime)
+        await GenerateBillRunService.go(billRun.id)
+
+        // Note that we would normally use .withGraphFetched('invoices.transactions') to pull the invoices and nested
+        // transactions from the bill run. However this way of doing it makes it easier to get to the transaction we
+        // want to test without having to dig through the object.
+        const { transactions } = await BillRunModel.query()
+          .findById(billRun.id)
+          .withGraphFetched('invoices')
+          .withGraphFetched('transactions')
+
+        const adjustmentTransactions = transactions.filter((transaction) => {
+          return transaction.minimumChargeAdjustment
+        })
+
+        expect(adjustmentTransactions.length).to.equal(0)
+      })
+
+      it('sets the minimumChargeInvoice flag', async () => {
+        await CreateTransactionService.go(payload, billRun.id, authorisedSystem, regime)
+        await GenerateBillRunService.go(billRun.id)
+
+        const { invoices } = await BillRunModel.query()
+          .findById(billRun.id)
+          .withGraphFetched('invoices')
+
+        expect(invoices[0].minimumChargeInvoice).to.equal(false)
       })
     })
 

--- a/test/services/generate_bill_run.service.test.js
+++ b/test/services/generate_bill_run.service.test.js
@@ -238,7 +238,7 @@ describe('Generate Bill Run Summary service', () => {
         expect(adjustmentTransactions.length).to.equal(1)
       })
 
-      it('sets the minimumChargeInvoice flag', async () => {
+      it('sets the minimumChargeInvoice flag to true', async () => {
         await CreateTransactionService.go({ ...payload, subjectToMinimumCharge: true }, billRun.id, authorisedSystem, regime)
         await GenerateBillRunService.go(billRun.id)
 
@@ -270,7 +270,7 @@ describe('Generate Bill Run Summary service', () => {
         expect(adjustmentTransactions.length).to.equal(0)
       })
 
-      it('sets the minimumChargeInvoice flag', async () => {
+      it('does not set the minimumChargeInvoice flag to true', async () => {
         await CreateTransactionService.go(payload, billRun.id, authorisedSystem, regime)
         await GenerateBillRunService.go(billRun.id)
 


### PR DESCRIPTION
According to the [draft API docs](https://app.swaggerhub.com/apis-docs/sro/charging-module_api/draft), viewing the bill run should return a `minimumChargeInvoice` flag at the invoice level, which isn't currently included in `ViewBillRunService`. This change amends `GenerateBillRunService` to implement it.

Note that it does this a little differently to the other invoice-level flags, `zeroValueInvoice` and `deminimisInvoice`, which are set by querying the db to return the relevant invoices and `patch`ing them to set the flag. For `minimumChargeInvoice`, we set this invoice-level flag when we update the invoice figures as part of the process of saving minimum charge adjustment transactions to the db.