### PR TITLE
Add bill run ID to generate bill run time logging

### DIFF
--- a/app/services/generate_bill_run.service.js
+++ b/app/services/generate_bill_run.service.js
@@ -25,11 +25,7 @@ class GenerateBillRunService {
     const billRun = await BillRunModel.query().findById(billRunId)
     await this._generateBillRun(billRun)
 
-    if (logger) {
-      const endTime = process.hrtime.bigint()
-      const timeInMs = this._calculateTime(startTime, endTime)
-      await this._logTime(timeInMs, logger)
-    }
+    await this._calculateAndLogTime(logger, billRunId, startTime)
   }
 
   static async _generateBillRun (billRun) {
@@ -145,20 +141,28 @@ class GenerateBillRunService {
       .patch({ status: 'generated' })
   }
 
-  static _calculateTime (startTime, endTime) {
-    const nanoseconds = endTime - startTime
-    const milliseconds = nanoseconds / 1000000n
-    return milliseconds
-  }
-
   /**
-   * Use a passed-in logger to log the time taken to generate the bill run
+   * Log the time taken to generate the bill run using the passed in logger
    *
-   * @param {integer} time Time to log in ms
-   * @param {function} logger Logger with an 'info' method we use to log the time taken
+   * If `logger` is not set then it will do nothing. If it is set this will get the current time and then calculate the
+   * difference from `startTime`. This and the `billRunId` are then used to generate a log message.
+   *
+   * @param {function} logger Logger with an 'info' method we use to log the time taken (assumed to be the one added to
+   * the Hapi server instance by hapi-pino)
+   * @param {string} billRunId Id of the bill run currently being 'generated'
+   * @param {BigInt} startTime The time the generate process kicked off. It is expected to be the result of a call to
+   * `process.hrtime.bigint()`
    */
-  static async _logTime (time, logger) {
-    logger.info(`Time taken to generate bill run: ${time}ms`)
+  static async _calculateAndLogTime (logger, billRunId, startTime) {
+    if (!logger) {
+      return
+    }
+
+    const endTime = process.hrtime.bigint()
+    const timeTakenNs = endTime - startTime
+    const timeTakenMs = timeTakenNs / 1000000n
+
+    logger.info(`Time taken to generate bill run '${billRunId}': ${timeTakenMs}ms`)
   }
 }
 


### PR DESCRIPTION
[Output generate bill run timing](https://github.com/DEFRA/sroc-charging-module-api/pull/196) has already proved to be a massive help in understanding how long the generate bill run process takes. But we did spot one more tweak that would make it perfect; including the bill run ID in the log output.