### PR TITLE
Add error handling to GenerateBillRunService

### DIFF
--- a/app/services/generate_bill_run.service.js
+++ b/app/services/generate_bill_run.service.js
@@ -19,13 +19,17 @@ class GenerateBillRunService {
   * @param {object} [logger] Server logger object. If passed in then logger.info will be called to log the time taken.
   */
   static async go (billRunId, logger = '') {
-    // Mark the start time for later logging
-    const startTime = process.hrtime.bigint()
+    try {
+      // Mark the start time for later logging
+      const startTime = process.hrtime.bigint()
 
-    const billRun = await BillRunModel.query().findById(billRunId)
-    await this._generateBillRun(billRun)
+      const billRun = await BillRunModel.query().findById(billRunId)
+      await this._generateBillRun(billRun)
 
-    await this._calculateAndLogTime(logger, billRunId, startTime)
+      await this._calculateAndLogTime(logger, billRunId, startTime)
+    } catch (error) {
+      this._logError(logger, error)
+    }
   }
 
   static async _generateBillRun (billRun) {
@@ -163,6 +167,25 @@ class GenerateBillRunService {
     const timeTakenMs = timeTakenNs / 1000000n
 
     logger.info(`Time taken to generate bill run '${billRunId}': ${timeTakenMs}ms`)
+  }
+
+  /**
+   * Log an error if the generate process fails
+   *
+   * If `logger` is not set then it will do nothing. If it is set this will log an error message based on the
+   * `billRunId` and error provided.
+   *
+   * @param {function} logger Logger with an 'info' method we use to log the error (assumed to be the one added to
+   * the Hapi server instance by hapi-pino)
+   * @param {string} billRunId Id of the bill run currently being 'generated'
+   * @param {Object} error The error that was thrown
+   */
+  static async _logError (logger, billRunId, error) {
+    if (!logger) {
+      return
+    }
+
+    logger.info(`Generate bill run '${billRunId}' failed: ${error.message} - ${error}`)
   }
 }
 

--- a/app/services/generate_bill_run.service.js
+++ b/app/services/generate_bill_run.service.js
@@ -28,7 +28,7 @@ class GenerateBillRunService {
 
       await this._calculateAndLogTime(logger, billRunId, startTime)
     } catch (error) {
-      this._logError(logger, error)
+      this._logError(logger, billRunId, error)
     }
   }
 

--- a/test/support/generators/bill_run.generator.js
+++ b/test/support/generators/bill_run.generator.js
@@ -213,7 +213,7 @@ class BillRunGenerator {
   }
 
   /**
-   * Log the time taken to generate the bill run using the passed in logger
+   * Log the time taken to auto-generate the bill run using the passed in logger
    *
    * If `logger` is not set then it will do nothing. If it is set this will get the current time and then calculate the
    * difference from `startTime`. This and the `billRunId` are then used to generate a log message.
@@ -221,8 +221,8 @@ class BillRunGenerator {
    * @param {function} logger Logger with an 'info' method we use to log the time taken (assumed to be the one added to
    * the Hapi server instance by hapi-pino)
    * @param {string} billRunId Id of the bill run currently being 'generated'
-   * @param {BigInt} startTime The time the generate process kicked off. It is expected to be the result of a call to
-   * `process.hrtime.bigint()`
+   * @param {BigInt} startTime The time the auto-generate process kicked off. It is expected to be the result of a call
+   * to `process.hrtime.bigint()`
    */
   static async _calculateAndLogTime (logger, billRunId, startTime) {
     if (!logger) {
@@ -233,11 +233,11 @@ class BillRunGenerator {
     const timeTakenNs = endTime - startTime
     const timeTakenMs = timeTakenNs / 1000000n
 
-    logger.info(`Time taken to generate bill run '${billRunId}': ${timeTakenMs}ms`)
+    logger.info(`Time taken to auto-generate bill run '${billRunId}': ${timeTakenMs}ms`)
   }
 
   /**
-   * Log an error if the generate process fails
+   * Log an error if the auto-generate process fails
    *
    * If `logger` is not set then it will do nothing. If it is set this will log an error message based on the
    * `billRunId` and error provided.
@@ -252,7 +252,7 @@ class BillRunGenerator {
       return
     }
 
-    logger.info(`Generate bill run '${billRunId}' failed: ${error.message} - ${error}`)
+    logger.info(`Auto-generate bill run '${billRunId}' failed: ${error.message} - ${error}`)
   }
 }
 

--- a/test/support/generators/bill_run.generator.js
+++ b/test/support/generators/bill_run.generator.js
@@ -27,7 +27,7 @@ class BillRunGenerator {
 
       await this._calculateAndLogTime(logger, billRunId, startTime)
     } catch (error) {
-      this._logError(logger, error)
+      this._logError(logger, billRunId, error)
     }
   }
 
@@ -212,6 +212,18 @@ class BillRunGenerator {
     }
   }
 
+  /**
+   * Log the time taken to generate the bill run using the passed in logger
+   *
+   * If `logger` is not set then it will do nothing. If it is set this will get the current time and then calculate the
+   * difference from `startTime`. This and the `billRunId` are then used to generate a log message.
+   *
+   * @param {function} logger Logger with an 'info' method we use to log the time taken (assumed to be the one added to
+   * the Hapi server instance by hapi-pino)
+   * @param {string} billRunId Id of the bill run currently being 'generated'
+   * @param {BigInt} startTime The time the generate process kicked off. It is expected to be the result of a call to
+   * `process.hrtime.bigint()`
+   */
   static async _calculateAndLogTime (logger, billRunId, startTime) {
     if (!logger) {
       return
@@ -224,12 +236,23 @@ class BillRunGenerator {
     logger.info(`Time taken to generate bill run '${billRunId}': ${timeTakenMs}ms`)
   }
 
-  static async _logError (logger, error) {
+  /**
+   * Log an error if the generate process fails
+   *
+   * If `logger` is not set then it will do nothing. If it is set this will log an error message based on the
+   * `billRunId` and error provided.
+   *
+   * @param {function} logger Logger with an 'info' method we use to log the error (assumed to be the one added to
+   * the Hapi server instance by hapi-pino)
+   * @param {string} billRunId Id of the bill run currently being 'generated'
+   * @param {Object} error The error that was thrown
+   */
+  static async _logError (logger, billRunId, error) {
     if (!logger) {
       return
     }
 
-    logger.info(`Generate bill run failed: ${error.message} - ${error}`)
+    logger.info(`Generate bill run '${billRunId}' failed: ${error.message} - ${error}`)
   }
 }
 


### PR DESCRIPTION
If an error occurs during the 'generate bill run' process it will cause the app to crash.

We first noticed this kind of behaviour when working on [Add test only bill run generator](https://github.com/DEFRA/sroc-charging-module-api/pull/199)

> At first [the error] was confusing (we're using Boom!) but then we understood. Whilst we are within the lifecycle of the Hapi request and doing things synchronously any errors we throw or that are thrown are captured by Hapi which then wraps them as Boom `500` errors (if they are not already boom errors).
>
> However, because we have set up the generator to 'kick-off' the generate process asynchronously and then immediately respond all bets are off. Now any errors that are thrown are outside of the lifecycle have nowhere to go. Hence, when they happen they crash the app.

By wrapping everything in the `go()` method of the service in a `try-catch` we can ensure no errors bubble up and crash the app. This solved the problem for the `BillRunGenerator` so this change does the same to the `GenerateBillRunService`.