### PR TITLE
Amend transactions and invoices tables

### DIFF
--- a/app/models/invoice.model.js
+++ b/app/models/invoice.model.js
@@ -120,6 +120,13 @@ class InvoiceModel extends BaseModel {
   $absoluteNetTotal () {
     return Math.abs(this.debitValue - this.creditValue)
   }
+
+  /**
+   * transactionType method returns C if this is a credit (ie. net total < 0) or I if it's an invoice/debit
+   */
+  $transactionType () {
+    return this.$netTotal() < 0 ? 'C' : 'I'
+  }
 }
 
 module.exports = InvoiceModel

--- a/db/migrations/20210215154015_alter_transactions_and_invoices.js
+++ b/db/migrations/20210215154015_alter_transactions_and_invoices.js
@@ -1,0 +1,39 @@
+'use strict'
+
+// Delete transaction_type, transaction_reference and deminimis columns from transactions table
+// Add transaction_reference column to invoices table
+exports.up = async function (knex) {
+  await knex
+    .schema
+    .alterTable('transactions', table => {
+      table.dropColumns(
+        'transaction_type',
+        'transaction_reference',
+        'deminimis'
+      )
+    })
+
+  await knex
+    .schema
+    .alterTable('invoices', table => {
+      table.string('transaction_reference')
+    })
+}
+
+// Re-add transaction_type, transaction_reference and deminimis columns to transactions table
+// Delete transaction_reference column from invoices table
+exports.down = async function (knex) {
+  await knex
+    .schema
+    .alterTable('transactions', table => {
+      table.string('transaction_type')
+      table.string('transaction_reference')
+      table.boolean('deminimis').defaultTo(false).notNullable()
+    })
+
+  await knex
+    .schema
+    .alterTable('transactions', table => {
+      table.dropColumn('transaction_reference')
+    })
+}

--- a/test/models/invoice.model.test.js
+++ b/test/models/invoice.model.test.js
@@ -79,4 +79,24 @@ describe('Invoice Model', () => {
       })
     })
   })
+
+  describe('$transactionType method', () => {
+    const billRunId = GeneralHelper.uuid4()
+
+    it('returns C for a credit', async () => {
+      const credit = await InvoiceHelper.addInvoice(billRunId, 'CRD0000001', 2020, 1, 500, 0, 0, 0)
+
+      const result = credit.$transactionType()
+
+      expect(result).to.equal('C')
+    })
+
+    it('returns I for an invoice/debit', async () => {
+      const debit = await InvoiceHelper.addInvoice(billRunId, 'INV0000001', 2020, 0, 0, 1, 500, 0)
+
+      const result = debit.$transactionType()
+
+      expect(result).to.equal('I')
+    })
+  })
 })


### PR DESCRIPTION
As part of the work of getting view bill run in line with the [draft spec](https://app.swaggerhub.com/apis-docs/sro/sroc-charging-module-api/draft#/billrun/ViewBillRun), we need to make a few changes to the `transactions` and `invoices` tables:

- `transaction_reference` is actually an invoice-level reference so we drop the column from the `transactions` table and add it to the `invoices_table`.
- `transaction_type` is also invoice-level so we drop the column from the `transactions` table. It contains `C` if the invoice is a net credit or `I` if it is a net debit, so instead of creating a column to the `invoices` table we instead add a `$transactionType` method to the `Invoices` model to generate it dynamically.
- While we're making amendments to the `transactions` table, we note that the `deminimis` column is not required so we also drop it.
