### PR TITLE
Add view bill run endpoint using ViewBillRunService

### DIFF
--- a/app/controllers/presroc/bill_runs.controller.js
+++ b/app/controllers/presroc/bill_runs.controller.js
@@ -5,7 +5,8 @@ const {
   CreateBillRunService,
   CreateTransactionService,
   GenerateBillRunService,
-  ValidateBillRunService
+  ValidateBillRunService,
+  ViewBillRunService
 } = require('../../services')
 
 class BillRunsController {
@@ -30,6 +31,12 @@ class BillRunsController {
 
   static async status (req, h) {
     const result = await BillRunStatusService.go(req.params.billRunId)
+
+    return h.response(result).code(200)
+  }
+
+  static async view (req, h) {
+    const result = await ViewBillRunService.go(req.params.billRunId)
 
     return h.response(result).code(200)
   }

--- a/app/routes/bill_run.routes.js
+++ b/app/routes/bill_run.routes.js
@@ -35,6 +35,11 @@ const routes = [
     method: 'GET',
     path: '/v2/{regimeId}/bill-runs/{billRunId}/status',
     handler: PresrocBillRunsController.status
+  },
+  {
+    method: 'GET',
+    path: '/v2/{regimeId}/bill-runs/{billRunId}',
+    handler: PresrocBillRunsController.view
   }
 ]
 

--- a/test/controllers/presroc/bill_runs.controller.test.js
+++ b/test/controllers/presroc/bill_runs.controller.test.js
@@ -247,4 +247,39 @@ describe('Presroc Bill Runs controller', () => {
       })
     })
   })
+
+  describe('View bill run: GET /v2/{regimeId}/bill-runs/{billRunId}', () => {
+    const options = (token, billRunId) => {
+      return {
+        method: 'GET',
+        url: `/v2/wrls/bill-runs/${billRunId}`,
+        headers: { authorization: `Bearer ${token}` }
+      }
+    }
+
+    describe('When the request is valid', () => {
+      it('returns success status 200', async () => {
+        billRun = await BillRunHelper.addBillRun(authorisedSystem.id, regime.id)
+
+        const response = await server.inject(options(authToken, billRun.id))
+        const responsePayload = JSON.parse(response.payload)
+
+        expect(response.statusCode).to.equal(200)
+        expect(responsePayload.billRun.id).to.equal(billRun.id)
+      })
+    })
+
+    describe('When the request is invalid', () => {
+      describe('because the bill run does not exist', () => {
+        it('returns error status 404', async () => {
+          const unknownBillRunId = GeneralHelper.uuid4()
+          const response = await server.inject(options(authToken, unknownBillRunId))
+          const responsePayload = JSON.parse(response.payload)
+
+          expect(response.statusCode).to.equal(404)
+          expect(responsePayload.message).to.equal(`Bill run ${unknownBillRunId} is unknown.`)
+        })
+      })
+    })
+  })
 })


### PR DESCRIPTION
The last step of implementing the View Bill Run functionality is to create an endpoint and hook its controller up to the `ViewBillRunService`, which is what we do in this change.