### PR TITLE
Allow period start to be same as period end date

### DIFF
--- a/app/translators/calculate_charge.translator.js
+++ b/app/translators/calculate_charge.translator.js
@@ -111,7 +111,7 @@ class CalculateChargeTranslator extends BaseTranslator {
       // validated in the rules service
       eiucSource: Joi.when('compensationCharge', { is: true, then: Joi.string().required() }),
       loss: Joi.string().required(), // validated in rules service
-      periodStart: Joi.date().format(validDateFormats).less(Joi.ref('periodEnd')).min('01-APR-2014').required(),
+      periodStart: Joi.date().format(validDateFormats).max(Joi.ref('periodEnd')).min('01-APR-2014').required(),
       periodEnd: Joi.date().format(validDateFormats).required(),
       regionalChargingArea: Joi.string().required(), // validated in the rules service
       // Set a new field called ruleset. This will be used to determine which ruleset to query in the rules service. If

--- a/test/translators/calculate_charge.translator.test.js
+++ b/test/translators/calculate_charge.translator.test.js
@@ -248,6 +248,20 @@ describe('Calculate Charge translator', () => {
           })
         })
       })
+
+      describe("when 'periodStartDate' is the same as 'periodEndDate'", () => {
+        it('still does not throw an error', async () => {
+          const validPayload = {
+            ...payload,
+            periodStart: '01-APR-2020',
+            periodEnd: '01-APR-2020'
+          }
+
+          const result = new CalculateChargeTranslator(data(validPayload))
+
+          expect(result).to.not.be.an.error()
+        })
+      })
     })
 
     describe('when the data is not valid', () => {


### PR DESCRIPTION
https://trello.com/c/Xz1R1zEf

It was noted when reviewing some data from WRLS recently that some charges have the same start and end period dates. Discussions with the WRLS team and the business confirmed this does happen and is acceptable.

So, this change alters the validation so that the `periodStartDate` when creating a transaction or calculating a charge can be the same (not just less than) the `periodEndDate`.