### PR TITLE
Add stand-in view bill run transaction endpoint

### DIFF
--- a/app/controllers/presroc/bill_runs.controller.js
+++ b/app/controllers/presroc/bill_runs.controller.js
@@ -40,6 +40,16 @@ class BillRunsController {
 
     return h.response(result).code(200)
   }
+
+  static async viewTransaction (req, h) {
+    const result = {
+      transaction: {
+        id: req.params.transactionId
+      }
+    }
+
+    return h.response(result).code(200)
+  }
 }
 
 module.exports = BillRunsController

--- a/app/routes/bill_run.routes.js
+++ b/app/routes/bill_run.routes.js
@@ -40,6 +40,11 @@ const routes = [
     method: 'GET',
     path: '/v2/{regimeId}/bill-runs/{billRunId}',
     handler: PresrocBillRunsController.view
+  },
+  {
+    method: 'GET',
+    path: '/v2/{regimeId}/bill-runs/{billRunId}/transactions/{transactionId}',
+    handler: PresrocBillRunsController.viewTransaction
   }
 ]
 

--- a/test/controllers/presroc/bill_runs.controller.test.js
+++ b/test/controllers/presroc/bill_runs.controller.test.js
@@ -282,4 +282,30 @@ describe('Presroc Bill Runs controller', () => {
       })
     })
   })
+
+  describe('View bill run transaction: GET /v2/{regimeId}/bill-runs/{billRunId}/transactions/{transactionId}', () => {
+    const options = (token, billRunId, transactionId) => {
+      return {
+        method: 'GET',
+        url: `/v2/wrls/bill-runs/${billRunId}/transactions/${transactionId}`,
+        headers: { authorization: `Bearer ${token}` }
+      }
+    }
+
+    describe('When the request is valid', () => {
+      it('returns success status 200', async () => {
+        billRun = await BillRunHelper.addBillRun(authorisedSystem.id, regime.id)
+        const transaction = await TransactionHelper.addTransaction(
+          billRun.id,
+          { createdBy: authorisedSystem.id, regimeId: regime.id }
+        )
+
+        const response = await server.inject(options(authToken, billRun.id, transaction.id))
+        const responsePayload = JSON.parse(response.payload)
+
+        expect(response.statusCode).to.equal(200)
+        expect(responsePayload.status).to.equal('endpoint not implemented')
+      })
+    })
+  })
 })

--- a/test/controllers/presroc/bill_runs.controller.test.js
+++ b/test/controllers/presroc/bill_runs.controller.test.js
@@ -304,7 +304,7 @@ describe('Presroc Bill Runs controller', () => {
         const responsePayload = JSON.parse(response.payload)
 
         expect(response.statusCode).to.equal(200)
-        expect(responsePayload.status).to.equal('endpoint not implemented')
+        expect(responsePayload.transaction.id).to.equal(transaction.id)
       })
     })
   })


### PR DESCRIPTION
https://trello.com/c/0m5idNGk

This is the first step in adding a `GET /v2/{regime}/bill-run/{id}/transactions/{id}` endpoint to the API.

Client systems need to see all the details we hold for a transaction. This change adds the endpoint that will be used, plus a basic test. But none of the logic to actually find and present the transaction is yet included.