### PR TITLE
Add support for automated builds in Docker Hub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,9 @@ EXPOSE $PORT 9229 9230
 
 # Install dependencies first, in a different location for easier app bind mounting for local development. To do this we
 # first copy just the package*.json files from the host
-COPY package.json package-lock.json* ./
+# Note. COPY is always run as the root user in Docker. So, to avoid permission issues we immediately make the node user
+# owner of the copied files
+COPY --chown=node:node package.json package-lock.json* ./
 
 RUN npm install
 
@@ -99,7 +101,9 @@ EXPOSE $PORT
 
 # Install dependencies first, in a different location for easier app bind mounting for local development. To do this we
 # first copy just the package*.json files from the host
-COPY package.json package-lock.json* ./
+# Note. COPY is always run as the root user in Docker. So, to avoid permission issues we immediately make the node user
+# owner of the copied files
+COPY --chown=node:node package.json package-lock.json* ./
 
 RUN npm install
 

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,0 +1,9 @@
+# Dockerhub Hooks
+
+As part of supporting users of the API we are provide access to Docker images via [DockerHub](https://hub.docker.com/repository/docker/environmentagency/sroc-charging-module-api). To ensure what is on DockerHub reflects the latest changes we have enabled [automated builds](https://docs.docker.com/docker-hub/builds/).
+
+This folder and the files in it are specific to supporting building on DockerHub.
+
+We need the current git commit hash and image name as build args. This means  we need to override the default `docker build` used by DockerHub.
+
+The mechanism for doing this is [hooks](https://docs.docker.com/docker-hub/builds/advanced/#override-build-test-or-push-commands), which are executable bash files named after the command they are overriding and placed in a folder called `hooks/`.

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Ensure the build args we need are set. The env vars are provided by Docker
+# https://docs.docker.com/docker-hub/builds/advanced/#environment-variables-for-building-and-testing
+docker build --target production -t $IMAGE_NAME . --build-arg GIT_COMMIT=$SOURCE_COMMIT --build-arg DOCKER_TAG=$IMAGE_NAME


### PR DESCRIPTION
https://trello.com/c/jHORNdnQ

We have been asked to start making available this project's Docker images so the WRLS team have the means to start working with the new version and migrating their code to use it.

We have done this before with [version 1 of the API](https://github.com/defra/charging-module-api) by creating a [repository on Docker Hub](https://hub.docker.com/r/environmentagency/charging-module-api) and pushing each release image to it.

This was fine for v1 where there were months between releases. But both teams are actively working on switching away from V1, so releases should now come thick and fast as new endpoints are added and fixes and improvements are made.

Docker Hub can be linked to your repo which then allows [Automated builds](https://docs.docker.com/docker-hub/builds/) to be enabled. This means every change to `main` will kick off an automated build on Docker Hub.

- we get feedback integrated with our project as to whether the image can still be built
- we can make available the very latest changes in a Docker image to WRLS

On top of that, we can also trigger Docker Hub to build every time we push a new tag to the repo. This means we no longer have to manually pull, re-tag and push images from Artifactory.

So this change makes all the changes necessary to support integration with Docker Hub.