### PR TITLE
Add system user seed

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,7 @@ AIRBRAKE_KEY=longvaluefullofnumbersandlettersinlowercase
 # Authentication config
 ENVIRONMENT=dev
 ADMIN_CLIENT_ID=cognitoclientidforadminuser
+SYSTEM_CLIENT_ID=cognitoclientidforsystemuser
 IGNORE_JWT_EXPIRATION=false
 
 # Database config

--- a/config/authentication.config.js
+++ b/config/authentication.config.js
@@ -5,6 +5,7 @@ require('dotenv').config()
 const config = {
   environment: process.env.ENVIRONMENT,
   adminClientId: process.env.ADMIN_CLIENT_ID,
+  systemClientId: process.env.SYSTEM_CLIENT_ID,
   // Credit to https://stackoverflow.com/a/323546/6117745 for how to handle
   // converting the env var to a boolean
   ignoreJwtExpiration: (String(process.env.IGNORE_JWT_EXPIRATION) === 'true') || false

--- a/db/seeds/02_authorised_systems.js
+++ b/db/seeds/02_authorised_systems.js
@@ -9,7 +9,7 @@ exports.seed = async function (knex) {
   // Utilized by PostgreSQL, the returning method specifies which column should be returned by the insert method.
   // It always returns an array which is way we return it to `result` before then setting `adminUserId` to `result[0]`.
   // http://knexjs.org/#Builder-returning
-  const result = await knex('authorised_systems')
+  let result = await knex('authorised_systems')
     .returning('id')
     .insert({
       client_id: config.adminClientId,
@@ -28,6 +28,23 @@ exports.seed = async function (knex) {
     await knex('authorised_systems_regimes').insert({
       authorised_system_id: adminUserId,
       regime_id: regime.id
+    })
+  }
+
+  if (config.systemClientId) {
+    result = await knex('authorised_systems')
+      .returning('id')
+      .insert({
+        client_id: config.systemClientId,
+        name: 'system',
+        admin: false,
+        status: 'active'
+      })
+    const systemUserId = result[0]
+    const wrlsRegime = regimes.filter(regime => regime.slug === 'wrls')[0]
+    await knex('authorised_systems_regimes').insert({
+      authorised_system_id: systemUserId,
+      regime_id: wrlsRegime.id
     })
   }
 }


### PR DESCRIPTION
https://trello.com/c/jHORNdnQ

When creating an environment from scratch, which we'll often do locally, without fail we'll spend 5 minutes wondering why nothing is working!

It's because we always forget to seed what we refer to as the 'system user'. Basically, a non-admin user that has the same client ID as the AWS Cognito user created for WRLS in that matching environment.

This change hopes to do away with that by adding a seed file that will populate the system user if the env var `SYSTEM_CLIENT_ID` is present.