### PR TITLE
Remove pre-sroc (ruleset) from view bill run

### DIFF
--- a/app/presenters/view_bill_run.presenter.js
+++ b/app/presenters/view_bill_run.presenter.js
@@ -18,7 +18,6 @@ class ViewBillRunPresenter extends BasePresenter {
         region: data.region,
         status: data.status,
         approvedForBilling: false,
-        ruleset: 'presroc',
         creditNoteCount: data.creditNoteCount,
         creditNoteValue: data.creditNoteValue,
         invoiceCount: data.invoiceCount,


### PR DESCRIPTION
https://trello.com/c/XgM2gCbm

This came up when building the view bill run endpoint. The `ruleset: 'presroc'` property is V2's version of the `presroc: true/false` property in V1.

Our issue is what ruleset to use is determined at the transaction, not bill run level. So, we checked in with the team's BA and confirmed that a bill run can include transactions calculated using different rulesets (when we finally have them). It is never going to be set at bill run level.

This change removes it from the view bill run response as it makes no sense at that level.