### PR TITLE
Add seed run script to package.json

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -97,7 +97,7 @@
       "label": "Run sroc-cma dev seeds",
       "detail": "Will run the seeds for the main db",
       "type": "shell",
-      "command": "docker-compose exec app npx knex seed:run",
+      "command": "docker-compose exec app npm run seeddb",
       "group": "test",
       "presentation": {
         "echo": true,

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "createdbtest": "NODE_ENV=test node db/create_database.js",
     "migratedb": "knex migrate:latest",
     "migratedbtest": "NODE_ENV=test knex migrate:latest",
+    "seeddb": "knex seed:run",
     "unit-test": "lab --silent-skips --shuffle"
   },
   "repository": {


### PR DESCRIPTION
We currently have run scripts for creating the database and running migrations in a new environment. But we don't have one for seeding the database. It is on new users to the project to work out what the relevant knex command should be.

We have also spotted some unexpected behaviour when you seed a standalone docker-compose based environment. In this situation we would run `docker-compose exec app npx knex seed:run` from a [makefile](https://en.wikipedia.org/wiki/Makefile). When we do though we see

```
$ make seed
docker-compose exec app npx knex seed:run
Need to install the following packages:
  knex
Ok to proceed? (y) y
npm WARN deprecated urix@0.1.0: Please see https://github.com/lydell/urix#deprecated
npm WARN deprecated resolve-url@0.2.1: https://github.com/lydell/resolve-url#deprecated
Using environment: production
Ran 3 seed files
```

We don't know why we are being prompted to install Knex 🤷. This doesn't happen for the migrations.

So, more for the first reason and a bit for the second, this change adds a run script for seeding the DB.