### PR TITLE
Add admin test view transaction endpoint

### DIFF
--- a/app/controllers/admin/test/test_transactions.controller.js
+++ b/app/controllers/admin/test/test_transactions.controller.js
@@ -1,0 +1,13 @@
+'use strict'
+
+const { ShowTransactionService } = require('../../../services')
+
+class TestTransactionsController {
+  static async show (req, h) {
+    const result = await ShowTransactionService.go(req.params.id)
+
+    return h.response(result).code(200)
+  }
+}
+
+module.exports = TestTransactionsController

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -7,6 +7,7 @@ const AuthorisedSystemsController = require('./admin/authorised_systems.controll
 const AirbrakeController = require('./admin/health/airbrake.controller')
 const DatabaseController = require('./admin/health/database.controller')
 const TestBillRunController = require('./admin/test/test_bill_run.controller')
+const TestTransactionsController = require('./admin/test/test_transactions.controller')
 const NotSupportedController = require('./not_supported.controller')
 const PresrocBillRunsController = require('./presroc/bill_runs.controller')
 const PresrocInvoicesController = require('./presroc/invoices.controller')
@@ -19,6 +20,7 @@ module.exports = {
   AuthorisedSystemsController,
   DatabaseController,
   TestBillRunController,
+  TestTransactionsController,
   PresrocBillRunsController,
   PresrocCalculateChargeController,
   PresrocInvoicesController,

--- a/app/routes/test.routes.js
+++ b/app/routes/test.routes.js
@@ -1,7 +1,8 @@
 'use strict'
 
 const {
-  TestBillRunController
+  TestBillRunController,
+  TestTransactionsController
 } = require('../controllers')
 
 const routes = [
@@ -11,6 +12,17 @@ const routes = [
     handler: TestBillRunController.generate,
     options: {
       description: 'Used by the delivery team to automatically generate bill runs for testing.',
+      auth: {
+        scope: ['admin']
+      }
+    }
+  },
+  {
+    method: 'GET',
+    path: '/admin/test/transactions/{id}',
+    handler: TestTransactionsController.show,
+    options: {
+      description: "Used by the delivery team to check all a transaction's data.",
       auth: {
         scope: ['admin']
       }

--- a/app/services/index.js
+++ b/app/services/index.js
@@ -22,6 +22,7 @@ const ObjectCleaningService = require('./object_cleaning.service')
 const RulesService = require('./rules.service')
 const ShowAuthorisedSystemService = require('./show_authorised_system.service')
 const ShowRegimeService = require('./show_regime.service')
+const ShowTransactionService = require('./show_transaction.service')
 const ValidateBillRunService = require('./validate_bill_run.service')
 const ViewBillRunService = require('./view_bill_run.service')
 
@@ -48,6 +49,7 @@ module.exports = {
   NextBillRunNumberService,
   ShowAuthorisedSystemService,
   ShowRegimeService,
+  ShowTransactionService,
   ValidateBillRunService,
   ViewBillRunService
 }

--- a/app/services/show_transaction.service.js
+++ b/app/services/show_transaction.service.js
@@ -1,0 +1,48 @@
+'use strict'
+
+/**
+ * @module ShowTransactionService
+ */
+
+const Boom = require('@hapi/boom')
+
+const { TransactionModel } = require('../models')
+const { JsonPresenter } = require('../presenters')
+
+/**
+ * Returns the transaction with matching Id
+ *
+ * If no matching transaction is found it will throw a `Boom.notFound()` error (404)
+ *
+ * @param {string} id Id of the transaction to find
+ *
+ * @returns {module:TransactionModel} an instance `TransactionModel` if found else it will throw a `Boom.notFound()`
+ * error (404)
+ */
+class ShowTransactionService {
+  static async go (id) {
+    const transaction = await this._transaction(id)
+
+    if (!transaction) {
+      throw Boom.notFound(`No transaction found with id ${id}`)
+    }
+
+    return this._response(transaction)
+  }
+
+  static _transaction (id) {
+    return TransactionModel.query()
+      .findById(id)
+      .withGraphFetched('billRun')
+      .withGraphFetched('invoice')
+      .withGraphFetched('licence')
+  }
+
+  static _response (transaction) {
+    const presenter = new JsonPresenter(transaction)
+
+    return presenter.go()
+  }
+}
+
+module.exports = ShowTransactionService

--- a/test/controllers/admin/test/test_transactions_controller.test.js
+++ b/test/controllers/admin/test/test_transactions_controller.test.js
@@ -1,0 +1,84 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, before, beforeEach, after } = exports.lab = Lab.script()
+const { expect } = Code
+
+// For running our service
+const { deployment } = require('../../../../server')
+
+// Test helpers
+const {
+  AuthorisationHelper,
+  AuthorisedSystemHelper,
+  BillRunHelper,
+  DatabaseHelper,
+  GeneralHelper,
+  TransactionHelper
+} = require('../../../support/helpers')
+
+// Things we need to stub
+const JsonWebToken = require('jsonwebtoken')
+
+describe('Test transactions controller', () => {
+  let server
+  let authToken
+  let billRun
+
+  before(async () => {
+    server = await deployment()
+    authToken = AuthorisationHelper.adminToken()
+
+    Sinon
+      .stub(JsonWebToken, 'verify')
+      .returns(AuthorisationHelper.decodeToken(authToken))
+  })
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+    await AuthorisedSystemHelper.addAdminSystem()
+    billRun = await BillRunHelper.addBillRun(GeneralHelper.uuid4(), GeneralHelper.uuid4())
+  })
+
+  after(async () => {
+    Sinon.restore()
+  })
+
+  describe('Show transaction: GET /admin/test/transactions/{id}', () => {
+    const options = (id, token) => {
+      return {
+        method: 'GET',
+        url: `/admin/test/transactions/${id}`,
+        headers: { authorization: `Bearer ${token}` }
+      }
+    }
+
+    describe('When the transaction exists', () => {
+      it('returns the matching transaction', async () => {
+        const transaction = await TransactionHelper.addTransaction(billRun.id)
+
+        const response = await server.inject(options(transaction.id, authToken))
+        const payload = JSON.parse(response.payload)
+
+        expect(response.statusCode).to.equal(200)
+        expect(payload.id).to.equal(transaction.id)
+      })
+    })
+
+    describe('When the regime does not exist', () => {
+      it("returns a 404 'not found' response", async () => {
+        const id = GeneralHelper.uuid4()
+        const response = await server.inject(options(id, authToken))
+
+        const payload = JSON.parse(response.payload)
+
+        expect(response.statusCode).to.equal(404)
+        expect(payload.message).to.equal(`No transaction found with id ${id}`)
+      })
+    })
+  })
+})

--- a/test/controllers/admin/test/test_transactions_controller.test.js
+++ b/test/controllers/admin/test/test_transactions_controller.test.js
@@ -24,7 +24,7 @@ const {
 // Things we need to stub
 const JsonWebToken = require('jsonwebtoken')
 
-describe('Test transactions controller', () => {
+describe.only('Test transactions controller', () => {
   let server
   let authToken
   let billRun
@@ -69,7 +69,7 @@ describe('Test transactions controller', () => {
       })
     })
 
-    describe('When the regime does not exist', () => {
+    describe('When the transaction does not exist', () => {
       it("returns a 404 'not found' response", async () => {
         const id = GeneralHelper.uuid4()
         const response = await server.inject(options(id, authToken))

--- a/test/controllers/admin/test/test_transactions_controller.test.js
+++ b/test/controllers/admin/test/test_transactions_controller.test.js
@@ -24,7 +24,7 @@ const {
 // Things we need to stub
 const JsonWebToken = require('jsonwebtoken')
 
-describe.only('Test transactions controller', () => {
+describe('Test transactions controller', () => {
   let server
   let authToken
   let billRun

--- a/test/services/show_transaction.service.test.js
+++ b/test/services/show_transaction.service.test.js
@@ -1,0 +1,101 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const {
+  AuthorisedSystemHelper,
+  BillRunHelper,
+  DatabaseHelper,
+  GeneralHelper,
+  RegimeHelper
+} = require('../support/helpers')
+const { BillRunGenerator } = require('../support/generators')
+const { BillRunModel, InvoiceModel, LicenceModel, TransactionModel } = require('../../app/models')
+const { DataError } = require('objection')
+
+// Thing under test
+const { ShowTransactionService } = require('../../app/services')
+
+describe('Show Transaction service', () => {
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+  })
+
+  describe('When there is a matching transaction', () => {
+    let initialBillRun
+    let transaction
+
+    beforeEach(async () => {
+      const regime = await RegimeHelper.addRegime('wrls', 'Water Resources')
+      const authorisedSystem = await AuthorisedSystemHelper.addSystem('1234546789', 'system', [regime])
+      initialBillRun = await BillRunHelper.addBillRun(authorisedSystem.id, regime.id)
+
+      const payload = {
+        region: 'A',
+        mix: [
+          { type: 'mixed-invoice', count: 1 }
+        ]
+      }
+      await BillRunGenerator.go(payload, initialBillRun.id, authorisedSystem, regime)
+
+      const { transactions } = await BillRunModel.query()
+        .findById(initialBillRun.id)
+        .withGraphFetched('transactions')
+      transaction = transactions[0]
+    })
+
+    it('returns a transaction', async () => {
+      const result = await ShowTransactionService.go(transaction.id)
+
+      expect(result instanceof TransactionModel).to.equal(true)
+      expect(result.id).to.equal(transaction.id)
+    })
+
+    it("returns a result that includes the related 'bill run'", async () => {
+      const result = await ShowTransactionService.go(transaction.id)
+
+      const billRun = await BillRunModel.query().findById(transaction.billRunId)
+
+      expect(result.billRun).to.equal(billRun)
+    })
+
+    it("returns a result that includes the related 'invoice'", async () => {
+      const result = await ShowTransactionService.go(transaction.id)
+
+      const invoice = await InvoiceModel.query().findById(transaction.invoiceId)
+
+      expect(result.invoice).to.equal(invoice)
+    })
+
+    it("returns a result that includes the related 'licence'", async () => {
+      const result = await ShowTransactionService.go(transaction.id)
+
+      const licence = await LicenceModel.query().findById(transaction.licenceId)
+
+      expect(result.licence).to.equal(licence)
+    })
+  })
+
+  describe('When there is no matching transaction', () => {
+    it('throws an error', async () => {
+      const id = GeneralHelper.uuid4()
+      const err = await expect(ShowTransactionService.go(id)).to.reject(Error, `No transaction found with id ${id}`)
+
+      expect(err).to.be.an.error()
+    })
+  })
+
+  describe('When an invalid UUID is used', () => {
+    it('throws an error', async () => {
+      const err = await expect(ShowTransactionService.go('123456789')).to.reject(DataError)
+
+      expect(err).to.be.an.error()
+    })
+  })
+})


### PR DESCRIPTION
https://trello.com/c/0m5idNGk

This is actually a re-think of the [Add stand-in view bill run transaction endpoint](https://github.com/DEFRA/sroc-charging-module-api/pull/211). [Version 1](https://github.com/defra/charging-module.api) of the API has view bill run transaction endpoint through discussions with the WRLS team have confirmed it's not used by them.

The main driver for replicating it in Version 2 of the API has actually been to support testing; our lead QA @anwarisse1 needs a view of the transaction to confirm everything is populated as expected in a range of scenarios.

So, we started PR #211 with the intent of providing a client-focused endpoint, even though WRLS re-confirmed they wouldn't use it and knowing it was just a priority for testing. They also confirmed they only want to see a very small subset of the fields Version 1 currently returns. Again, if we were truly building this endpoint for the client we'd focus on just the fields needed, which would hinder testing.

Having taken a step back, we've decided that at this time what is really needed is an endpoint where the focus is _testing_ and not a potential client system.

Because of this, we're doing this change which adds a view transaction endpoint to our `/admin/test` area of the API. Plus, like the regime and authorised system endpoints, we'll just return everything the database returns by way of the `JsonPresenter`.

Should a 'true' client-facing view transaction endpoint be needed, we can continue with the work in PR #211.

<details>
<summary>Screenshot of response</summary>

![Screenshot 2021-02-22 at 23 51 09](https://user-images.githubusercontent.com/1789650/108785401-3ff57980-7569-11eb-8e4a-041c7bee4c6c.png)

</details>