### PR TITLE
Add stand-in approve bill run endpoint

### DIFF
--- a/app/controllers/presroc/bill_runs.controller.js
+++ b/app/controllers/presroc/bill_runs.controller.js
@@ -33,6 +33,15 @@ class BillRunsController {
 
     return h.response(result).code(200)
   }
+
+  static async approve (req, h) {
+    if (req.app.billRun.status === 'generated') {
+      return h.response().code(204)
+    } else {
+      const Boom = require('@hapi/boom')
+      throw Boom.badData(`Bill run ${req.app.billRun.id} needs to be generated first.`)
+    }
+  }
 }
 
 module.exports = BillRunsController

--- a/app/routes/bill_run.routes.js
+++ b/app/routes/bill_run.routes.js
@@ -22,6 +22,11 @@ const routes = [
     handler: PresrocBillRunsController.generate
   },
   {
+    method: 'PATCH',
+    path: '/v2/{regimeId}/bill-runs/{billRunId}/approve',
+    handler: PresrocBillRunsController.approve
+  },
+  {
     method: 'GET',
     path: '/v2/{regimeId}/bill-runs/{billRunId}/status',
     handler: PresrocBillRunsController.status


### PR DESCRIPTION
https://trello.com/c/SmiI8YaG

This is the first step in adding a `PATCH /v2/{regime}/bill-run/{id}/approve` endpoint to the API.

The roots of this project are based on the work done on the [sroc-tcm-admin](https://github.com/DEFRA/sroc-tcm-admin) service. In that service, individual transactions would need to be approved first at which point they would be included in the next 'bill run' (though it doesn't use that term).

As this API has been developed to serve the WRLS service first, 'bill runs' and creating them first before adding transactions to them came to the fore. But the idea of needing to 'approve' transactions has remained.

The overall need is to add an endpoint that allows the transactions linked to a bill run to be mass approved. This change gets things started with a stand-in endpoint ready to hook up to a service.