### PR TITLE
Add approve bill run service

### DIFF
--- a/app/models/bill_run.model.js
+++ b/app/models/bill_run.model.js
@@ -81,6 +81,13 @@ class BillRunModel extends BaseModel {
   }
 
   /**
+   * Returns true if the bill run status is being 'generated'
+   */
+  $generated () {
+    return this.status === 'generated'
+  }
+
+  /**
    * Returns true if no transactions have been added to this bill run
    */
   $empty () {

--- a/app/services/approve_bill_run.service.js
+++ b/app/services/approve_bill_run.service.js
@@ -1,0 +1,30 @@
+'use strict'
+
+/**
+ * @module ApproveBillRunService
+ */
+
+const Boom = require('@hapi/boom')
+
+class ApproveBillRunService {
+  static async go (billRun) {
+    this._validate(billRun)
+
+    // If we don't await here as well as in the _approve() method the call to go() ends. In our tests we have found this
+    // means any attempt to check the status has changed immediately after fails
+    await this._approve(billRun)
+  }
+
+  static _validate (billRun) {
+    if (!billRun.$generated()) {
+      throw Boom.conflict(`Bill run ${billRun.id} does not have a status of 'generated'.`)
+    }
+  }
+
+  static async _approve (billRun) {
+    await billRun.$query()
+      .patch({ status: 'approved' })
+  }
+}
+
+module.exports = ApproveBillRunService

--- a/app/services/index.js
+++ b/app/services/index.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const ApproveBillRunService = require('./approve_bill_run.service')
 const AuthorisationService = require('./authorisation.service')
 const BillRunService = require('./bill_run.service')
 const BillRunStatusService = require('./bill_run_status.service')
@@ -28,6 +29,7 @@ const ShowTransactionService = require('./show_transaction.service')
 const ViewBillRunService = require('./view_bill_run.service')
 
 module.exports = {
+  ApproveBillRunService,
   AuthorisationService,
   BillRunService,
   BillRunStatusService,

--- a/test/services/approve_bill_run.service.test.js
+++ b/test/services/approve_bill_run.service.test.js
@@ -1,0 +1,51 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const {
+  BillRunHelper,
+  DatabaseHelper,
+  GeneralHelper
+} = require('../support/helpers')
+
+// Thing under test
+const { ApproveBillRunService } = require('../../app/services')
+
+describe('Approve Bill Run service', () => {
+  let billRun
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+
+    billRun = await BillRunHelper.addBillRun(GeneralHelper.uuid4(), GeneralHelper.uuid4())
+  })
+
+  describe("When the 'bill run' can be approved", () => {
+    it("approves the 'bill run'", async () => {
+      billRun.status = 'generated'
+
+      await ApproveBillRunService.go(billRun)
+
+      const refreshedBillRun = await billRun.$query()
+
+      expect(refreshedBillRun.status).to.equal('approved')
+    })
+  })
+
+  describe("When the 'bill run' cannot be approved", () => {
+    describe("because the status is not 'generated'", () => {
+      it('throws an error', async () => {
+        const err = await expect(ApproveBillRunService.go(billRun)).to.reject()
+
+        expect(err).to.be.an.error()
+        expect(err.output.payload.message).to.equal(`Bill run ${billRun.id} does not have a status of 'generated'.`)
+      })
+    })
+  })
+})


### PR DESCRIPTION
https://trello.com/c/SmiI8YaG

As part of adding an endpoint to 'approve' bill runs, we need a service that actually does the work of checking if a bill run is in the right status to be approved, and then marks it as so.

This change adds that service!