### PR TITLE
Hook up approve bill run endpoint to service

### DIFF
--- a/app/controllers/presroc/bill_runs.controller.js
+++ b/app/controllers/presroc/bill_runs.controller.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const {
+  ApproveBillRunService,
   BillRunStatusService,
   CreateBillRunService,
   GenerateBillRunService,
@@ -35,12 +36,9 @@ class BillRunsController {
   }
 
   static async approve (req, h) {
-    if (req.app.billRun.status === 'generated') {
-      return h.response().code(204)
-    } else {
-      const Boom = require('@hapi/boom')
-      throw Boom.badData(`Bill run ${req.app.billRun.id} needs to be generated first.`)
-    }
+    await ApproveBillRunService.go(req.app.billRun)
+
+    return h.response().code(204)
   }
 }
 

--- a/test/controllers/presroc/bill_runs.controller.test.js
+++ b/test/controllers/presroc/bill_runs.controller.test.js
@@ -254,12 +254,12 @@ describe('Presroc Bill Runs controller', () => {
 
     describe('When the request is invalid', () => {
       describe("because the 'bill run' has not been generated", () => {
-        it('returns error status 422', async () => {
+        it('returns error status 409', async () => {
           const response = await server.inject(options(authToken, billRun.id))
           const responsePayload = JSON.parse(response.payload)
 
-          expect(response.statusCode).to.equal(422)
-          expect(responsePayload.message).to.equal(`Bill run ${billRun.id} needs to be generated first.`)
+          expect(response.statusCode).to.equal(409)
+          expect(responsePayload.message).to.equal(`Bill run ${billRun.id} does not have a status of 'generated'.`)
         })
       })
     })


### PR DESCRIPTION
https://trello.com/c/SmiI8YaG

This finishes off the work on a new `/v2/{regimeId}/bill-runs/{billRunId}/approve` endpoint.

We hook up the new `ApproveBillRunService` to the endpoint and check our tests.