### PR TITLE
Correct view bill run zero line count property

### DIFF
--- a/app/presenters/view_bill_run.presenter.js
+++ b/app/presenters/view_bill_run.presenter.js
@@ -26,7 +26,7 @@ class ViewBillRunPresenter extends BasePresenter {
         creditLineValue: data.creditLineValue,
         debitLineCount: data.debitLineCount,
         debitLineValue: data.debitLineValue,
-        zeroValueLineCount: data.zeroLineCount,
+        zeroLineCount: data.zeroLineCount,
         netTotal: data.netTotal,
         transactionFileReference: '',
         invoices: data.invoices

--- a/test/services/view_bill_run.service.test.js
+++ b/test/services/view_bill_run.service.test.js
@@ -104,7 +104,7 @@ describe('View bill run service', () => {
         expect(result.billRun.creditLineValue).to.equal(creditLineValue)
         expect(result.billRun.debitLineCount).to.equal(1)
         expect(result.billRun.debitLineValue).to.equal(debitLineValue)
-        expect(result.billRun.zeroValueLineCount).to.equal(1)
+        expect(result.billRun.zeroLineCount).to.equal(1)
         expect(result.billRun.netTotal).to.equal(debitLineValue - creditLineValue)
       })
 


### PR DESCRIPTION
Spotted in recent testing that in the view bill run presenter we return `zeroValueLineCount` but at the invoice and licence level, we just do `zeroLineCount` i.e. the actual name of the field.

This small change just corrects the inconsistency.