### PR TITLE
Fix invoiceValue for minimum charge

### DIFF
--- a/app/services/generate_bill_run.service.js
+++ b/app/services/generate_bill_run.service.js
@@ -113,7 +113,7 @@ class GenerateBillRunService {
 
   static async _summariseDebitInvoices (billRun, trx) {
     const { count: invoiceCount, value: invoiceValue } = await this._calculateInvoices(
-      await billRun.$relatedQuery('invoices').modify('debit')
+      await billRun.$relatedQuery('invoices', trx).modify('debit')
     )
 
     await billRun.$query(trx)
@@ -125,7 +125,7 @@ class GenerateBillRunService {
 
   static async _summariseCreditInvoices (billRun, trx) {
     const { count: creditNoteCount, value: creditNoteValue } = await this._calculateInvoices(
-      await billRun.$relatedQuery('invoices').modify('credit')
+      await billRun.$relatedQuery('invoices', trx).modify('credit')
     )
 
     await billRun.$query(trx)

--- a/test/services/generate_bill_run.service.test.js
+++ b/test/services/generate_bill_run.service.test.js
@@ -233,7 +233,7 @@ describe('Generate Bill Run Summary service', () => {
 
     describe('When minimum charge applies', () => {
       describe('with one transaction in the invoice', () => {
-        describe("and only a 'credit' transaction is needed", () => {
+        describe("and only a 'credit' adjustment transaction is needed", () => {
           beforeEach(async () => {
             const minimumChargePayload = {
               ...payload,
@@ -246,7 +246,7 @@ describe('Generate Bill Run Summary service', () => {
             await GenerateBillRunService.go(billRun)
           })
 
-          it("saves just a 'credit' adjustment transaction to the db", async () => {
+          it("saves just the 'credit' adjustment transaction to the db", async () => {
             const { transactions } = await BillRunModel.query()
               .findById(billRun.id)
               .withGraphFetched('invoices')
@@ -288,7 +288,7 @@ describe('Generate Bill Run Summary service', () => {
           })
         })
 
-        describe("and only a 'debit' transaction is needed", () => {
+        describe("and only a 'debit' adjustment transaction is needed", () => {
           beforeEach(async () => {
             const minimumChargePayload = {
               ...payload,
@@ -300,7 +300,7 @@ describe('Generate Bill Run Summary service', () => {
             await GenerateBillRunService.go(billRun)
           })
 
-          it("saves just a 'debit' adjustment transaction to the db", async () => {
+          it("saves just the 'debit' adjustment transaction to the db", async () => {
             const { transactions } = await BillRunModel.query()
               .findById(billRun.id)
               .withGraphFetched('invoices')

--- a/test/services/generate_bill_run.service.test.js
+++ b/test/services/generate_bill_run.service.test.js
@@ -34,7 +34,7 @@ const { RulesService } = require('../../app/services')
 // Thing under test
 const { GenerateBillRunService } = require('../../app/services')
 
-describe.only('Generate Bill Run Summary service', () => {
+describe('Generate Bill Run Summary service', () => {
   const customerReference = 'A11111111A'
 
   let billRun

--- a/test/services/generate_bill_run.service.test.js
+++ b/test/services/generate_bill_run.service.test.js
@@ -291,6 +291,19 @@ describe('Generate Bill Run Summary service', () => {
             expect(minimumChargeInvoice.subjectToMinimumChargeDebitValue).to.equal(0)
             expect(minimumChargeInvoice.minimumChargeInvoice).to.equal(true)
           })
+
+          it("updates the 'licence' as expected", async () => {
+            const licences = await minimumChargeBill.$relatedQuery('licences')
+            const minimumChargeLicence = licences[0]
+
+            expect(minimumChargeLicence.creditLineCount).to.equal(2)
+            expect(minimumChargeLicence.creditLineValue).to.equal(2500)
+            expect(minimumChargeLicence.debitLineCount).to.equal(0)
+            expect(minimumChargeLicence.debitLineValue).to.equal(0)
+            expect(minimumChargeLicence.subjectToMinimumChargeCount).to.equal(2)
+            expect(minimumChargeLicence.subjectToMinimumChargeCreditValue).to.equal(2500)
+            expect(minimumChargeLicence.subjectToMinimumChargeDebitValue).to.equal(0)
+          })
         })
 
         describe("and only a 'debit' adjustment transaction is needed", () => {
@@ -347,6 +360,19 @@ describe('Generate Bill Run Summary service', () => {
             expect(minimumChargeInvoice.subjectToMinimumChargeCreditValue).to.equal(0)
             expect(minimumChargeInvoice.subjectToMinimumChargeDebitValue).to.equal(2500)
             expect(minimumChargeInvoice.minimumChargeInvoice).to.equal(true)
+          })
+
+          it("updates the 'licence' as expected", async () => {
+            const licences = await minimumChargeBill.$relatedQuery('invoices')
+            const minimumChargeLicence = licences[0]
+
+            expect(minimumChargeLicence.creditLineCount).to.equal(0)
+            expect(minimumChargeLicence.creditLineValue).to.equal(0)
+            expect(minimumChargeLicence.debitLineCount).to.equal(2)
+            expect(minimumChargeLicence.debitLineValue).to.equal(2500)
+            expect(minimumChargeLicence.subjectToMinimumChargeCount).to.equal(2)
+            expect(minimumChargeLicence.subjectToMinimumChargeCreditValue).to.equal(0)
+            expect(minimumChargeLicence.subjectToMinimumChargeDebitValue).to.equal(2500)
           })
         })
       })

--- a/test/services/generate_bill_run.service.test.js
+++ b/test/services/generate_bill_run.service.test.js
@@ -233,6 +233,8 @@ describe('Generate Bill Run Summary service', () => {
 
     describe('When minimum charge applies', () => {
       describe('with one transaction in the invoice', () => {
+        let minimumChargeBill
+
         describe("and only a 'credit' adjustment transaction is needed", () => {
           beforeEach(async () => {
             const minimumChargePayload = {
@@ -244,6 +246,8 @@ describe('Generate Bill Run Summary service', () => {
             await CreateTransactionService.go(minimumChargePayload, billRun.id, authorisedSystem, regime)
 
             await GenerateBillRunService.go(billRun)
+
+            minimumChargeBill = await BillRunModel.query().findById(billRun.id)
           })
 
           it("saves just the 'credit' adjustment transaction to the db", async () => {
@@ -260,11 +264,7 @@ describe('Generate Bill Run Summary service', () => {
             expect(adjustmentTransactions[0].chargeCredit).to.be.true()
           })
 
-          it('updates the bill run and invoice as expected', async () => {
-            const minimumChargeBill = await BillRunModel.query().findById(billRun.id)
-            const invoices = await minimumChargeBill.$relatedQuery('invoices')
-            const minimumChargeInvoice = invoices[0]
-
+          it("updates the 'bill run' as expected", async () => {
             expect(minimumChargeBill.creditLineCount).to.equal(2)
             expect(minimumChargeBill.creditLineValue).to.equal(2500)
             expect(minimumChargeBill.debitLineCount).to.equal(0)
@@ -276,6 +276,11 @@ describe('Generate Bill Run Summary service', () => {
             expect(minimumChargeBill.creditNoteValue).to.equal(2500)
             expect(minimumChargeBill.invoiceCount).to.equal(0)
             expect(minimumChargeBill.invoiceValue).to.equal(0)
+          })
+
+          it("updates the 'invoice' as expected", async () => {
+            const invoices = await minimumChargeBill.$relatedQuery('invoices')
+            const minimumChargeInvoice = invoices[0]
 
             expect(minimumChargeInvoice.creditLineCount).to.equal(2)
             expect(minimumChargeInvoice.creditLineValue).to.equal(2500)
@@ -298,6 +303,8 @@ describe('Generate Bill Run Summary service', () => {
             await CreateTransactionService.go(minimumChargePayload, billRun.id, authorisedSystem, regime)
 
             await GenerateBillRunService.go(billRun)
+
+            minimumChargeBill = await BillRunModel.query().findById(billRun.id)
           })
 
           it("saves just the 'debit' adjustment transaction to the db", async () => {
@@ -314,11 +321,7 @@ describe('Generate Bill Run Summary service', () => {
             expect(adjustmentTransactions[0].chargeCredit).to.be.false()
           })
 
-          it('updates the bill run and invoice as expected', async () => {
-            const minimumChargeBill = await BillRunModel.query().findById(billRun.id)
-            const invoices = await minimumChargeBill.$relatedQuery('invoices')
-            const minimumChargeInvoice = invoices[0]
-
+          it("updates the 'bill run' as expected", async () => {
             expect(minimumChargeBill.creditLineCount).to.equal(0)
             expect(minimumChargeBill.creditLineValue).to.equal(0)
             expect(minimumChargeBill.debitLineCount).to.equal(2)
@@ -330,6 +333,11 @@ describe('Generate Bill Run Summary service', () => {
             expect(minimumChargeBill.creditNoteValue).to.equal(0)
             expect(minimumChargeBill.invoiceCount).to.equal(1)
             expect(minimumChargeBill.invoiceValue).to.equal(2500)
+          })
+
+          it("updates the 'invoice' as expected", async () => {
+            const invoices = await minimumChargeBill.$relatedQuery('invoices')
+            const minimumChargeInvoice = invoices[0]
 
             expect(minimumChargeInvoice.creditLineCount).to.equal(0)
             expect(minimumChargeInvoice.creditLineValue).to.equal(0)


### PR DESCRIPTION
While developing [`DeleteInvoiceService`](https://github.com/DEFRA/sroc-charging-module-api/pull/221) we realised that `invoiceValue` was being calculated incorrectly in cases where minimum charge applies. This change aims to resolve this.