### PR TITLE
Hook up view bill run invoice endpoint to service

### DIFF
--- a/app/controllers/presroc/bill_runs_invoices.controller.js
+++ b/app/controllers/presroc/bill_runs_invoices.controller.js
@@ -1,7 +1,8 @@
 'use strict'
 
 const {
-  DeleteInvoiceService
+  DeleteInvoiceService,
+  ViewBillRunInvoiceService
 } = require('../../services')
 
 class BillRunsInvoicesController {
@@ -12,11 +13,7 @@ class BillRunsInvoicesController {
   }
 
   static async view (req, h) {
-    const result = {
-      invoice: {
-        id: req.params.invoiceId
-      }
-    }
+    const result = await ViewBillRunInvoiceService.go(req.app.billRun.id, req.params.invoiceId)
 
     return h.response(result).code(200)
   }


### PR DESCRIPTION
https://trello.com/c/r9UClZob

This finishes off the work on a new `GET /v2/{regimeId}/bill-runs/{billRunId}/invoices/{invoiceId}` endpoint.

We hook up the new `ViewBillRunInvoiceService` to the endpoint and check our tests.