### PR TITLE
Spike - Investigate deadlock issues with bill runs

### DIFF
--- a/app/services/create_transaction_licence.service.js
+++ b/app/services/create_transaction_licence.service.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { transaction } = require('objection')
 /**
  * @module CreateTransactionLicenceService
  */
@@ -8,59 +9,60 @@ const { LicenceModel } = require('../models')
 const CreateTransactionTallyService = require('./create_transaction_tally.service')
 
 class CreateTransactionLicenceService {
-  /**
-  * Creates or finds the licence record then generates and returns a 'patch' object to be used update it based on values
-  * in the transaction
-  *
-  * The service accepts a transaction and creates an entry in the `licences` table if one doesn't already exist for the
-  * transaction's 'invoice/licence/customer ref/financial year' combo. It then generates a 'patch' object intended to be
-  * used in a call to `LicenceModel.query().patch()`. The 'patch' object has 2 properties
-  *
-  * - the ID of the licence to update (determined by either the fetched or created `licence`)
-  * - a child object specifiying which fields to update and how
-  *
-  * A full example would be
-  *
-  * ```
-  * const patchObject = await CreateTransactionLicenceService.go(transaction)
-  * await LicenceModel.query().findById(patchObject.id).patch(patchObject.update)
-  * ```
-  *
-  * Note - Our experience is that patching a record in this way is more performant than updating the instance and
-  * calling `$patch()` on it.
-  *
-  * @param {module:TransactionTranslator} transaction translator representing the transaction to be added
-  *
-  * @returns {Object} an object that contains the ID of the licence to be updated, and the updates to be applied
-  */
-  static async go (transaction) {
-    const licence = await this._licence(transaction)
+  static async go (transaction, trx = null) {
+    const id = await this._update(transaction, trx)
 
-    return this._generatePatch(licence.id, transaction)
+    return id
   }
 
-  static async _licence ({
-    invoiceId,
-    billRunId,
-    lineAttr1: licenceNumber
-  }) {
-    return LicenceModel.query()
-      .findOrInsert(
-        {
-          invoiceId,
-          billRunId,
-          licenceNumber
-        }
-      )
+  static async _update (transaction, trx) {
+    const insertRecord = this._generateInsertRecord(transaction)
+    const insertSql = LicenceModel.knexQuery().insert(insertRecord).toQuery()
+    const updateSql = await this._generatePatch(transaction)
+
+    const result = await LicenceModel.knex().raw(
+      `${insertSql}
+      ON CONFLICT (invoice_id, licence_number)
+      DO UPDATE SET
+      ${updateSql}
+      RETURNING id;`
+    ).transacting(trx)
+
+    return result.rows[0].id
   }
 
-  static async _generatePatch (id, transaction) {
-    const patch = {
-      id: id,
-      update: await CreateTransactionTallyService.go(transaction)
+  static _generateInsertRecord (transaction) {
+    const record = {
+      billRunId: transaction.billRunId,
+      invoiceId: transaction.invoiceId,
+      licenceNumber: transaction.lineAttr1
     }
 
-    return patch
+    if (transaction.chargeCredit) {
+      record.creditLineCount = 1
+      record.creditLineValue = transaction.chargeValue
+    } else if (transaction.chargeValue === 0) {
+      record.zeroLineCount = 1
+    } else {
+      record.debitLineCount = 1
+      record.debitLineValue = transaction.chargeValue
+    }
+
+    if (transaction.subjectToMinimumCharge) {
+      record.subjectToMinimumChargeCount = 1
+
+      if (transaction.chargeCredit) {
+        record.subjectToMinimumChargeCreditValue = transaction.chargeValue
+      } else if (transaction.chargeValue !== 0) {
+        record.subjectToMinimumChargeDebitValue = transaction.chargeValue
+      }
+    }
+
+    return record
+  }
+
+  static async _generatePatch (transaction) {
+    return await CreateTransactionTallyService.go(transaction, LicenceModel.tableName)
   }
 }
 

--- a/app/services/create_transaction_tally.service.js
+++ b/app/services/create_transaction_tally.service.js
@@ -4,62 +4,41 @@
  * @module CreateTransactionTallyService
  */
 
-const { raw } = require('../models/base.model')
-
 class CreateTransactionTallyService {
-  /**
-   * Generate a 'patch' object based on a transaction for use in an Objection `query().patch()` call
-   *
-   * When a transaction is added to the system there are fields on the linked bill run, invoice and licence record that
-   * need to be updated. These fields are essentially 'tallies' of the number and value of different types of
-   * transactions added at that level.
-   *
-   * This service takes the transaction and returns an object which can be passed into a `patch()` call.
-   *
-   * ```
-   *  await BillRunModel.query().findById(bullRunId).patch(patchObject)
-   * ```
-   *
-   * @param {module:TransactionTranslator} transaction translator representing the transaction to be tallied and used as
-   * the basis for the 'patch'
-   *
-   * @returns {Object} a 'patch' object suitable for using in an Objection `query().patch()` call where each property is
-   * an instance of `RawBuilder`
-   */
-  static async go (transactionToBeTallied) {
-    return this._generatePatch(transactionToBeTallied)
+  static async go (transactionToBeTallied, tableName) {
+    return this._generatePatch(transactionToBeTallied, tableName)
   }
 
-  static _generatePatch (transaction) {
-    const update = {}
+  static _generatePatch (transaction, tableName) {
+    const updates = []
 
     if (transaction.chargeCredit) {
-      update.creditLineCount = raw('credit_line_count + ?', 1)
-      update.creditLineValue = raw('credit_line_value + ?', transaction.chargeValue)
+      updates.push(`credit_line_count = ${tableName}.credit_line_count + EXCLUDED.credit_line_count`)
+      updates.push(`credit_line_value = ${tableName}.credit_line_value + EXCLUDED.credit_line_value`)
     } else if (transaction.chargeValue === 0) {
-      update.zeroLineCount = raw('zero_line_count + ?', 1)
+      updates.push(`zero_line_count = ${tableName}.zero_line_count + EXCLUDED.zero_line_count`)
     } else {
-      update.debitLineCount = raw('debit_line_count + ?', 1)
-      update.debitLineValue = raw('debit_Line_value + ?', transaction.chargeValue)
+      updates.push(`debit_line_count = ${tableName}.debit_line_count + EXCLUDED.debit_line_count`)
+      updates.push(`debit_line_value = ${tableName}.debit_line_value + EXCLUDED.debit_line_value`)
     }
 
     if (transaction.subjectToMinimumCharge) {
-      update.subjectToMinimumChargeCount = raw('subject_to_minimum_charge_count + ?', 1)
+      updates.push(
+        `subject_to_minimum_charge_count = ${tableName}.subject_to_minimum_charge_count + EXCLUDED.subject_to_minimum_charge_count`
+      )
 
       if (transaction.chargeCredit) {
-        update.subjectToMinimumChargeCreditValue = raw(
-          'subject_to_minimum_charge_credit_value + ?',
-          transaction.chargeValue
+        updates.push(
+          `subject_to_minimum_charge_credit_value = ${tableName}.subject_to_minimum_charge_credit_value + EXCLUDED.subject_to_minimum_charge_credit_value`
         )
       } else if (transaction.chargeValue !== 0) {
-        update.subjectToMinimumChargeDebitValue = raw(
-          'subject_to_minimum_charge_debit_value + ?',
-          transaction.chargeValue
+        updates.push(
+          `subject_to_minimum_charge_debit_value = ${tableName}.subject_to_minimum_charge_debit_value + EXCLUDED.subject_to_minimum_charge_debit_value`
         )
       }
     }
 
-    return update
+    return updates.join(', ')
   }
 }
 


### PR DESCRIPTION
The WRLS team have reported a [deadlock](https://www.postgresql.org/docs/current/explicit-locking.html#LOCKING-DEADLOCKS) issue when trying to add transactions. They received the following error message when running the service locally using Docker.

```
db_1 | 2021-02-27 23:53:07.077 UTC [1235] ERROR: deadlock detected
db_1 | 2021-02-27 23:53:07.077 UTC [1235] DETAIL: Process 1235 waits for ShareLock on transaction 1086; blocked by process 1240.
db_1 | Process 1240 waits for ShareLock on transaction 1089; blocked by process 1235.
db_1 | Process 1235: update "bill_runs" set "id" = $1, "regime_id" = $2, "region" = $3, "status" = $4, "created_by" = $5, "created_at" = $6, "updated_at" = $7, "bill_run_number" = $8, "credit_line_count" = $9, "credit_line_value" = $10, "debit_line_count" = $11, "debit_line_value" = $12, "zero_line_count" = $13, "subject_to_minimum_charge_count" = $14, "subject_to_minimum_charge_credit_value" = $15, "subject_to_minimum_charge_debit_value" = $16, "credit_note_count" = $17, "credit_note_value" = $18, "invoice_count" = $19, "invoice_value" = $20 where "bill_runs"."id" = $21
db_1 | Process 1240: update "bill_runs" set "id" = $1, "regime_id" = $2, "region" = $3, "status" = $4, "created_by" = $5, "created_at" = $6, "updated_at" = $7, "bill_run_number" = $8, "credit_line_count" = $9, "credit_line_value" = $10, "debit_line_count" = $11, "debit_line_value" = $12, "zero_line_count" = $13, "subject_to_minimum_charge_count" = $14, "subject_to_minimum_charge_credit_value" = $15, "subject_to_minimum_charge_debit_value" = $16, "credit_note_count" = $17, "credit_note_value" = $18, "invoice_count" = $19, "invoice_value" = $20 where "bill_runs"."id" = $21
db_1 | 2021-02-27 23:53:07.077 UTC [1235] HINT: See server log for query details.
db_1 | 2021-02-27 23:53:07.077 UTC [1235] CONTEXT: while locking tuple (0,23) in relation "bill_runs"
```

We understand that the WRLS service sends the create transaction requests in batches, with each batch run as a separate job. This means the service will receive multiple requests _at the same time_, all attempting to update the same bill run.

This opens us up to deadlocks. This [stackoverflow post](https://stackoverflow.com/a/16044035/6117745) gives a simple example of how it only takes a couple of `INSERT` statements in the wrong order to cause a deadlock.

This spike is just to allow us to investigate possible solutions. Any solutions or changes we wish to take from this will be done in new PR's.