### PR TITLE
Remove approvedForBilling from view bill run

### DIFF
--- a/app/presenters/view_bill_run.presenter.js
+++ b/app/presenters/view_bill_run.presenter.js
@@ -17,7 +17,6 @@ class ViewBillRunPresenter extends BasePresenter {
         billRunNumber: data.billRunNumber,
         region: data.region,
         status: data.status,
-        approvedForBilling: false,
         creditNoteCount: data.creditNoteCount,
         creditNoteValue: data.creditNoteValue,
         invoiceCount: data.invoiceCount,


### PR DESCRIPTION
An artefact of [version 1](https://github.com/defra/charging-module-api) was that the bill run record had an `approved_for_billing` flag separate from the bill run status.

As part of the improvements we have been doing to Version 2 we have managed to drop the need for this, specifically with the work we have done in [Add approve bill run service](https://github.com/DEFRA/sroc-charging-module-api/pull/237).

But as we were not sure what we'd be doing when we developed the view bill run endpoint, we still have this as a property in the `ViewBillRunPresenter`.

This change drops it from the presenter.