### PR TITLE
Update bill run status when last invoice is deleted

### DIFF
--- a/app/models/bill_run.model.js
+++ b/app/models/bill_run.model.js
@@ -58,6 +58,26 @@ class BillRunModel extends BaseModel {
   }
 
   /**
+   * Modifiers allow us to reuse logic in queries, eg. to select all bill runs which are empty:
+   *
+   * return billRun.$query()
+   *   .modify('empty')
+   */
+  static get modifiers () {
+    return {
+      /**
+       * empty modifier selects all bill runs which are empty.
+       */
+      empty (query) {
+        query
+          .where('creditLineCount', 0)
+          .where('debitLineCount', 0)
+          .where('zeroLineCount', 0)
+      }
+    }
+  }
+
+  /**
    * Returns whether the bill run can be 'edited'
    *
    * Once a bill run has been 'sent', which means the transaction file is generated, it cannot be edited. This includes

--- a/app/services/delete_invoice.service.js
+++ b/app/services/delete_invoice.service.js
@@ -31,9 +31,23 @@ class DeleteInvoiceService {
 
       await BillRunModel
         .query(trx)
-        .findById(invoice.billRunId)
+        .findById(billRunId)
         .patch(billRunPatch)
+
+      await this._setBillRunStatusIfEmpty(billRunId, trx)
     })
+  }
+
+  /**
+   * Set the bill run status to 'initialised' if it's empty. We find by bill run id then use the empty modifier to
+   * ensure we only patch the bill run if it's empty.
+   */
+  static async _setBillRunStatusIfEmpty (billRunId, trx) {
+    await BillRunModel
+      .query(trx)
+      .findById(billRunId)
+      .modify('empty')
+      .patch({ status: 'initialised' })
   }
 
   /**

--- a/test/services/delete_invoice.service.test.js
+++ b/test/services/delete_invoice.service.test.js
@@ -312,6 +312,54 @@ describe('Delete Invoice service', () => {
         expect(transactions).to.be.empty()
       })
     })
+
+    describe("and it's the only invoice in the bill run", () => {
+      beforeEach(async () => {
+        await CreateTransactionService.go(payload, billRun.id, authorisedSystem, regime)
+        invoice = await InvoiceModel.query().findOne({ billRunId: billRun.id })
+        await billRun.$query().patch({ status: 'NOT_INITIALISED' })
+      })
+
+      it.only("changes the bill run status to 'initialised'", async () => {
+        await DeleteInvoiceService.go(invoice.id, billRun.id)
+
+        const result = await BillRunModel.query().findById(billRun.id)
+
+        expect(result.status).to.equal('initialised')
+      })
+
+      it('updates the bill run values', async () => {
+        // We generate the bill run to ensure that the invoice-level figures are updated
+        await GenerateBillRunService.go(billRun)
+
+        await DeleteInvoiceService.go(invoice.id, billRun.id)
+
+        const result = await BillRunModel.query().findById(billRun.id)
+
+        expect(result.debitLineCount).to.equal(0)
+        expect(result.debitLineValue).to.equal(0)
+        expect(result.invoiceCount).to.equal(0)
+        expect(result.invoiceValue).to.equal(0)
+      })
+
+      it('deletes the invoice licences', async () => {
+        const invoice = await InvoiceModel.query().findOne({ billRunId: billRun.id })
+
+        await DeleteInvoiceService.go(invoice.id, billRun.id)
+
+        const licences = await LicenceModel.query().select().where({ billRunId: billRun.id })
+        expect(licences).to.be.empty()
+      })
+
+      it('deletes the invoice transactions', async () => {
+        const invoice = await InvoiceModel.query().findOne({ billRunId: billRun.id })
+
+        await DeleteInvoiceService.go(invoice.id, billRun.id)
+
+        const transactions = await TransactionModel.query().select().where({ billRunId: billRun.id })
+        expect(transactions).to.be.empty()
+      })
+    })
   })
 
   describe('When an invalid invoice is supplied', () => {


### PR DESCRIPTION
An additional consideration when deleting an invoice from a bill run is that we want to ensure the bill run status reverts to its `initialised` state if there are no invoices left. This change implements this.