### PR TITLE
Remove bill run fetch and checks in BillRunService

### DIFF
--- a/app/controllers/admin/test/test_bill_runs.controller.js
+++ b/app/controllers/admin/test/test_bill_runs.controller.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { BillRunModel } = require('../../../models')
 const { CreateBillRunService } = require('../../../services')
 const { BillRunGenerator } = require('../../../../test/support/generators')
 
@@ -11,9 +12,11 @@ class TestBillRunController {
       req.app.regime
     )
 
+    const billRun = await BillRunModel.query().findById(result.billRun.id)
+
     BillRunGenerator.go(
       req.payload,
-      result.billRun.id,
+      billRun,
       req.auth.credentials.user,
       req.app.regime,
       req.server.logger

--- a/app/controllers/presroc/bill_runs_transactions.controller.js
+++ b/app/controllers/presroc/bill_runs_transactions.controller.js
@@ -6,7 +6,7 @@ const {
 
 class BillRunsTransactionsController {
   static async create (req, h) {
-    const result = await CreateTransactionService.go(req.payload, req.params.billRunId, req.auth.credentials.user, req.app.regime)
+    const result = await CreateTransactionService.go(req.payload, req.app.billRun, req.auth.credentials.user, req.app.regime)
 
     return h.response(result).code(201)
   }

--- a/app/services/bill_run.service.js
+++ b/app/services/bill_run.service.js
@@ -26,14 +26,6 @@ class BillRunService {
   }
 
   static _validateBillRun (billRun, transaction) {
-    if (!billRun) {
-      throw Boom.badData(`Bill run ${transaction.billRunId} is unknown.`)
-    }
-
-    if (!billRun.$editable()) {
-      throw Boom.badData(`Bill run ${billRun.id} cannot be edited because its status is ${billRun.status}.`)
-    }
-
     if (billRun.region !== transaction.region) {
       throw Boom.badData(
         `Bill run ${billRun.id} is for region ${billRun.region} but transaction is for region ${transaction.region}.`

--- a/app/services/bill_run.service.js
+++ b/app/services/bill_run.service.js
@@ -6,21 +6,19 @@
 
 const Boom = require('@hapi/boom')
 
-const { BillRunModel } = require('../models')
-
 class BillRunService {
   /**
-  * Finds the matching bill run, determines if a transaction can be added to it and updates the count and value stat
-  * as per the transaction details.
+  * Determines if a transaction is for the same region as the requested bill run and if so, updates the bill run's count
+  * and value stats based on the transaction details
   *
-  * Note that the updated stats are _not_ saved back to the database; it is up to the caller to do this.
+  * Note - The updated stats are _not_ saved back to the database; it is up to the caller to do this.
   *
-  * @param {Object} transaction translator belonging to the bill run to find and assess
-  * @returns {module:BillRunModel} a `BillRunModel` if found else it will throw a `Boom` error
+  * @param {module:BillRunModel} billRun the bill run this transaction is being added to
+  * @param {module:TransactionTranslator} transaction translator representing the transaction to be added
+  *
+  * @returns {module:BillRunModel} the updated (but not persisted) instance of `BillRunModel`
   */
-  static async go (transaction) {
-    const billRun = await BillRunModel.query().findById(transaction.billRunId)
-
+  static async go (billRun, transaction) {
     this._validateBillRun(billRun, transaction)
     this._updateStats(billRun, transaction)
 

--- a/app/services/create_transaction.service.js
+++ b/app/services/create_transaction.service.js
@@ -13,18 +13,18 @@ const LicenceService = require('./licence.service')
 const { CreateTransactionPresenter } = require('../presenters')
 
 class CreateTransactionService {
-  static async go (payload, billRunId, authorisedSystem, regime) {
-    const translator = this._translateRequest(payload, billRunId, authorisedSystem, regime)
+  static async go (payload, billRun, authorisedSystem, regime) {
+    const translator = this._translateRequest(payload, billRun.id, authorisedSystem, regime)
 
     const calculatedCharge = await this._calculateCharge(translator, regime)
 
     this._applyCalculatedCharge(translator, calculatedCharge)
 
-    const billRun = await this._billRun(translator)
+    const billRunPatch = await this._billRun(billRun, translator)
     const invoice = await this._invoice(translator)
     const licence = await this._licence({ ...translator, invoiceId: invoice.id })
 
-    const transaction = await this._create(translator, invoice, licence, billRun)
+    const transaction = await this._create(translator, invoice, licence, billRunPatch)
 
     return this._response(transaction)
   }
@@ -57,8 +57,8 @@ class CreateTransactionService {
     Object.assign(translator, calculatedCharge)
   }
 
-  static async _billRun (translator) {
-    return BillRunService.go(translator)
+  static async _billRun (billRun, translator) {
+    return BillRunService.go(billRun, translator)
   }
 
   static async _invoice (translator) {

--- a/test/controllers/presroc/bill_runs.controller.test.js
+++ b/test/controllers/presroc/bill_runs.controller.test.js
@@ -132,7 +132,7 @@ describe('Presroc Bill Runs controller', () => {
       describe('because the summary has not yet been generated', () => {
         it('returns success status 204 (IMPORTANT! Does not mean generation completed successfully)', async () => {
           const requestPayload = GeneralHelper.cloneObject(requestFixtures.simple)
-          await CreateTransactionService.go(requestPayload, billRun.id, authorisedSystem, regime)
+          await CreateTransactionService.go(requestPayload, billRun, authorisedSystem, regime)
 
           const response = await server.inject(options(authToken, billRun.id))
 

--- a/test/services/bill_run.service.test.js
+++ b/test/services/bill_run.service.test.js
@@ -39,14 +39,14 @@ describe('Bill Run service', () => {
     })
 
     it('returns the matching bill run', async () => {
-      const result = await BillRunService.go(transaction)
+      const result = await BillRunService.go(billRun, transaction)
 
       expect(result.id).to.equal(billRun.id)
     })
 
     describe('When a debit transaction is supplied', () => {
       it('correctly calculates the summary', async () => {
-        const result = await BillRunService.go(transaction)
+        const result = await BillRunService.go(billRun, transaction)
 
         expect(result.debitLineCount).to.equal(1)
         expect(result.debitLineValue).to.equal(transaction.chargeValue)
@@ -57,7 +57,7 @@ describe('Bill Run service', () => {
       it('correctly calculates the summary', async () => {
         transaction.chargeCredit = true
 
-        const result = await BillRunService.go(transaction)
+        const result = await BillRunService.go(billRun, transaction)
 
         expect(result.creditLineCount).to.equal(1)
         expect(result.creditLineValue).to.equal(transaction.chargeValue)
@@ -68,7 +68,7 @@ describe('Bill Run service', () => {
       it('correctly calculates the summary', async () => {
         transaction.chargeValue = 0
 
-        const result = await BillRunService.go(transaction)
+        const result = await BillRunService.go(billRun, transaction)
 
         expect(result.zeroLineCount).to.equal(1)
       })
@@ -80,7 +80,7 @@ describe('Bill Run service', () => {
       })
 
       it('correctly sets the subject to minimum charge flag', async () => {
-        const result = await BillRunService.go(transaction)
+        const result = await BillRunService.go(billRun, transaction)
 
         expect(result.subjectToMinimumChargeCount).to.equal(1)
       })
@@ -91,11 +91,11 @@ describe('Bill Run service', () => {
         })
 
         it('correctly calculates the total for a debit', async () => {
-          const firstResult = await BillRunService.go(transaction)
+          const firstResult = await BillRunService.go(billRun, transaction)
           // We save the invoice with stats to the database as this isn't done by BillRunService
           await BillRunModel.query().update(firstResult)
 
-          const secondResult = await BillRunService.go(transaction)
+          const secondResult = await BillRunService.go(billRun, transaction)
 
           expect(secondResult.subjectToMinimumChargeCount).to.equal(2)
           expect(secondResult.subjectToMinimumChargeDebitValue).to.equal(transaction.chargeValue * 2)
@@ -104,11 +104,11 @@ describe('Bill Run service', () => {
         it('correctly calculates the total for a credit', async () => {
           transaction.chargeCredit = true
 
-          const firstResult = await BillRunService.go(transaction)
+          const firstResult = await BillRunService.go(billRun, transaction)
           // We save the invoice with stats to the database as this isn't done by BillRunService
           await BillRunModel.query().update(firstResult)
 
-          const secondResult = await BillRunService.go(transaction)
+          const secondResult = await BillRunService.go(billRun, transaction)
 
           expect(secondResult.subjectToMinimumChargeCount).to.equal(2)
           expect(secondResult.subjectToMinimumChargeCreditValue).to.equal(transaction.chargeValue * 2)
@@ -119,11 +119,11 @@ describe('Bill Run service', () => {
     describe('When two transactions are created', () => {
       it('correctly calculates the summary', async () => {
         transaction.billRunId = billRun.id
-        const firstResult = await BillRunService.go(transaction)
+        const firstResult = await BillRunService.go(billRun, transaction)
         // We save the invoice with stats to the database as this isn't done by BillRunService
         await BillRunModel.query().update(firstResult)
 
-        const secondResult = await BillRunService.go(transaction)
+        const secondResult = await BillRunService.go(billRun, transaction)
 
         expect(secondResult.debitLineCount).to.equal(2)
         expect(secondResult.debitLineValue).to.equal(transaction.chargeValue * 2)
@@ -132,36 +132,6 @@ describe('Bill Run service', () => {
   })
 
   describe('When an invalid bill run ID is supplied', () => {
-    const unknownBillRunId = GeneralHelper.uuid4()
-
-    describe('because no matching bill run exists', () => {
-      it('throws an error', async () => {
-        const transaction = { ...dummyTransaction, billRunId: unknownBillRunId }
-
-        const err = await expect(BillRunService.go(transaction)).to.reject()
-
-        expect(err).to.be.an.error()
-        expect(err.output.payload.message).to.equal(`Bill run ${unknownBillRunId} is unknown.`)
-      })
-    })
-
-    describe('because the bill run is not editable', () => {
-      beforeEach(async () => {
-        billRun = await BillRunHelper.addBillRun(authorisedSystemId, regimeId, 'A', 'billed')
-      })
-
-      it('throws an error', async () => {
-        const transaction = { ...dummyTransaction, billRunId: billRun.id }
-
-        const err = await expect(BillRunService.go(transaction)).to.reject()
-
-        expect(err).to.be.an.error()
-        expect(err.output.payload.message)
-          .to
-          .equal(`Bill run ${billRun.id} cannot be edited because its status is billed.`)
-      })
-    })
-
     describe('because the bill run is for a different region', () => {
       beforeEach(async () => {
         billRun = await BillRunHelper.addBillRun(authorisedSystemId, regimeId, 'W')
@@ -170,7 +140,7 @@ describe('Bill Run service', () => {
       it('throws an error', async () => {
         const transaction = { ...dummyTransaction, billRunId: billRun.id }
 
-        const err = await expect(BillRunService.go(transaction)).to.reject()
+        const err = await expect(BillRunService.go(billRun, transaction)).to.reject()
 
         expect(err).to.be.an.error()
         expect(err.output.payload.message)

--- a/test/services/calculate_minimum_charge.service.test.js
+++ b/test/services/calculate_minimum_charge.service.test.js
@@ -67,7 +67,7 @@ describe('Calculate Minimum Charge service', () => {
     })
 
     it('returns an array of transactions', async () => {
-      await CreateTransactionService.go(payload, billRun.id, authorisedSystem, regime)
+      await CreateTransactionService.go(payload, billRun, authorisedSystem, regime)
 
       const calculatedMinimumCharges = await CalculateMinimumChargeService.go(billRun)
 
@@ -76,7 +76,7 @@ describe('Calculate Minimum Charge service', () => {
     })
 
     it('correctly calculates the debit value', async () => {
-      const transaction = await CreateTransactionService.go(payload, billRun.id, authorisedSystem, regime)
+      const transaction = await CreateTransactionService.go(payload, billRun, authorisedSystem, regime)
       const transactionRecord = await TransactionModel.query().findById(transaction.transaction.id)
 
       const calculatedMinimumCharges = await CalculateMinimumChargeService.go(billRun)
@@ -87,7 +87,7 @@ describe('Calculate Minimum Charge service', () => {
     })
 
     it('correctly calculates the credit value', async () => {
-      const transaction = await CreateTransactionService.go({ ...payload, credit: true }, billRun.id, authorisedSystem, regime)
+      const transaction = await CreateTransactionService.go({ ...payload, credit: true }, billRun, authorisedSystem, regime)
       const transactionRecord = await TransactionModel.query().findById(transaction.transaction.id)
 
       const calculatedMinimumCharges = await CalculateMinimumChargeService.go(billRun)
@@ -98,8 +98,8 @@ describe('Calculate Minimum Charge service', () => {
     })
 
     it('correctly calculates both a credit and debit if required', async () => {
-      const creditTransaction = await CreateTransactionService.go({ ...payload, credit: true }, billRun.id, authorisedSystem, regime)
-      const debitTransaction = await CreateTransactionService.go(payload, billRun.id, authorisedSystem, regime)
+      const creditTransaction = await CreateTransactionService.go({ ...payload, credit: true }, billRun, authorisedSystem, regime)
+      const debitTransaction = await CreateTransactionService.go(payload, billRun, authorisedSystem, regime)
       const creditTransactionRecord = await TransactionModel.query().findById(creditTransaction.transaction.id)
       const debitTransactionRecord = await TransactionModel.query().findById(debitTransaction.transaction.id)
 
@@ -125,7 +125,7 @@ describe('Calculate Minimum Charge service', () => {
       it('returns an empty array', async () => {
         rulesServiceStub.restore()
         RulesServiceHelper.mockValue(Sinon, RulesService, rulesServiceResponse, 5000)
-        await CreateTransactionService.go(payload, billRun.id, authorisedSystem, regime)
+        await CreateTransactionService.go(payload, billRun, authorisedSystem, regime)
 
         const calculatedMinimumCharges = await CalculateMinimumChargeService.go(billRun)
 
@@ -136,7 +136,7 @@ describe('Calculate Minimum Charge service', () => {
 
     describe("because minimum charge doesn't apply to this transaction", () => {
       it('returns an empty array', async () => {
-        await CreateTransactionService.go({ ...payload, subjectToMinimumCharge: false }, billRun.id, authorisedSystem, regime)
+        await CreateTransactionService.go({ ...payload, subjectToMinimumCharge: false }, billRun, authorisedSystem, regime)
 
         const calculatedMinimumCharges = await CalculateMinimumChargeService.go(billRun)
 
@@ -155,8 +155,8 @@ describe('Calculate Minimum Charge service', () => {
     })
 
     it('handles them all correctly', async () => {
-      const firstTransaction = await CreateTransactionService.go({ ...payload, customerReference: 'FIRST_CUST' }, billRun.id, authorisedSystem, regime)
-      const secondTransaction = await CreateTransactionService.go({ ...payload, customerReference: 'SECOND_CUST' }, billRun.id, authorisedSystem, regime)
+      const firstTransaction = await CreateTransactionService.go({ ...payload, customerReference: 'FIRST_CUST' }, billRun, authorisedSystem, regime)
+      const secondTransaction = await CreateTransactionService.go({ ...payload, customerReference: 'SECOND_CUST' }, billRun, authorisedSystem, regime)
       const firstRecord = await TransactionModel.query().findById(firstTransaction.transaction.id)
       const secondRecord = await TransactionModel.query().findById(secondTransaction.transaction.id)
 

--- a/test/services/create_minimum_charge_adjustment.service.test.js
+++ b/test/services/create_minimum_charge_adjustment.service.test.js
@@ -72,7 +72,7 @@ describe('Create Minimum Charge Adjustment service', () => {
 
     beforeEach(async () => {
       billRun = await BillRunHelper.addBillRun(authorisedSystem.id, regime.id)
-      transaction = await CreateTransactionService.go(payload, billRun.id, authorisedSystem, regime)
+      transaction = await CreateTransactionService.go(payload, billRun, authorisedSystem, regime)
       transactionRecord = await TransactionModel.query().findById(transaction.transaction.id)
       licence = await LicenceModel.query().findById(transactionRecord.licenceId)
       minimumChargeAdjustment = await CreateMinimumChargeAdjustmentService.go(licence, chargeValue, chargeCredit)

--- a/test/services/delete_invoice.service.test.js
+++ b/test/services/delete_invoice.service.test.js
@@ -66,7 +66,7 @@ describe('Delete Invoice service', () => {
   describe('When a valid invoice is supplied', () => {
     describe("and it's a debit invoice", () => {
       beforeEach(async () => {
-        await CreateTransactionService.go(payload, billRun.id, authorisedSystem, regime)
+        await CreateTransactionService.go(payload, billRun, authorisedSystem, regime)
         invoice = await InvoiceModel.query().findOne({ billRunId: billRun.id })
       })
 
@@ -113,7 +113,7 @@ describe('Delete Invoice service', () => {
 
     describe("and it's a credit invoice", () => {
       beforeEach(async () => {
-        await CreateTransactionService.go({ ...payload, credit: true }, billRun.id, authorisedSystem, regime)
+        await CreateTransactionService.go({ ...payload, credit: true }, billRun, authorisedSystem, regime)
         invoice = await InvoiceModel.query().findOne({ billRunId: billRun.id })
       })
 
@@ -162,7 +162,7 @@ describe('Delete Invoice service', () => {
       beforeEach(async () => {
         rulesServiceStub.restore()
         RulesServiceHelper.mockValue(Sinon, RulesService, rulesServiceResponse, 0)
-        await CreateTransactionService.go(payload, billRun.id, authorisedSystem, regime)
+        await CreateTransactionService.go(payload, billRun, authorisedSystem, regime)
         invoice = await InvoiceModel.query().findOne({ billRunId: billRun.id })
       })
 
@@ -211,7 +211,7 @@ describe('Delete Invoice service', () => {
         await CreateTransactionService.go({
           ...payload,
           subjectToMinimumCharge: true
-        }, billRun.id, authorisedSystem, regime)
+        }, billRun, authorisedSystem, regime)
         invoice = await InvoiceModel.query().findOne({ billRunId: billRun.id })
       })
 
@@ -266,7 +266,7 @@ describe('Delete Invoice service', () => {
           ...payload,
           subjectToMinimumCharge: true,
           credit: true
-        }, billRun.id, authorisedSystem, regime)
+        }, billRun, authorisedSystem, regime)
         invoice = await InvoiceModel.query().findOne({ billRunId: billRun.id })
       })
 
@@ -315,7 +315,7 @@ describe('Delete Invoice service', () => {
 
     describe("and it's the only invoice in the bill run", () => {
       beforeEach(async () => {
-        await CreateTransactionService.go(payload, billRun.id, authorisedSystem, regime)
+        await CreateTransactionService.go(payload, billRun, authorisedSystem, regime)
         invoice = await InvoiceModel.query().findOne({ billRunId: billRun.id })
         await billRun.$query().patch({ status: 'NOT_INITIALISED' })
       })
@@ -331,11 +331,11 @@ describe('Delete Invoice service', () => {
 
     describe('and there are other invoices in the bill run', () => {
       beforeEach(async () => {
-        await CreateTransactionService.go(payload, billRun.id, authorisedSystem, regime)
+        await CreateTransactionService.go(payload, billRun, authorisedSystem, regime)
         await CreateTransactionService.go({
           ...payload,
           customerReference: 'SOMEONE_ELSE'
-        }, billRun.id, authorisedSystem, regime)
+        }, billRun, authorisedSystem, regime)
 
         invoice = await InvoiceModel.query().findOne({
           billRunId: billRun.id,
@@ -369,7 +369,7 @@ describe('Delete Invoice service', () => {
 
     describe('because there the invoice is not linked to the bill run', () => {
       it('throws an error', async () => {
-        await CreateTransactionService.go(payload, billRun.id, authorisedSystem, regime)
+        await CreateTransactionService.go(payload, billRun, authorisedSystem, regime)
         invoice = await InvoiceModel.query().findOne({ billRunId: billRun.id })
         const unknownBillRunId = GeneralHelper.uuid4()
 

--- a/test/services/show_transaction.service.test.js
+++ b/test/services/show_transaction.service.test.js
@@ -42,7 +42,7 @@ describe('Show Transaction service', () => {
           { type: 'mixed-invoice', count: 1 }
         ]
       }
-      await BillRunGenerator.go(payload, initialBillRun.id, authorisedSystem, regime)
+      await BillRunGenerator.go(payload, initialBillRun, authorisedSystem, regime)
 
       const { transactions } = await BillRunModel.query()
         .findById(initialBillRun.id)

--- a/test/services/view_bill_run.service.test.js
+++ b/test/services/view_bill_run.service.test.js
@@ -80,21 +80,21 @@ describe('View bill run service', () => {
           ...payload,
           customerReference: 'CREDIT',
           credit: true
-        }, billRun.id, authorisedSystem, regime)
+        }, billRun, authorisedSystem, regime)
 
         rulesServiceStub.restore()
         RulesServiceHelper.mockValue(Sinon, RulesService, rulesServiceResponse, debitLineValue)
         await CreateTransactionService.go({
           ...payload,
           customerReference: 'DEBIT'
-        }, billRun.id, authorisedSystem, regime)
+        }, billRun, authorisedSystem, regime)
 
         rulesServiceStub.restore()
         RulesServiceHelper.mockValue(Sinon, RulesService, rulesServiceResponse, 0)
         await CreateTransactionService.go({
           ...payload,
           customerReference: 'ZERO'
-        }, billRun.id, authorisedSystem, regime)
+        }, billRun, authorisedSystem, regime)
       })
 
       it('returns correct credit/debit values', async () => {


### PR DESCRIPTION
A follow up to [Remove redundant bill run 'gets' and 'checks'](https://github.com/DEFRA/sroc-charging-module-api/pull/233) we've spotted that the `BillRunService` both fetches the bill run and then performs the same checks that the bill run plugin is doing via `RequestBillRunService`.

This change removes these redundant calls.

> Found as part of [Spike - Investigate deadlock issues with bill runs](https://github.com/DEFRA/sroc-charging-module-api/pull/247)