### PR TITLE
Add CreateTransactionTallyPatchService

### DIFF
--- a/app/services/create_transaction_tally.service.js
+++ b/app/services/create_transaction_tally.service.js
@@ -1,0 +1,47 @@
+'use strict'
+
+/**
+ * @module CreateTransactionTallyService
+ */
+
+const { raw } = require('../models/base.model')
+
+class CreateTransactionTallyService {
+  static async go (transactionToBeTallied) {
+    return this._generatePatch(transactionToBeTallied)
+  }
+
+  static _generatePatch (transaction) {
+    const update = {}
+
+    if (transaction.chargeCredit) {
+      update.creditLineCount = raw('credit_line_count + ?', 1)
+      update.creditLineValue = raw('credit_line_value + ?', transaction.chargeValue)
+    } else if (transaction.chargeValue === 0) {
+      update.zeroLineCount = raw('zero_line_count + ?', 1)
+    } else {
+      update.debitLineCount = raw('debit_line_count + ?', 1)
+      update.debitLineValue = raw('debit_Line_value + ?', transaction.chargeValue)
+    }
+
+    if (transaction.subjectToMinimumCharge) {
+      update.subjectToMinimumChargeCount = raw('subject_to_minimum_charge_count + ?', 1)
+
+      if (transaction.chargeCredit) {
+        update.subjectToMinimumChargeCreditValue = raw(
+          'subject_to_minimum_charge_credit_value + ?',
+          transaction.chargeValue
+        )
+      } else if (transaction.chargeValue !== 0) {
+        update.subjectToMinimumChargeDebitValue = raw(
+          'subject_to_minimum_charge_debit_value + ?',
+          transaction.chargeValue
+        )
+      }
+    }
+
+    return update
+  }
+}
+
+module.exports = CreateTransactionTallyService

--- a/app/services/create_transaction_tally.service.js
+++ b/app/services/create_transaction_tally.service.js
@@ -7,6 +7,25 @@
 const { raw } = require('../models/base.model')
 
 class CreateTransactionTallyService {
+  /**
+   * Generate a 'patch' object based on a transaction for use in an Objection `query().patch()` call
+   *
+   * When a transaction is added to the system there are fields on the linked bill run, invoice and licence record that
+   * need to be updated. These fields are essentially 'tallies' of the number and value of different types of
+   * transactions added at that level.
+   *
+   * This service takes the transaction and returns an object which can be passed into a `patch()` call.
+   *
+   * ```
+   *  await BillRunModel.query().findById(bullRunId).patch(patchObject)
+   * ```
+   *
+   * @param {module:TransactionTranslator} transaction translator representing the transaction to be tallied and used as
+   * the basis for the 'patch'
+   *
+   * @returns {Object} a 'patch' object suitable for using in an Objection `query().patch()` call where each property is
+   * an instance of `RawBuilder`
+   */
   static async go (transactionToBeTallied) {
     return this._generatePatch(transactionToBeTallied)
   }

--- a/app/services/index.js
+++ b/app/services/index.js
@@ -11,6 +11,7 @@ const CreateAuthorisedSystemService = require('./create_authorised_system.servic
 const CreateBillRunService = require('./create_bill_run.service')
 const CreateMinimumChargeAdjustmentService = require('./create_minimum_charge_adjustment.service')
 const CreateTransactionService = require('./create_transaction.service')
+const CreateTransactionTallyService = require('./create_transaction_tally.service')
 const DatabaseHealthCheckService = require('./database_health_check.service')
 const DbErrorsService = require('./db_errors.service')
 const DeleteInvoiceService = require('./delete_invoice.service')
@@ -43,6 +44,7 @@ module.exports = {
   CreateMinimumChargeAdjustmentService,
   CreateBillRunService,
   CreateTransactionService,
+  CreateTransactionTallyService,
   DatabaseHealthCheckService,
   DbErrorsService,
   DeleteInvoiceService,

--- a/test/services/create_transaction_tally.service.test.js
+++ b/test/services/create_transaction_tally.service.test.js
@@ -34,6 +34,11 @@ describe('Create Transaction Tally service', () => {
       const result = await CreateTransactionTallyService.go(transaction)
 
       expect(result.debitLineCount).to.be.an.instanceOf(RawBuilder)
+      // Adding this comment to the first instance we do this. We lowercase() the value before asserting it matches
+      // because of inconsistencies we found in knex's camel to snake case conversion. In our tests `debitLineValue`
+      // was getting converted to `debit_Line_value`. Rather than update our test to match the inconsistency we have
+      // chosen to lowercase everything before comparing. The case does not matter to the final query, and we feel this
+      // will make our tests less brittle should it get fixed, or other examples arise.
       expect(result.debitLineCount._sql.toLowerCase()).to.equal('debit_line_count + ?')
       expect(result.debitLineCount._args[0]).to.equal(1)
 

--- a/test/services/create_transaction_tally.service.test.js
+++ b/test/services/create_transaction_tally.service.test.js
@@ -1,0 +1,189 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const { RawBuilder } = require('objection/lib/queryBuilder/RawBuilder')
+
+// Thing under test
+const { CreateTransactionTallyService } = require('../../app/services')
+
+describe('Create Transaction Tally service', () => {
+  let transaction
+
+  beforeEach(() => {
+    transaction = {
+      chargeCredit: false,
+      chargeValue: 10
+    }
+  })
+
+  describe("When the transaction is a 'debit'", () => {
+    it("only includes 'debit' properties", async () => {
+      const result = await CreateTransactionTallyService.go(transaction)
+
+      expect(result).to.only.include(['debitLineCount', 'debitLineValue'])
+    })
+
+    it("has correctly configured instances of 'Objection RawBuilder'", async () => {
+      const result = await CreateTransactionTallyService.go(transaction)
+
+      expect(result.debitLineCount).to.be.an.instanceOf(RawBuilder)
+      expect(result.debitLineCount._sql.toLowerCase()).to.equal('debit_line_count + ?')
+      expect(result.debitLineCount._args[0]).to.equal(1)
+
+      expect(result.debitLineValue).to.be.an.instanceOf(RawBuilder)
+      expect(result.debitLineValue._sql.toLowerCase()).to.equal('debit_line_value + ?')
+      expect(result.debitLineValue._args[0]).to.equal(transaction.chargeValue)
+    })
+
+    describe("and 'subject to minimum charge'", () => {
+      beforeEach(() => {
+        transaction.subjectToMinimumCharge = true
+      })
+
+      it("only includes 'debit' properties and 'subjectToMinimumChargeCount'", async () => {
+        const result = await CreateTransactionTallyService.go(transaction)
+
+        expect(result).to.only.include([
+          'debitLineCount',
+          'debitLineValue',
+          'subjectToMinimumChargeCount',
+          'subjectToMinimumChargeDebitValue'
+        ])
+      })
+
+      it("has correctly configured instances of 'Objection RawBuilder'", async () => {
+        const result = await CreateTransactionTallyService.go(transaction)
+
+        expect(result.debitLineCount).to.be.an.instanceOf(RawBuilder)
+        expect(result.debitLineCount._sql.toLowerCase()).to.equal('debit_line_count + ?')
+        expect(result.debitLineCount._args[0]).to.equal(1)
+
+        expect(result.debitLineValue).to.be.an.instanceOf(RawBuilder)
+        expect(result.debitLineValue._sql.toLowerCase()).to.equal('debit_line_value + ?')
+        expect(result.debitLineValue._args[0]).to.equal(transaction.chargeValue)
+
+        expect(result.subjectToMinimumChargeCount).to.be.an.instanceOf(RawBuilder)
+        expect(result.subjectToMinimumChargeCount._sql.toLowerCase()).to.equal('subject_to_minimum_charge_count + ?')
+        expect(result.subjectToMinimumChargeCount._args[0]).to.equal(1)
+
+        expect(result.subjectToMinimumChargeDebitValue).to.be.an.instanceOf(RawBuilder)
+        expect(result.subjectToMinimumChargeDebitValue._sql.toLowerCase())
+          .to.equal('subject_to_minimum_charge_debit_value + ?')
+        expect(result.subjectToMinimumChargeDebitValue._args[0]).to.equal(transaction.chargeValue)
+      })
+    })
+  })
+
+  describe("When the transaction is a 'credit'", () => {
+    beforeEach(() => {
+      transaction.chargeCredit = true
+    })
+
+    it("only includes 'credit' properties", async () => {
+      const result = await CreateTransactionTallyService.go(transaction)
+
+      expect(result).to.only.include(['creditLineCount', 'creditLineValue'])
+    })
+
+    it("has correctly configured instances of 'Objection RawBuilder'", async () => {
+      const result = await CreateTransactionTallyService.go(transaction)
+
+      expect(result.creditLineCount).to.be.an.instanceOf(RawBuilder)
+      expect(result.creditLineCount._sql.toLowerCase()).to.equal('credit_line_count + ?')
+      expect(result.creditLineCount._args[0]).to.equal(1)
+
+      expect(result.creditLineValue).to.be.an.instanceOf(RawBuilder)
+      expect(result.creditLineValue._sql.toLowerCase()).to.equal('credit_line_value + ?')
+      expect(result.creditLineValue._args[0]).to.equal(transaction.chargeValue)
+    })
+
+    describe("and 'subject to minimum charge'", () => {
+      beforeEach(() => {
+        transaction.subjectToMinimumCharge = true
+      })
+
+      it("only includes 'credit' properties and 'subjectToMinimumChargeCount'", async () => {
+        const result = await CreateTransactionTallyService.go(transaction)
+
+        expect(result).to.only.include([
+          'creditLineCount',
+          'creditLineValue',
+          'subjectToMinimumChargeCount',
+          'subjectToMinimumChargeCreditValue'
+        ])
+      })
+
+      it("has correctly configured instances of 'Objection RawBuilder'", async () => {
+        const result = await CreateTransactionTallyService.go(transaction)
+
+        expect(result.creditLineCount).to.be.an.instanceOf(RawBuilder)
+        expect(result.creditLineCount._sql.toLowerCase()).to.equal('credit_line_count + ?')
+        expect(result.creditLineCount._args[0]).to.equal(1)
+
+        expect(result.creditLineValue).to.be.an.instanceOf(RawBuilder)
+        expect(result.creditLineValue._sql.toLowerCase()).to.equal('credit_line_value + ?')
+        expect(result.creditLineValue._args[0]).to.equal(transaction.chargeValue)
+
+        expect(result.subjectToMinimumChargeCount).to.be.an.instanceOf(RawBuilder)
+        expect(result.subjectToMinimumChargeCount._sql.toLowerCase()).to.equal('subject_to_minimum_charge_count + ?')
+        expect(result.subjectToMinimumChargeCount._args[0]).to.equal(1)
+
+        expect(result.subjectToMinimumChargeCreditValue).to.be.an.instanceOf(RawBuilder)
+        expect(result.subjectToMinimumChargeCreditValue._sql.toLowerCase())
+          .to.equal('subject_to_minimum_charge_credit_value + ?')
+        expect(result.subjectToMinimumChargeCreditValue._args[0]).to.equal(transaction.chargeValue)
+      })
+    })
+  })
+
+  describe("When the transaction is 'zero value'", () => {
+    beforeEach(() => {
+      transaction.chargeValue = 0
+    })
+
+    it("only includes 'zero value' properties", async () => {
+      const result = await CreateTransactionTallyService.go(transaction)
+
+      expect(result).to.only.include(['zeroLineCount'])
+    })
+
+    it("has correctly configured instances of 'Objection RawBuilder'", async () => {
+      const result = await CreateTransactionTallyService.go(transaction)
+
+      expect(result.zeroLineCount).to.be.an.instanceOf(RawBuilder)
+      expect(result.zeroLineCount._sql.toLowerCase()).to.equal('zero_line_count + ?')
+      expect(result.zeroLineCount._args[0]).to.equal(1)
+    })
+
+    describe("and 'subject to minimum charge'", () => {
+      beforeEach(() => {
+        transaction.subjectToMinimumCharge = true
+      })
+
+      it("only includes 'zero value' properties and 'subjectToMinimumChargeCount'", async () => {
+        const result = await CreateTransactionTallyService.go(transaction)
+
+        expect(result).to.only.include(['zeroLineCount', 'subjectToMinimumChargeCount'])
+      })
+
+      it("has correctly configured instances of 'Objection RawBuilder'", async () => {
+        const result = await CreateTransactionTallyService.go(transaction)
+
+        expect(result.zeroLineCount).to.be.an.instanceOf(RawBuilder)
+        expect(result.zeroLineCount._sql.toLowerCase()).to.equal('zero_line_count + ?')
+        expect(result.zeroLineCount._args[0]).to.equal(1)
+
+        expect(result.subjectToMinimumChargeCount).to.be.an.instanceOf(RawBuilder)
+        expect(result.subjectToMinimumChargeCount._sql.toLowerCase()).to.equal('subject_to_minimum_charge_count + ?')
+        expect(result.subjectToMinimumChargeCount._args[0]).to.equal(1)
+      })
+    })
+  })
+})


### PR DESCRIPTION
When we add a transaction to a bill run we also update 'tally' values in the related bill run, invoice and licence records.

We were already aware of duplication across the `BillRunService`, `InvoiceService` and `LicenceService` for handling this. Now, as part of performance improvements identified in [Spike - Investigate deadlock issues with bill runs](https://github.com/DEFRA/sroc-charging-module-api/pull/247) we need to change the way it's done.

So, we're taking the opportunity to put the functionality into a new service that can then be reused. The new service needs to generate a 'patch' object that can be used with an Objection model's static `query().patch()` method. We have found updating a model in this way, versus using the instance `$patch()` method, gives a slight performance boost.

This change just adds the new service and associated tests. We'll update the services in later PR's as we move them over to the new method of updating the DB.