### PR TITLE
Add signedChargeValue to ShowTransactionService

### DIFF
--- a/app/services/show_transaction.service.js
+++ b/app/services/show_transaction.service.js
@@ -39,9 +39,16 @@ class ShowTransactionService {
   }
 
   static _response (transaction) {
+    const signedChargeValue = this._signedChargeValue(transaction)
+    Object.assign(transaction, { signedChargeValue })
     const presenter = new JsonPresenter(transaction)
 
     return presenter.go()
+  }
+
+  static _signedChargeValue (transaction) {
+    const { chargeCredit, chargeValue } = transaction
+    return chargeCredit ? -chargeValue : chargeValue
   }
 }
 


### PR DESCRIPTION
To help with testing it's been requested that we add the signed value of `chargeValue` to the test `ShowTransactionService`. This change implements this by adding `signedChargeValue`.