### PR TITLE
Handle call to /generate for generated bill run

### DIFF
--- a/app/services/generate_bill_run_validation.service.js
+++ b/app/services/generate_bill_run_validation.service.js
@@ -23,6 +23,10 @@ class GenerateBillRunValidationService {
       throw Boom.conflict(`Summary for bill run ${billRun.id} is already being generated`)
     }
 
+    if (billRun.$generated()) {
+      throw Boom.conflict(`Summary for bill run ${billRun.id} has already been generated.`)
+    }
+
     if (billRun.$empty()) {
       throw Boom.badData(`Summary for bill run ${billRun.id} cannot be generated because it has no transactions.`)
     }

--- a/test/services/generate_bill_run_validation.service.test.js
+++ b/test/services/generate_bill_run_validation.service.test.js
@@ -56,6 +56,16 @@ describe('Generate Bill Run Validation service', () => {
       })
     })
 
+    describe("because the bill run has already been 'generated'", () => {
+      it('throws an error', async () => {
+        const generatingBillRun = await BillRunHelper.addBillRun(authorisedSystem.id, regime.id, 'A', 'generated')
+        const err = await expect(GenerateBillRunValidationService.go(generatingBillRun)).to.reject()
+
+        expect(err).to.be.an.error()
+        expect(err.output.payload.message).to.equal(`Summary for bill run ${generatingBillRun.id} has already been generated.`)
+      })
+    })
+
     describe('because the bill run is empty', () => {
       it('throws an error', async () => {
         const emptyBillRun = await BillRunHelper.addBillRun(authorisedSystem.id, regime.id, 'A')


### PR DESCRIPTION
https://trello.com/c/TNehNlxK

This came up as an edge case we had not considered when generating bill runs. What should we do if a request to `/generate` is received for a bill run that has a status of 'generated'?

Whilst we believe running the process for a second time would not change the generated bill run values, we've decided it would be more prudent to just not allow this. We certainly cannot think of a scenario where this would be needed so there is no question regards needing to support it.

So, this change adds a new check to `GenerateBillRunValidationService`. If the `status` is generated we will return a `409` in the same way we do if the status is `generating`.