### PR TITLE
Add SendBillRunReferenceService

### DIFF
--- a/app/models/bill_run.model.js
+++ b/app/models/bill_run.model.js
@@ -108,6 +108,13 @@ class BillRunModel extends BaseModel {
   }
 
   /**
+   * Returns true if the bill run status is 'approved'
+   */
+  $approved () {
+    return this.status === 'approved'
+  }
+
+  /**
    * Returns true if no transactions have been added to this bill run
    */
   $empty () {

--- a/app/models/invoice.model.js
+++ b/app/models/invoice.model.js
@@ -103,6 +103,16 @@ class InvoiceModel extends BaseModel {
       debit (query) {
         query
           .whereRaw('debit_line_value > credit_line_value')
+      },
+
+      /**
+       * billable modifier only returns those invoices which are not flagged as deminimis or zero value. Intended to
+       * be used when `/send` a bill run is requested to determine which to generate transaction references for
+       */
+      billable (query) {
+        query
+          .where('zeroValueInvoice', false)
+          .where('deminimisInvoice', false)
       }
     }
   }

--- a/app/services/index.js
+++ b/app/services/index.js
@@ -29,6 +29,7 @@ const NextTransactionReferenceService = require('./next_transaction_reference.se
 const ObjectCleaningService = require('./object_cleaning.service')
 const RequestBillRunService = require('./request_bill_run.service')
 const RulesService = require('./rules.service')
+const SendBillRunReferenceService = require('./send_bill_run_reference.service')
 const ShowAuthorisedSystemService = require('./show_authorised_system.service')
 const ShowRegimeService = require('./show_regime.service')
 const ShowTransactionService = require('./show_transaction.service')
@@ -65,6 +66,7 @@ module.exports = {
   NextBillRunNumberService,
   NextFileReferenceService,
   NextTransactionReferenceService,
+  SendBillRunReferenceService,
   ShowAuthorisedSystemService,
   ShowRegimeService,
   ShowTransactionService,

--- a/app/services/next_file_reference.service.js
+++ b/app/services/next_file_reference.service.js
@@ -29,17 +29,19 @@ class NextFileReferenceService {
    *
    * @param {module:RegimeModel} regime instance of the `RegimeModel` that the reference is for
    * @param {string} region The region the reference is for
+   * @param {Object} [trx] Optional Objection database `transaction` object to be used in the update to
+   * `sequence_counters`
    *
    * @returns {string} the generated file reference
    */
-  static async go (regime, region) {
-    const result = await this._updateSequenceCounter(regime.id, region)
+  static async go (regime, region, trx = null) {
+    const result = await this._updateSequenceCounter(regime.id, region, trx)
 
     return this._response(regime.slug, region, result.fileNumber)
   }
 
-  static async _updateSequenceCounter (regimeId, region) {
-    return SequenceCounterModel.query()
+  static async _updateSequenceCounter (regimeId, region, trx) {
+    return SequenceCounterModel.query(trx)
       .findOne({
         regime_id: regimeId,
         region

--- a/app/services/next_transaction_reference.service.js
+++ b/app/services/next_transaction_reference.service.js
@@ -31,17 +31,19 @@ class NextTransactionReferenceService {
    * @param {string} region The region to get the next reference for
    * @param {string} transactionType Either a `'C'` or an `'I'` which denotes whether the invoice the reference is for
    * is an invoice or a credit note.
+   * @param {Object} [trx] Optional Objection database `transaction` object to be used in the update to
+   * `sequence_counters`
    *
    * @returns {string} the generated transaction reference
    */
-  static async go (regimeId, region, transactionType) {
-    const result = await this._updateSequenceCounter(regimeId, region)
+  static async go (regimeId, region, transactionType, trx = null) {
+    const result = await this._updateSequenceCounter(regimeId, region, trx)
 
     return this._response(region, result.transactionNumber, transactionType)
   }
 
-  static async _updateSequenceCounter (regimeId, region) {
-    return SequenceCounterModel.query()
+  static async _updateSequenceCounter (regimeId, region, trx) {
+    return SequenceCounterModel.query(trx)
       .findOne({
         regime_id: regimeId,
         region

--- a/app/services/send_bill_run_reference.service.js
+++ b/app/services/send_bill_run_reference.service.js
@@ -11,6 +11,22 @@ const NextFileReferenceService = require('./next_file_reference.service')
 const NextTransactionReferenceService = require('./next_transaction_reference.service')
 
 class SendBillRunReferenceService {
+  /**
+   * Prepare a 'bill run' to be ready for billing by generating transaction references for its billable invoices and
+   * generating an export file reference for it
+   *
+   * Before we export the invoices for a bill run to SSCL for billing we are required to generate a transaction
+   * reference for each one.
+   *
+   * With that done we then need to generate a file reference for the export but only if there were invoices to be
+   * billed. We don't want the files we send to SSCL to appear to have a gap in their reference so no one gets worried
+   * something has gotten lost or missed.
+   *
+   * Either way, the bill run status is updated to 'pending' to flag it ready to be exported.
+   *
+   * @param {@module RegimeModel} regime An instance of `RegimeModel` which matches the requested regime
+   * @param {@module:BillRunModel} billRun The 'bill run' to send for billing
+   */
   static async go (regime, billRun) {
     this._validate(billRun)
 

--- a/app/services/send_bill_run_reference.service.js
+++ b/app/services/send_bill_run_reference.service.js
@@ -1,0 +1,41 @@
+'use strict'
+
+/**
+ * @module SendBillRunReferenceService
+ */
+
+const Boom = require('@hapi/boom')
+
+const { BillRunModel } = require('../models')
+const NextFileReferenceService = require('./next_file_reference.service')
+
+class SendBillRunReferenceService {
+  static async go (regime, billRun) {
+    this._validate(billRun)
+
+    // If we don't await here as well as in the _send() method the call to go() ends. In our tests we have found this
+    // means any attempt to check the status has changed immediately after fails
+    await this._send(regime, billRun)
+  }
+
+  static _validate (billRun) {
+    if (!billRun.$approved()) {
+      throw Boom.conflict(`Bill run ${billRun.id} does not have a status of 'approved'.`)
+    }
+  }
+
+  static async _send (regime, billRun) {
+    await BillRunModel.transaction(async trx => {
+      const fileReference = await NextFileReferenceService.go(regime, billRun.region, trx)
+
+      await BillRunModel.query(trx)
+        .findById(billRun.id)
+        .patch({
+          status: 'pending',
+          fileReference
+        })
+    })
+  }
+}
+
+module.exports = SendBillRunReferenceService

--- a/app/services/send_bill_run_reference.service.js
+++ b/app/services/send_bill_run_reference.service.js
@@ -61,18 +61,19 @@ class SendBillRunReferenceService {
   static async _updateBillableInvoices (regime, billRun, trx) {
     const billableInvoices = await this._billableInvoices(billRun)
 
-    for (let i = 0; i < billableInvoices.length; i++) {
-      const invoice = billableInvoices[i]
+    let updatedInvoices = 0
+
+    for (const invoice of billableInvoices) {
       const reference = await NextTransactionReferenceService.go(
         regime.id,
         billRun.region,
         invoice.$transactionType(),
         trx
       )
-      await invoice.$query(trx).patch({ transactionReference: reference })
+      updatedInvoices += await invoice.$query(trx).patch({ transactionReference: reference })
     }
 
-    return billableInvoices.length
+    return updatedInvoices
   }
 
   static _billableInvoices (billRun) {

--- a/db/migrations/20210305132500_alter_bill_runs.js
+++ b/db/migrations/20210305132500_alter_bill_runs.js
@@ -1,0 +1,21 @@
+'use strict'
+
+const tableName = 'bill_runs'
+
+exports.up = async function (knex) {
+  await knex
+    .schema
+    .alterTable(tableName, table => {
+      // Add column
+      table.string('file_reference')
+    })
+}
+
+exports.down = async function (knex) {
+  await knex
+    .schema
+    .alterTable(tableName, table => {
+      // Drop the column we added
+      table.dropColumn('file_reference')
+    })
+}

--- a/test/models/bill_run.model.test.js
+++ b/test/models/bill_run.model.test.js
@@ -54,4 +54,18 @@ describe('Bill Run Model', () => {
       expect(instance.$editable()).to.be.false()
     })
   })
+
+  describe('the $approved() method', () => {
+    it("returns 'true' when the status is 'approved'", async () => {
+      const instance = BillRunModel.fromJson({ status: 'approved' })
+
+      expect(instance.$approved()).to.be.true()
+    })
+
+    it("returns 'false' when the status is something else", async () => {
+      const instance = BillRunModel.fromJson({ status: 'initialised' })
+
+      expect(instance.$approved()).to.be.false()
+    })
+  })
 })

--- a/test/models/invoice.model.test.js
+++ b/test/models/invoice.model.test.js
@@ -81,6 +81,25 @@ describe('Invoice Model', () => {
         })
       })
     })
+
+    describe('#Billable', () => {
+      describe('when there is a mix of invoices', () => {
+        let billableInvoice
+
+        beforeEach(async () => {
+          billableInvoice = await InvoiceHelper.addInvoice(billRun.id, 'CMA0000001', 2020, 0, 0, 1, 501, 0)
+          await InvoiceHelper.addInvoice(billRun.id, 'CMA0000002', 2020, 0, 0, 1, 350, 0) // debit less than 500
+          await InvoiceHelper.addInvoice(billRun.id, 'CMA0000003', 2020, 0, 0, 0, 0, 1) // zero value
+        })
+
+        it("only returns those which are 'billable'", async () => {
+          const results = await InvoiceModel.query().modify('billable').debug()
+
+          expect(results.length).to.equal(1)
+          expect(results[0].id).to.equal(billableInvoice.id)
+        })
+      })
+    })
   })
 
   describe('$transactionType method', () => {

--- a/test/models/invoice.model.test.js
+++ b/test/models/invoice.model.test.js
@@ -93,7 +93,7 @@ describe('Invoice Model', () => {
         })
 
         it("only returns those which are 'billable'", async () => {
-          const results = await InvoiceModel.query().modify('billable').debug()
+          const results = await InvoiceModel.query().modify('billable')
 
           expect(results.length).to.equal(1)
           expect(results[0].id).to.equal(billableInvoice.id)

--- a/test/services/send_bill_run_reference.service.test.js
+++ b/test/services/send_bill_run_reference.service.test.js
@@ -75,6 +75,29 @@ describe('Send Bill Run Reference service', () => {
         expect(updatedInvoices).to.only.include(billableInvoices)
       })
     })
+
+    describe("but none of its invoices are 'billable'", () => {
+      beforeEach(async () => {
+        await InvoiceHelper.addInvoice(billRun.id, 'CMA0000001', 2020, 0, 0, 1, 350, 0) // deminimis debit
+        await InvoiceHelper.addInvoice(billRun.id, 'CMA0000002', 2020, 0, 0, 0, 0, 1) // zero value
+      })
+
+      it("still updates the status to 'pending'", async () => {
+        await SendBillRunReferenceService.go(regime, billRun)
+
+        const refreshedBillRun = await billRun.$query()
+
+        expect(refreshedBillRun.status).to.equal('pending')
+      })
+
+      it("it does not assign a 'file reference'", async () => {
+        await SendBillRunReferenceService.go(regime, billRun)
+
+        const refreshedBillRun = await billRun.$query()
+
+        expect(refreshedBillRun.fileReference).to.be.null()
+      })
+    })
   })
 
   describe("When the 'bill run' cannot be sent", () => {

--- a/test/services/send_bill_run_reference.service.test.js
+++ b/test/services/send_bill_run_reference.service.test.js
@@ -46,6 +46,8 @@ describe('Send Bill Run Reference service', () => {
     })
 
     it("generates a file reference for the 'bill run'", async () => {
+      // A bill run needs at least one billable invoice for a file reference to be generated
+      await InvoiceHelper.addInvoice(billRun.id, 'CMA0000001', 2020, 0, 0, 1, 501, 0) // standard debit
       await SendBillRunReferenceService.go(regime, billRun)
 
       const refreshedBillRun = await billRun.$query()

--- a/test/services/send_bill_run_reference.service.test.js
+++ b/test/services/send_bill_run_reference.service.test.js
@@ -1,0 +1,66 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const {
+  BillRunHelper,
+  DatabaseHelper,
+  GeneralHelper,
+  RegimeHelper,
+  SequenceCounterHelper
+} = require('../support/helpers')
+
+// Thing under test
+const { SendBillRunReferenceService } = require('../../app/services')
+
+describe.only('Send Bill Run Reference service', () => {
+  let regime
+  let billRun
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+
+    regime = await RegimeHelper.addRegime('wrls', 'WRLS')
+    billRun = await BillRunHelper.addBillRun(regime.id, GeneralHelper.uuid4())
+    await SequenceCounterHelper.addSequenceCounter(regime.id, billRun.region)
+  })
+
+  describe("When the 'bill run' can be sent", () => {
+    it("sets the 'bill run' status to 'pending'", async () => {
+      billRun.status = 'approved'
+
+      await SendBillRunReferenceService.go(regime, billRun)
+
+      const refreshedBillRun = await billRun.$query()
+
+      expect(refreshedBillRun.status).to.equal('pending')
+    })
+
+    it.only("generates a file reference for the 'bill run'", async () => {
+      billRun.status = 'approved'
+
+      await SendBillRunReferenceService.go(regime, billRun)
+
+      const refreshedBillRun = await billRun.$query()
+
+      expect(refreshedBillRun.fileReference).to.equal('nalai50001')
+    })
+  })
+
+  describe("When the 'bill run' cannot be sent", () => {
+    describe("ecause the status is not 'approved'", () => {
+      it('throws an error', async () => {
+        const err = await expect(SendBillRunReferenceService.go(regime, billRun)).to.reject()
+
+        expect(err).to.be.an.error()
+        expect(err.output.payload.message).to.equal(`Bill run ${billRun.id} does not have a status of 'approved'.`)
+      })
+    })
+  })
+})

--- a/test/services/send_bill_run_reference.service.test.js
+++ b/test/services/send_bill_run_reference.service.test.js
@@ -63,7 +63,7 @@ describe('Send Bill Run Reference service', () => {
         await InvoiceHelper.addInvoice(billRun.id, 'CMA0000006', 2020, 0, 0, 1, 501, 0, 1, 0, 501) // std minimum charge
       })
 
-      it("generates and assigns a 'transaction reference' to the billable invoices", async () => {
+      it("generates and assigns a 'transaction reference' to only the billable invoices", async () => {
         await SendBillRunReferenceService.go(regime, billRun)
 
         const invoices = await billRun.$relatedQuery('invoices')

--- a/test/support/helpers/invoice.helper.js
+++ b/test/support/helpers/invoice.helper.js
@@ -81,7 +81,7 @@ class InvoiceHelper {
     const netValue = debitLineValue - creditLineValue
     const minimumChargeNetValue = subjectToMinimumChargeCreditValue + subjectToMinimumChargeDebitValue
 
-    if ((nonZeroLinceCount === 0) && (zeroLineCount > 0)) {
+    if ((nonZeroLineCount === 0) && (zeroLineCount > 0)) {
       flags.zeroValueInvoice = true
     } else if ((netValue > 0) && (netValue < 500)) {
       if (minimumChargeNetValue === 0) {

--- a/test/support/helpers/invoice.helper.js
+++ b/test/support/helpers/invoice.helper.js
@@ -77,7 +77,7 @@ class InvoiceHelper {
       deminimisInvoice: false
     }
 
-    const nonZeroLinceCount = creditLineCount + debitLineCount
+    const nonZeroLineCount = creditLineCount + debitLineCount
     const netValue = debitLineValue - creditLineValue
     const minimumChargeNetValue = subjectToMinimumChargeCreditValue + subjectToMinimumChargeDebitValue
 

--- a/test/support/helpers/invoice.helper.js
+++ b/test/support/helpers/invoice.helper.js
@@ -35,6 +35,16 @@ class InvoiceHelper {
     subjectToMinimumChargeCreditValue = 0,
     subjectToMinimumChargeDebitValue = 0
   ) {
+    const flags = this._flags(
+      creditLineCount,
+      creditLineValue,
+      debitLineCount,
+      debitLineValue,
+      zeroLineCount,
+      subjectToMinimumChargeCreditValue,
+      subjectToMinimumChargeDebitValue
+    )
+
     return InvoiceModel.query()
       .insert({
         billRunId,
@@ -47,9 +57,39 @@ class InvoiceHelper {
         zeroLineCount,
         subjectToMinimumChargeCount,
         subjectToMinimumChargeCreditValue,
-        subjectToMinimumChargeDebitValue
+        subjectToMinimumChargeDebitValue,
+        ...flags
       })
       .returning('*')
+  }
+
+  static _flags (
+    creditLineCount,
+    creditLineValue,
+    debitLineCount,
+    debitLineValue,
+    zeroLineCount,
+    subjectToMinimumChargeCreditValue,
+    subjectToMinimumChargeDebitValue
+  ) {
+    const flags = {
+      zeroValueInvoice: false,
+      deminimisInvoice: false
+    }
+
+    const nonZeroLinceCount = creditLineCount + debitLineCount
+    const netValue = debitLineValue - creditLineValue
+    const minimumChargeNetValue = subjectToMinimumChargeCreditValue + subjectToMinimumChargeDebitValue
+
+    if ((nonZeroLinceCount === 0) && (zeroLineCount > 0)) {
+      flags.zeroValueInvoice = true
+    } else if ((netValue > 0) && (netValue < 500)) {
+      if (minimumChargeNetValue === 0) {
+        flags.deminimisInvoice = true
+      }
+    }
+
+    return flags
   }
 }
 


### PR DESCRIPTION
https://trello.com/c/kU8RWnKq

As part of implementing the PATCH /v2/{regimeId}/bill-runs/{billRunId}/send endpoint we need a service that manages generating transaction and file references and applying them to the invoices and bill run.

This change adds the service.