### PR TITLE
Fix deminimis invoices being included in bill run figures

### DIFF
--- a/app/services/generate_bill_run.service.js
+++ b/app/services/generate_bill_run.service.js
@@ -104,16 +104,16 @@ class GenerateBillRunService {
   }
 
   static async _summariseBillRun (billRun, trx) {
-    await this._summariseDebitInvoices(billRun, trx)
-    await this._summariseCreditInvoices(billRun, trx)
     await this._setZeroValueInvoiceFlags(billRun, trx)
     await this._setDeminimisInvoiceFlags(billRun, trx)
+    await this._summariseDebitInvoices(billRun, trx)
+    await this._summariseCreditInvoices(billRun, trx)
     await this._setGeneratedStatus(billRun, trx)
   }
 
   static async _summariseDebitInvoices (billRun, trx) {
     const { count: invoiceCount, value: invoiceValue } = await this._calculateInvoices(
-      await billRun.$relatedQuery('invoices', trx).modify('debit')
+      await billRun.$relatedQuery('invoices', trx).modify('debit').where('deminimisInvoice', false)
     )
 
     await billRun.$query(trx)

--- a/app/services/generate_bill_run.service.js
+++ b/app/services/generate_bill_run.service.js
@@ -124,6 +124,8 @@ class GenerateBillRunService {
   }
 
   static async _summariseCreditInvoices (billRun, trx) {
+    // Note that we don't specify .where('deminimisInvoice', false) as we do with debit invoices as credit invoices
+    // aren't subject to deminimis
     const { count: creditNoteCount, value: creditNoteValue } = await this._calculateInvoices(
       await billRun.$relatedQuery('invoices', trx).modify('credit')
     )

--- a/test/services/generate_bill_run.service.test.js
+++ b/test/services/generate_bill_run.service.test.js
@@ -189,6 +189,19 @@ describe('Generate Bill Run service', () => {
 
         expect(invoice.deminimisInvoice).to.equal(true)
       })
+
+      it('correctly summarises debit invoices', async () => {
+        rulesServiceStub.restore()
+        RulesServiceHelper.mockValue(Sinon, RulesService, rulesServiceResponse, 499)
+        await CreateTransactionService.go(payload, billRun, authorisedSystem, regime)
+
+        await GenerateBillRunService.go(billRun)
+
+        const result = await BillRunModel.query().findById(billRun.id)
+
+        expect(result.invoiceCount).to.equal(0)
+        expect(result.invoiceValue).to.equal(0)
+      })
     })
 
     describe('When deminimis does not apply', () => {

--- a/test/services/generate_bill_run.service.test.js
+++ b/test/services/generate_bill_run.service.test.js
@@ -202,6 +202,23 @@ describe('Generate Bill Run service', () => {
         expect(result.invoiceCount).to.equal(0)
         expect(result.invoiceValue).to.equal(0)
       })
+
+      it('correctly summarises a debit invoice containing a credit', async () => {
+        rulesServiceStub.restore()
+        RulesServiceHelper.mockValue(Sinon, RulesService, rulesServiceResponse, 499)
+        await CreateTransactionService.go(payload, billRun, authorisedSystem, regime)
+
+        rulesServiceStub.restore()
+        RulesServiceHelper.mockValue(Sinon, RulesService, rulesServiceResponse, 250)
+        await CreateTransactionService.go({ ...payload, credit: true }, billRun, authorisedSystem, regime)
+
+        await GenerateBillRunService.go(billRun)
+
+        const result = await BillRunModel.query().findById(billRun.id)
+
+        expect(result.invoiceCount).to.equal(0)
+        expect(result.invoiceValue).to.equal(0)
+      })
     })
 
     describe('When deminimis does not apply', () => {


### PR DESCRIPTION
https://trello.com/c/pswT0yjy/1905-identify-de-minimis-invoices-v2

The defect was raised as deminimis invoices were being included in the counts and values returned at the bill run level for the invoices belonging to it.

We resolve this by:
- Changing the order of bill run generation so that deminimis flags are set before summarising invoices;
- Adding a condition to the query that retrieves debit invoices so that it doesn't include invoices flagged as deminimis.