### PR TITLE
Hook up /send bill run endpoint to new service

### DIFF
--- a/app/controllers/presroc/bill_runs.controller.js
+++ b/app/controllers/presroc/bill_runs.controller.js
@@ -6,6 +6,7 @@ const {
   CreateBillRunService,
   GenerateBillRunService,
   GenerateBillRunValidationService,
+  SendBillRunReferenceService,
   ViewBillRunService
 } = require('../../services')
 
@@ -42,12 +43,9 @@ class BillRunsController {
   }
 
   static async send (req, h) {
-    if (req.app.billRun.status === 'approved') {
-      return h.response().code(204)
-    } else {
-      const Boom = require('@hapi/boom')
-      throw Boom.conflict(`Bill run ${req.app.billRun.id} does not have a status of 'approved'.`)
-    }
+    await SendBillRunReferenceService.go(req.app.regime, req.app.billRun)
+
+    return h.response().code(204)
   }
 
   static async delete (req, h) {

--- a/test/controllers/presroc/bill_runs.controller.test.js
+++ b/test/controllers/presroc/bill_runs.controller.test.js
@@ -19,6 +19,7 @@ const {
   BillRunHelper,
   DatabaseHelper,
   GeneralHelper,
+  InvoiceHelper,
   RegimeHelper,
   RulesServiceHelper,
   SequenceCounterHelper,
@@ -276,6 +277,9 @@ describe('Presroc Bill Runs controller', () => {
 
     beforeEach(async () => {
       billRun = await BillRunHelper.addBillRun(authorisedSystem.id, regime.id)
+      await SequenceCounterHelper.addSequenceCounter(regime.id, billRun.region)
+      // A bill run needs at least one billable invoice for a file reference to be generated
+      await InvoiceHelper.addInvoice(billRun.id, 'CMA0000001', 2020, 0, 0, 1, 501, 0) // standard debit
     })
 
     describe('When the request is valid', () => {


### PR DESCRIPTION
https://trello.com/c/kU8RWnKq

This is the final step in implementing the `PATCH /v2/{regimeId}/bill-runs/{billRunId}/send` endpoint.

We just need to hook up our standin endpoint to the new `SendBillRunReferenceService`.

Note - In a future iteration we will also trigger creating of the export file as a background task. However, there is additional work that needs to be done first before this can happen. The scope of the endpoint right now is to get the bill run ready for being exported.