### PR TITLE
Bill run summary net zero value fix

### DIFF
--- a/app/models/invoice.model.js
+++ b/app/models/invoice.model.js
@@ -54,13 +54,11 @@ class InvoiceModel extends BaseModel {
   static get modifiers () {
     return {
       /**
-       * zeroValue modifier selects all invoices which are zero value.
+       * zeroValue modifier selects all invoices which are net zero value.
        */
       zeroValue (query) {
         query
-          .where('creditLineCount', 0)
-          .where('debitLineCount', 0)
-          .where('zeroLineCount', '>', 0)
+          .whereRaw('debit_line_value - credit_line_value = 0')
       },
 
       /**

--- a/test/services/generate_bill_run.service.test.js
+++ b/test/services/generate_bill_run.service.test.js
@@ -178,7 +178,7 @@ describe('Generate Bill Run service', () => {
       })
     })
 
-    // These tests are for net zero value invoices, ie. which where the net total of the invoice is zero
+    // These tests are for net zero value invoices, ie. where the net total of the invoice is zero
     describe('When there are net zero value invoices', () => {
       it("sets the 'zeroValueInvoice' flag to true", async () => {
         await CreateTransactionService.go(payload, billRun, authorisedSystem, regime)

--- a/test/services/generate_bill_run.service.test.js
+++ b/test/services/generate_bill_run.service.test.js
@@ -136,6 +136,7 @@ describe('Generate Bill Run service', () => {
       expect(loggerFake.info.callCount).to.equal(1)
     })
 
+    // These tests are for zero value invoices, ie. which only contain zero-value transactions
     describe('When there are zero value invoices', () => {
       it("sets the 'zeroValueInvoice' flag to true", async () => {
         await CreateTransactionService.go(payload, billRun, authorisedSystem, regime)
@@ -167,6 +168,32 @@ describe('Generate Bill Run service', () => {
         it("leaves the 'zeroValueInvoice' flag of the non-zero value invoice as false", async () => {
           await CreateTransactionService.go(payload, billRun, authorisedSystem, regime)
           await InvoiceHelper.addInvoice(billRun.id, customerReference, 2020, 0, 0, 0, 0, 1)
+          const invoice = await InvoiceHelper.addInvoice(billRun.id, customerReference, 2021, 1, 1000, 1, 200, 1)
+          await GenerateBillRunService.go(billRun)
+
+          const result = await InvoiceModel.query().findById(invoice.id)
+
+          expect(result.zeroValueInvoice).to.equal(false)
+        })
+      })
+    })
+
+    // These tests are for net zero value invoices, ie. which where the net total of the invoice is zero
+    describe('When there are net zero value invoices', () => {
+      it("sets the 'zeroValueInvoice' flag to true", async () => {
+        await CreateTransactionService.go(payload, billRun, authorisedSystem, regime)
+        const invoice = await InvoiceHelper.addInvoice(billRun.id, customerReference, 2021, 1, 1000, 1, 1000, 0)
+        await GenerateBillRunService.go(billRun)
+
+        const result = await InvoiceModel.query().findById(invoice.id)
+
+        expect(result.zeroValueInvoice).to.equal(true)
+      })
+
+      describe('and there is also a non-net zero value invoice', () => {
+        it("leaves the 'zeroValueInvoice' flag of the non-zero value invoice as false", async () => {
+          await CreateTransactionService.go(payload, billRun, authorisedSystem, regime)
+          await InvoiceHelper.addInvoice(billRun.id, customerReference, 2020, 1, 1000, 1, 1000, 0)
           const invoice = await InvoiceHelper.addInvoice(billRun.id, customerReference, 2021, 1, 1000, 1, 200, 1)
           await GenerateBillRunService.go(billRun)
 


### PR DESCRIPTION
https://trello.com/c/GraJh0f7/1904-identify-zero-value-invoices-v2

The acceptance criteria specifically refer to _net_ zero value invoices (ie. where the invoice debit value minus the invoice credit value is 0), whereas the existing behaviour is to only mark invoices as a zero value if they contain solely zero value transactions. This change therefore updates the `zeroValue` modifier of `InvoiceModel` to `debit_line_value - credit_line_value = 0` so that net zero value invoices are correctly identified and `zeroValueInvoice` therefore set to `true`.

Note that a [previous discussion regarding v1](https://trello.com/c/9DvL0KtU/378-exclude-invoices-with-net-zero-value-from-transaction-files#comment-5fb399553923270a49c81415) confirms that `zeroValueInvoice` should be net zero value. We also discussed renaming the field to `netZeroValueInvoice`; if we still want to do this it'll be done in another PR.

The existing unit tests, which test the behaviour for invoices with only zero value transactions, have been left in place even though they have arguably been superseded by the new tests for net zero value invoices.