### PR TITLE
Update the view bill run response

### DIFF
--- a/app/presenters/view_bill_run.presenter.js
+++ b/app/presenters/view_bill_run.presenter.js
@@ -21,13 +21,8 @@ class ViewBillRunPresenter extends BasePresenter {
         creditNoteValue: data.creditNoteValue,
         invoiceCount: data.invoiceCount,
         invoiceValue: data.invoiceValue,
-        creditLineCount: data.creditLineCount,
-        creditLineValue: data.creditLineValue,
-        debitLineCount: data.debitLineCount,
-        debitLineValue: data.debitLineValue,
-        zeroLineCount: data.zeroLineCount,
         netTotal: data.netTotal,
-        transactionFileReference: '',
+        transactionFileReference: data.fileReference,
         invoices: data.invoices
       }
     }

--- a/app/services/view_bill_run.service.js
+++ b/app/services/view_bill_run.service.js
@@ -34,18 +34,16 @@ class ViewBillRunService {
         'region',
         'status',
         'billRunNumber',
-        'creditLineCount',
-        'creditLineValue',
-        'debitLineCount',
-        'debitLineValue',
-        'zeroLineCount',
         'subjectToMinimumChargeCount',
         'subjectToMinimumChargeCreditValue',
         'subjectToMinimumChargeDebitValue',
+        'debitLineValue',
+        'creditLineValue',
         'creditNoteCount',
         'creditNoteValue',
         'invoiceCount',
-        'invoiceValue'
+        'invoiceValue',
+        'fileReference'
       )
       .withGraphFetched('invoices.licences')
       .modifyGraph('invoices', (builder) => {

--- a/test/services/view_bill_run.service.test.js
+++ b/test/services/view_bill_run.service.test.js
@@ -97,14 +97,9 @@ describe('View bill run service', () => {
         }, billRun, authorisedSystem, regime)
       })
 
-      it('returns correct credit/debit values', async () => {
+      it('returns the net total', async () => {
         const result = await ViewBillRunService.go(billRun.id)
 
-        expect(result.billRun.creditLineCount).to.equal(1)
-        expect(result.billRun.creditLineValue).to.equal(creditLineValue)
-        expect(result.billRun.debitLineCount).to.equal(1)
-        expect(result.billRun.debitLineValue).to.equal(debitLineValue)
-        expect(result.billRun.zeroLineCount).to.equal(1)
         expect(result.billRun.netTotal).to.equal(debitLineValue - creditLineValue)
       })
 


### PR DESCRIPTION
https://trello.com/c/kU8RWnKq
https://trello.com/c/TvlmPtZ4

This change updates the properties included in the view bill run response

- `transactionReference` now exists and is set when a bill run is 'sent'
- `debitLineCount`, `debitLineValue`, `creditLineCount`, `creditLineValue`, and `zeroLineCount` can all be removed. We have confirmed with WRLS they are not being used and they were really only intended for our internal use anyway