### PR TITLE
Connect Delete Bill Run service to endpoint

### DIFF
--- a/app/controllers/presroc/bill_runs.controller.js
+++ b/app/controllers/presroc/bill_runs.controller.js
@@ -4,6 +4,7 @@ const {
   ApproveBillRunService,
   BillRunStatusService,
   CreateBillRunService,
+  DeleteBillRunService,
   GenerateBillRunService,
   GenerateBillRunValidationService,
   SendBillRunReferenceService,
@@ -49,6 +50,8 @@ class BillRunsController {
   }
 
   static async delete (req, h) {
+    await DeleteBillRunService.go(req.app.billRun)
+
     return h.response().code(204)
   }
 }

--- a/app/services/delete_bill_run.service.js
+++ b/app/services/delete_bill_run.service.js
@@ -4,28 +4,20 @@
  * @module DeleteInvoiceService
  */
 
-const Boom = require('@hapi/boom')
-
 const { BillRunModel } = require('../models')
 
 class DeleteBillRunService {
   /**
-   * Deletes a bill run along with its invoices, licences and transactions.
+   * Deletes a bill run along with its invoices, licences and transactions. Note there is no validation performed on the
+   * bill run before deletion; when this service is accessed via a controller, the bill run's status will already have
+   * been validated to ensure the bill run is editable.
    *
    * @param {@module:BillRunModel} billRun The bill run to be deleted.
    */
   static async go (billRun) {
-    this._validate(billRun)
-
     await BillRunModel
       .query()
       .deleteById(billRun.id)
-  }
-
-  static _validate (billRun) {
-    if (billRun.$billed()) {
-      throw Boom.conflict(`Bill run ${billRun.id} has a status of 'billed'.`)
-    }
   }
 }
 

--- a/test/services/delete_bill_run.service.test.js
+++ b/test/services/delete_bill_run.service.test.js
@@ -62,16 +62,4 @@ describe('Delete Bill Run service', () => {
       expect(transactions).to.be.empty()
     })
   })
-
-  describe('When an invalid bill run is supplied', () => {
-    describe("because the status is 'billed'", () => {
-      it('throws an error', async () => {
-        billRun.status = 'billed'
-        const err = await expect(DeleteBillRunService.go(billRun)).to.reject()
-
-        expect(err).to.be.an.error()
-        expect(err.output.payload.message).to.equal(`Bill run ${billRun.id} has a status of 'billed'.`)
-      })
-    })
-  })
 })


### PR DESCRIPTION
https://trello.com/c/IKn83UpO/1927-s-develop-delete-bill-run-v2

The last part of developing Delete Bill Run is to connect `DeleteBillRunService` to the `DELETE /v2/{regimeId}/bill-runs/{billRunId}` endpoint.

Note that this PR removes the bill run status validation previously done by the service -- we realised during testing that `FetchAndValidateBillRunInvoiceService` already handles status validation prior to the controller actually being called, and therefore additional validation wasn't necessary.