### PR TITLE
Fix incorrect values on minimum charge transaction

### DIFF
--- a/app/services/create_minimum_charge_adjustment.service.js
+++ b/app/services/create_minimum_charge_adjustment.service.js
@@ -26,7 +26,6 @@ class CreateMinimumChargeAdjustmentService {
         'lineAreaCode',
         'lineAttr1',
         'lineAttr2',
-        'lineDescription',
         'ruleset',
         'chargeFinancialYear',
         'invoiceId',
@@ -37,6 +36,7 @@ class CreateMinimumChargeAdjustmentService {
     this._applyChargeValue(transactionTemplate, chargeValue)
     this._applyChargeCredit(transactionTemplate, chargeCredit)
     this._applyMinimumChargeFlags(transactionTemplate)
+    this._applyLineDescription(transactionTemplate)
 
     return transactionTemplate
   }
@@ -68,6 +68,17 @@ class CreateMinimumChargeAdjustmentService {
       subjectToMinimumCharge: true,
       minimumChargeAdjustment: true
     })
+  }
+
+  /**
+   * Assign the correct line description to the new minimum charge transaction record
+   */
+  static _applyLineDescription (translator) {
+    Object.assign(
+      translator, {
+        lineDescription: 'Minimum Charge Calculation - raised under Schedule 23 of the Environment Act 1995'
+      }
+    )
   }
 }
 

--- a/app/services/create_minimum_charge_adjustment.service.js
+++ b/app/services/create_minimum_charge_adjustment.service.js
@@ -23,6 +23,7 @@ class CreateMinimumChargeAdjustmentService {
         'createdBy',
         'region',
         'customerReference',
+        'lineAreaCode',
         'lineAttr1',
         'lineAttr2',
         'lineDescription',

--- a/test/services/create_minimum_charge_adjustment.service.test.js
+++ b/test/services/create_minimum_charge_adjustment.service.test.js
@@ -105,6 +105,7 @@ describe('Create Minimum Charge Adjustment service', () => {
         'createdBy',
         'region',
         'customerReference',
+        'lineAreaCode',
         'lineAttr1',
         'lineAttr2',
         'lineDescription',

--- a/test/services/create_minimum_charge_adjustment.service.test.js
+++ b/test/services/create_minimum_charge_adjustment.service.test.js
@@ -98,6 +98,12 @@ describe('Create Minimum Charge Adjustment service', () => {
       expect(minimumChargeAdjustment.minimumChargeAdjustment).to.equal(true)
     })
 
+    it('has the correct lineDescription', async () => {
+      expect(minimumChargeAdjustment.lineDescription).to.equal(
+        'Minimum Charge Calculation - raised under Schedule 23 of the Environment Act 1995'
+      )
+    })
+
     it('reads data from another transaction within the licence', async () => {
       const fieldsToTest = [
         'billRunId',
@@ -108,7 +114,6 @@ describe('Create Minimum Charge Adjustment service', () => {
         'lineAreaCode',
         'lineAttr1',
         'lineAttr2',
-        'lineDescription',
         'ruleset',
         'chargeFinancialYear'
       ]


### PR DESCRIPTION
https://trello.com/c/sNDQVgoh

When testing the 'minimum charge' functionality in the service it was spotted there are 2 issues with the transactions we generate

- The `lineDescription` is supposed to be set to a specific value
- `areaCode` is not being populated

This change fixes both those issues