### PR TITLE
Add transaction type to test GET endpoint

### DIFF
--- a/app/services/show_transaction.service.js
+++ b/app/services/show_transaction.service.js
@@ -39,7 +39,8 @@ class ShowTransactionService {
   }
 
   static _response (transaction) {
-    transaction.invoice = this._addTransactionTypeToInvoice(transaction.invoice)
+    const transactionType = this._transactionType(transaction.invoice)
+    Object.assign(transaction.invoice, { transactionType })
 
     const signedChargeValue = this._signedChargeValue(transaction)
     Object.assign(transaction, { signedChargeValue })
@@ -54,11 +55,8 @@ class ShowTransactionService {
     return chargeCredit ? -chargeValue : chargeValue
   }
 
-  static _addTransactionTypeToInvoice (invoice) {
-    return {
-      ...invoice,
-      transactionType: invoice.$transactionType()
-    }
+  static _transactionType (invoice) {
+    return invoice.$transactionType()
   }
 }
 

--- a/app/services/show_transaction.service.js
+++ b/app/services/show_transaction.service.js
@@ -39,8 +39,11 @@ class ShowTransactionService {
   }
 
   static _response (transaction) {
+    transaction.invoice = this._addTransactionTypeToInvoice(transaction.invoice)
+
     const signedChargeValue = this._signedChargeValue(transaction)
     Object.assign(transaction, { signedChargeValue })
+
     const presenter = new JsonPresenter(transaction)
 
     return presenter.go()
@@ -49,6 +52,13 @@ class ShowTransactionService {
   static _signedChargeValue (transaction) {
     const { chargeCredit, chargeValue } = transaction
     return chargeCredit ? -chargeValue : chargeValue
+  }
+
+  static _addTransactionTypeToInvoice (invoice) {
+    return {
+      ...invoice,
+      transactionType: invoice.$transactionType()
+    }
   }
 }
 

--- a/test/services/show_transaction.service.test.js
+++ b/test/services/show_transaction.service.test.js
@@ -95,6 +95,12 @@ describe('Show Transaction service', () => {
 
       expect(Math.sign(result.signedChargeValue)).to.equal(-1)
     })
+
+    it("returns the 'transactionType' for the invoice", async () => {
+      const result = await ShowTransactionService.go(creditTransaction.id)
+
+      expect(result.invoice.transactionType).to.equal('C')
+    })
   })
 
   describe('When there is no matching transaction', () => {

--- a/test/services/show_transaction.service.test.js
+++ b/test/services/show_transaction.service.test.js
@@ -73,7 +73,7 @@ describe('Show Transaction service', () => {
 
       const invoice = await InvoiceModel.query().findById(creditTransaction.invoiceId)
 
-      expect(result.invoice).to.equal(invoice)
+      expect(result.invoice).to.equal({ ...invoice, transactionType: invoice.$transactionType() })
     })
 
     it("returns a result that includes the related 'licence'", async () => {


### PR DESCRIPTION
To support testing our QA @anwarisse1 has asked if the calculated `InvoiceModel` property `$transactionType()` can be included in the test view of a transaction.

This change makes it so 😁