### PR TITLE
Fix deminimis/minimum charge defect

### DIFF
--- a/app/models/invoice.model.js
+++ b/app/models/invoice.model.js
@@ -68,8 +68,6 @@ class InvoiceModel extends BaseModel {
         query
           .whereRaw('debit_line_value - credit_line_value > 0')
           .whereRaw('debit_line_value - credit_line_value < ?', DEMINIMIS_LIMIT)
-          .where('subjectToMinimumChargeCreditValue', '=', 0)
-          .where('subjectToMinimumChargeDebitValue', '=', 0)
       },
 
       /**

--- a/app/services/generate_bill_run.service.js
+++ b/app/services/generate_bill_run.service.js
@@ -104,8 +104,8 @@ class GenerateBillRunService {
   }
 
   static async _summariseBillRun (billRun, trx) {
-    await this._setZeroValueInvoiceFlags(billRun, trx)
     await this._setDeminimisInvoiceFlags(billRun, trx)
+    await this._setZeroValueInvoiceFlags(billRun, trx)
     await this._summariseDebitInvoices(billRun, trx)
     await this._summariseCreditInvoices(billRun, trx)
     await this._setGeneratedStatus(billRun, trx)

--- a/test/models/invoice.model.test.js
+++ b/test/models/invoice.model.test.js
@@ -38,11 +38,12 @@ describe('Invoice Model', () => {
           await InvoiceHelper.addInvoice(billRun.id, 'CMA0000003', 2020, 1, 350, 0, 0, 0) // credit less than 500
           await InvoiceHelper.addInvoice(billRun.id, 'CMA0000004', 2020, 1, 501, 0, 0, 0) // credit more than 500
           await InvoiceHelper.addInvoice(billRun.id, 'CMA0000005', 2020, 0, 0, 0, 0, 1) // zero value
-          await InvoiceHelper.addInvoice(billRun.id, 'CMA0000006', 2020, 0, 0, 1, 350, 0, 1, 0, 350) // minimum charge
+          await InvoiceHelper.addInvoice(billRun.id, 'CMA0000006', 2020, 0, 0, 1, 2500, 0, 1, 0, 2500) // minimum charge
         })
 
         it("only returns those which are 'deminimis'", async () => {
           const results = await InvoiceModel.query().modify('deminimis')
+          console.log(results)
 
           expect(results.length).to.equal(1)
           expect(results[0].id).to.equal(deminimisInvoice.id)
@@ -55,7 +56,7 @@ describe('Invoice Model', () => {
           await InvoiceHelper.addInvoice(billRun.id, 'CMA0000003', 2020, 1, 350, 0, 0, 0) // credit less than 500
           await InvoiceHelper.addInvoice(billRun.id, 'CMA0000004', 2020, 1, 501, 0, 0, 0) // credit more than 500
           await InvoiceHelper.addInvoice(billRun.id, 'CMA0000005', 2020, 0, 0, 0, 0, 1) // zero value
-          await InvoiceHelper.addInvoice(billRun.id, 'CMA0000006', 2020, 0, 0, 1, 350, 0, 1, 0, 350) // minimum charge
+          await InvoiceHelper.addInvoice(billRun.id, 'CMA0000006', 2020, 0, 0, 1, 2500, 0, 1, 0, 2500) // minimum charge
         })
 
         it('returns nothing', async () => {
@@ -68,10 +69,10 @@ describe('Invoice Model', () => {
       describe("when there are only 'minimum charge' invoices", () => {
         beforeEach(async () => {
           // Minimum charge debit invoice
-          await InvoiceHelper.addInvoice(billRun.id, 'CMA0000001', 2020, 0, 0, 1, 350, 0, 1, 0, 350)
+          await InvoiceHelper.addInvoice(billRun.id, 'CMA0000001', 2020, 0, 0, 1, 2500, 0, 1, 0, 2500)
 
           // Minimum charge credit invoice
-          await InvoiceHelper.addInvoice(billRun.id, 'CMA0000002', 2020, 1, 350, 0, 0, 0, 1, 350, 0)
+          await InvoiceHelper.addInvoice(billRun.id, 'CMA0000002', 2020, 1, 2500, 0, 0, 0, 1, 2500, 0)
         })
 
         it('returns nothing', async () => {

--- a/test/services/generate_bill_run.service.test.js
+++ b/test/services/generate_bill_run.service.test.js
@@ -610,7 +610,7 @@ describe('Generate Bill Run service', () => {
           })
         })
 
-        describe.only('and deminimis applies', () => {
+        describe('and deminimis applies', () => {
           beforeEach(async () => {
             const minimumChargePayload = {
               ...payload,

--- a/test/services/generate_bill_run.service.test.js
+++ b/test/services/generate_bill_run.service.test.js
@@ -543,8 +543,11 @@ describe('Generate Bill Run service', () => {
             expect(minimumChargeBill.subjectToMinimumChargeCreditValue).to.equal(2500)
             expect(minimumChargeBill.creditNoteCount).to.equal(0)
             expect(minimumChargeBill.creditNoteValue).to.equal(0)
-            expect(minimumChargeBill.invoiceCount).to.equal(1)
-            expect(minimumChargeBill.invoiceValue).to.equal(1)
+
+            // We expect invoice count and value to be 0 because the debit value of 2501 minus the credit value of 2500
+            // makes this a deminimis invoice and therefore not included in the figures.
+            expect(minimumChargeBill.invoiceCount).to.equal(0)
+            expect(minimumChargeBill.invoiceValue).to.equal(0)
 
             expect(minimumChargeInvoice.debitLineCount).to.equal(1)
             expect(minimumChargeInvoice.creditLineCount).to.equal(2)

--- a/test/services/view_bill_run.service.test.js
+++ b/test/services/view_bill_run.service.test.js
@@ -165,7 +165,7 @@ describe('View bill run service', () => {
       })
     })
 
-    describe.only('when there is a deminimis invoice with minimum charge', () => {
+    describe('when there is a deminimis invoice with minimum charge', () => {
       beforeEach(async () => {
         creditLineValue = 2365
         minimumChargeDebitLineValue = 1

--- a/test/services/view_bill_run.service.test.js
+++ b/test/services/view_bill_run.service.test.js
@@ -39,6 +39,7 @@ describe('View bill run service', () => {
   let rulesServiceStub
   let creditLineValue
   let debitLineValue
+  let minimumChargeDebitLineValue
 
   beforeEach(async () => {
     await DatabaseHelper.clean()
@@ -150,6 +151,37 @@ describe('View bill run service', () => {
         await CreateTransactionService.go({
           ...payload,
           customerReference: 'DEBIT'
+        }, billRun, authorisedSystem, regime)
+      })
+
+      describe('and the bill run is generated', () => {
+        it('correctly calculates the net total', async () => {
+          await GenerateBillRunService.go(billRun)
+
+          const result = await ViewBillRunService.go(billRun.id)
+
+          expect(result.billRun.netTotal).to.equal(0)
+        })
+      })
+    })
+
+    describe.only('when there is a deminimis invoice with minimum charge', () => {
+      beforeEach(async () => {
+        creditLineValue = 2365
+        minimumChargeDebitLineValue = 1
+
+        rulesServiceStub.restore()
+        RulesServiceHelper.mockValue(Sinon, RulesService, rulesServiceResponse, minimumChargeDebitLineValue)
+        await CreateTransactionService.go({
+          ...payload,
+          subjectToMinimumCharge: true
+        }, billRun, authorisedSystem, regime)
+
+        rulesServiceStub.restore()
+        RulesServiceHelper.mockValue(Sinon, RulesService, rulesServiceResponse, creditLineValue)
+        await CreateTransactionService.go({
+          ...payload,
+          credit: true
         }, billRun, authorisedSystem, regime)
       })
 


### PR DESCRIPTION
It was discovered that deminimis was not being correctly applied in some scenarios involving minimum charge, eg:
- Debit subject to minimum charge with charge value of 1 is added to an invoice.
- Credit with charge value of 2500 is added to the same invoice so the total value of the invoice is 2499.
- The bill run is generated.
- The debit value of the invoice is therefore adjusted to 2500 so the total value of the bill run is now 0.

Since this falls into deminimis, the invoice should not be included in the bill run. However we were not including invoices with minimum charge values when determining whether an invoice was subject to deminimis and therefore the invoice would be included. This change resolves this by amending `InvoiceModel` to no longer exclude minimum charge invoices from the deminimis selection.

We also update breaking unit tests:
- `InvoiceModel` tests are changed to use realistic values for minimum charge invoices;
- A `GenerateBillRunService` test is changed to correctly expect no invoice in this scenario.