### PR TITLE
Fix MaxListenersExceededWarning in tests

### DIFF
--- a/app/plugins/stop.plugin.js
+++ b/app/plugins/stop.plugin.js
@@ -48,8 +48,10 @@ const StopPlugin = {
       }
     }
 
-    process.on('SIGTERM', stop)
-    process.on('SIGINT', stop)
+    if (process.env.NODE_ENV !== 'test') {
+      process.on('SIGTERM', stop)
+      process.on('SIGINT', stop)
+    }
   }
 }
 


### PR DESCRIPTION
Since adding the [stop (SIGTERM) plugin](https://github.com/DEFRA/sroc-charging-module-api/pull/105) we see the following warning message in our test suite output

```
(node:1310) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 SIGTERM listeners added to [process]. Use emitter.setMaxListeners() to increase limit
(node:1310) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 SIGINT listeners added to [process]. Use emitter.setMaxListeners() to increase limit
```

After looking into it we know it's because every time we generate an instance of the `server` in our test suite (controller tests being the primary culprit) the plugin is being run and a listener added using `process.on('SIGTERM', stop)`. In the context of the test suite we never actually stop, so the listeners never get removed until the run is complete.

When the app is running properly, we only register one listener each for `SIGTERM` and `SIGINT`. The change updates the plugin to understand when it's being run within a 'test' environment and so _not_ to register any listeners. This prevents us from exceeding `MaxListeners` and makes the warning go away!