### PR TITLE
Housekeeping - Remove stray console.log() calls

### DIFF
--- a/app/controllers/presroc/customer_details.controller.js
+++ b/app/controllers/presroc/customer_details.controller.js
@@ -4,8 +4,8 @@ const { CreateCustomerDetailsService } = require('../../services')
 
 class PresrocCustomerDetailsController {
   static async create (req, h) {
-    const response = await CreateCustomerDetailsService.go(req.payload, req.app.regime)
-    console.log(response)
+    await CreateCustomerDetailsService.go(req.payload, req.app.regime)
+
     return h.response().code(204)
   }
 }

--- a/test/models/invoice.model.test.js
+++ b/test/models/invoice.model.test.js
@@ -43,7 +43,6 @@ describe('Invoice Model', () => {
 
         it("only returns those which are 'deminimis'", async () => {
           const results = await InvoiceModel.query().modify('deminimis')
-          console.log(results)
 
           expect(results.length).to.equal(1)
           expect(results[0].id).to.equal(deminimisInvoice.id)


### PR DESCRIPTION
Whilst working on the codebase recently we have spotted some stray `console.log()` calls, added no doubt as part of some debugging but inadvertently left in.