### PR TITLE
Add more data overrides to test LicenceHelper

### DIFF
--- a/test/support/helpers/licence.helper.js
+++ b/test/support/helpers/licence.helper.js
@@ -14,6 +14,16 @@ class LicenceHelper {
    * @param {string} [invoiceId] Id to use for the `invoice_id` field. If empty then a new invoice will be created.
    * @param {string} [customerReference] Customer reference to use if an invoice is to be created.
    * @param {integer} [financialYear] Financial year to use if an invoice is to be created.
+   * @param {integer} [creditLineCount] Number of credits in the licence.
+   * @param {integer} [creditLineValue] Total value of credits in the licence.
+   * @param {integer} [debitLineCount] Number of debits in the licence.
+   * @param {integer} [debitLineValue] Total value of debits in the licence.
+   * @param {integer} [zeroLineCount] Number of zero value transactions in the licence.
+   * @param {integer} [subjectToMinimumChargeCount] Number of transactions flagged as 'miniumum charge' in the licence.
+   * @param {integer} [subjectToMinimumChargeCreditValue] Total value of minimum charge credit transactions in the
+   *  licence.
+   * @param {integer} [subjectToMinimumChargeDebitValue] Total value of minimum charge debit transactions in the
+   *  licence.
    *
    * @returns {module:LicenceModel} The newly created instance of `LicenceModel`.
    */
@@ -22,13 +32,29 @@ class LicenceHelper {
     licenceNumber,
     invoiceId = '',
     customerReference = '',
-    financialYear = ''
+    financialYear = '',
+    creditLineCount = 0,
+    creditLineValue = 0,
+    debitLineCount = 0,
+    debitLineValue = 0,
+    zeroLineCount = 0,
+    subjectToMinimumChargeCount = 0,
+    subjectToMinimumChargeCreditValue = 0,
+    subjectToMinimumChargeDebitValue = 0
   ) {
     return LicenceModel.query()
       .insert({
         billRunId,
         licenceNumber,
-        invoiceId: await this._invoiceId(invoiceId, billRunId, customerReference, financialYear)
+        invoiceId: await this._invoiceId(invoiceId, billRunId, customerReference, financialYear),
+        creditLineCount,
+        creditLineValue,
+        debitLineCount,
+        debitLineValue,
+        zeroLineCount,
+        subjectToMinimumChargeCount,
+        subjectToMinimumChargeCreditValue,
+        subjectToMinimumChargeDebitValue
       })
       .returning('*')
   }


### PR DESCRIPTION
We will need the ability to set initial values of 'tally' fields for licences when testing. This is to support testing we'll be doing as we move from a 'find or insert' pattern to one that uses [UPSERT (on conflict)](https://www.postgresql.org/docs/current/sql-insert.html).

This change expands what we can set in the `LicenceHelper`.