### PR TITLE
Fix no SONAR_TOKEN for dependabot PR's

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,7 @@ jobs:
           sed -i 's/\/home\/runner\/work\/sroc-charging-module-api\/sroc-charging-module-api\//\/github\/workspace\//g' coverage/lcov.info
 
       - name: Analyze with SonarCloud
+        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != ''}}
         uses: sonarsource/sonarcloud-github-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This is provided automatically by GitHub


### PR DESCRIPTION
We have started seeing PR's raised by [Dependabot](https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/) fail because the `Analyze with SonarCloud` step fails.

```
    [...]
    RULES_SERVICE_TIMEOUT: 1000
    GITHUB_TOKEN: ***
    SONAR_TOKEN:
/usr/bin/docker run --name e4a97565f2b5d944e48e47caefd7a85a14_7b8529 --label 5588e4 --workdir /github/workspace --rm -e ADMIN_CLIENT_ID -e AIRBRAKE_HOST -e AIRBRAKE_KEY -e PORT -e POSTGRES_USER -e POSTGRES_PASSWORD -e POSTGRES_HOST -e POSTGRES_PORT -e POSTGRES_DB -e POSTGRES_DB_TEST -e ENVIRONMENT -e RULES_SERVICE_URL -e RULES_SERVICE_USER -e RULES_SERVICE_PASSWORD -e CFD_APP -e CFD_RULESET -e WML_APP -e WML_RULESET -e PAS_APP -e PAS_RULESET -e WRLS_APP -e WRLS_RULESET -e WRLS_SROC_APP -e WRLS_SROC_RULESET -e RULES_SERVICE_TIMEOUT -e GITHUB_TOKEN -e SONAR_TOKEN -e INPUT_ARGS -e INPUT_PROJECTBASEDIR -e HOME -e GITHUB_JOB -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_REPOSITORY_OWNER -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RETENTION_DAYS -e GITHUB_ACTOR -e GITHUB_WORKFLOW -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GITHUB_EVENT_NAME -e GITHUB_SERVER_URL -e GITHUB_API_URL -e GITHUB_GRAPHQL_URL -e GITHUB_WORKSPACE -e GITHUB_ACTION -e GITHUB_EVENT_PATH -e GITHUB_ACTION_REPOSITORY -e GITHUB_ACTION_REF -e GITHUB_PATH -e GITHUB_ENV -e RUNNER_OS -e RUNNER_TOOL_CACHE -e RUNNER_TEMP -e RUNNER_WORKSPACE -e ACTIONS_RUNTIME_URL -e ACTIONS_RUNTIME_TOKEN -e ACTIONS_CACHE_URL -e GITHUB_ACTIONS=true -e CI=true --network github_network_14077410f5e14529a724295410907766 -v "/var/run/docker.sock":"/var/run/docker.sock" -v "/home/runner/work/_temp/_github_home":"/github/home" -v "/home/runner/work/_temp/_github_workflow":"/github/workflow" -v "/home/runner/work/_temp/_runner_file_commands":"/github/file_commands" -v "/home/runner/work/sroc-charging-module-api/sroc-charging-module-api":"/github/workspace" 5588e4:a97565f2b5d944e48e47caefd7a85a14
Set the SONAR_TOKEN env variable.
```

Looking at the output it's because it cannot see the env var `SONAR_TOKEN`. This gets set in repository settings as a [Repository secret](https://docs.github.com/en/actions/reference/encrypted-secrets).

To begin with, we couldn't understand what had changed. We wondered if something had happened to tighten up the permissions for Dependabot so that it can no longer see the env var. TBH, we tried to track down examples or posts of others suffering this problem to no avail. But it was definitely

- just Dependabot PR's that were failing
- the same behaviour is seen in some of our other repos

The closest example we could find of this was [Run SonarCloud analysis only when SONAR_TOKEN is available](https://github.com/dropwizard/dropwizard/pull/3541) and its that PR we cribbed this fix from!

Eventually, we did track down the cause. Repository secrets now need to be set per integration it seems

<details>
<summary>GitHub Respository secrets</summary>

![Screenshot 2021-03-16 at 15 23 48](https://user-images.githubusercontent.com/1789650/111334644-a4d55880-866b-11eb-96e7-a43a1519d826.png)

</details>

Once we added `SONAR_TOKEN` there, Dependabot PR's started building again. We're still keeping this fix though because TBH, SonarCloud analysis for a Dependabot PR is not essential and this will give us a fallback.
