### PR TITLE
Update CreateTransactionTallyService for UPSERT

### DIFF
--- a/app/services/create_transaction_bill_run.service.js
+++ b/app/services/create_transaction_bill_run.service.js
@@ -6,6 +6,7 @@
 
 const Boom = require('@hapi/boom')
 
+const { BillRunModel } = require('../models')
 const CreateTransactionTallyService = require('./create_transaction_tally.service')
 
 class CreateTransactionBillRunService {
@@ -46,9 +47,10 @@ class CreateTransactionBillRunService {
   }
 
   static async _generatePatch (id, transaction) {
+    const tallyObject = await CreateTransactionTallyService.go(transaction, BillRunModel.tableName)
     const patch = {
       id: id,
-      update: await CreateTransactionTallyService.go(transaction)
+      update: tallyObject.patch
     }
 
     return patch

--- a/app/services/create_transaction_bill_run.service.js
+++ b/app/services/create_transaction_bill_run.service.js
@@ -47,10 +47,9 @@ class CreateTransactionBillRunService {
   }
 
   static async _generatePatch (id, transaction) {
-    const tallyObject = await CreateTransactionTallyService.go(transaction, BillRunModel.tableName)
     const patch = {
       id,
-      update: tallyObject.patch
+      update: await CreateTransactionTallyService.go(transaction, BillRunModel.tableName).patch
     }
 
     return patch

--- a/app/services/create_transaction_bill_run.service.js
+++ b/app/services/create_transaction_bill_run.service.js
@@ -49,7 +49,7 @@ class CreateTransactionBillRunService {
   static async _generatePatch (id, transaction) {
     const tallyObject = await CreateTransactionTallyService.go(transaction, BillRunModel.tableName)
     const patch = {
-      id: id,
+      id,
       update: tallyObject.patch
     }
 

--- a/app/services/create_transaction_invoice.service.js
+++ b/app/services/create_transaction_invoice.service.js
@@ -55,9 +55,10 @@ class CreateTransactionInvoiceService {
   }
 
   static async _generatePatch (id, transaction) {
+    const tallyObject = await CreateTransactionTallyService.go(transaction, InvoiceModel.tableName)
     const patch = {
       id: id,
-      update: await CreateTransactionTallyService.go(transaction)
+      update: tallyObject.patch
     }
 
     return patch

--- a/app/services/create_transaction_invoice.service.js
+++ b/app/services/create_transaction_invoice.service.js
@@ -57,7 +57,7 @@ class CreateTransactionInvoiceService {
   static async _generatePatch (id, transaction) {
     const tallyObject = await CreateTransactionTallyService.go(transaction, InvoiceModel.tableName)
     const patch = {
-      id: id,
+      id,
       update: tallyObject.patch
     }
 

--- a/app/services/create_transaction_invoice.service.js
+++ b/app/services/create_transaction_invoice.service.js
@@ -55,10 +55,9 @@ class CreateTransactionInvoiceService {
   }
 
   static async _generatePatch (id, transaction) {
-    const tallyObject = await CreateTransactionTallyService.go(transaction, InvoiceModel.tableName)
     const patch = {
       id,
-      update: tallyObject.patch
+      update: await CreateTransactionTallyService.go(transaction, InvoiceModel.tableName).patch
     }
 
     return patch

--- a/app/services/create_transaction_licence.service.js
+++ b/app/services/create_transaction_licence.service.js
@@ -57,7 +57,7 @@ class CreateTransactionLicenceService {
   static async _generatePatch (id, transaction) {
     const tallyObject = await CreateTransactionTallyService.go(transaction, LicenceModel.tableName)
     const patch = {
-      id: id,
+      id,
       update: tallyObject.patch
     }
 

--- a/app/services/create_transaction_licence.service.js
+++ b/app/services/create_transaction_licence.service.js
@@ -55,10 +55,9 @@ class CreateTransactionLicenceService {
   }
 
   static async _generatePatch (id, transaction) {
-    const tallyObject = await CreateTransactionTallyService.go(transaction, LicenceModel.tableName)
     const patch = {
       id,
-      update: tallyObject.patch
+      update: await CreateTransactionTallyService.go(transaction, LicenceModel.tableName).patch
     }
 
     return patch

--- a/app/services/create_transaction_licence.service.js
+++ b/app/services/create_transaction_licence.service.js
@@ -55,9 +55,10 @@ class CreateTransactionLicenceService {
   }
 
   static async _generatePatch (id, transaction) {
+    const tallyObject = await CreateTransactionTallyService.go(transaction, LicenceModel.tableName)
     const patch = {
       id: id,
-      update: await CreateTransactionTallyService.go(transaction)
+      update: tallyObject.patch
     }
 
     return patch

--- a/app/services/create_transaction_tally.service.js
+++ b/app/services/create_transaction_tally.service.js
@@ -110,7 +110,9 @@ class CreateTransactionTallyService {
 
   static _applyStandardTallyStatements (tallyObject, tableName, prefix, suffix, value) {
     // Don't bother to generate an insert/update/patch if the value is 0. There is no point
-    if (!value) return
+    if (!value) {
+      return
+    }
 
     // For example debitLineCount
     const propertyName = `${prefix.toLowerCase()}Line${suffix}`
@@ -139,7 +141,9 @@ class CreateTransactionTallyService {
 
   static _applyMinimumChargeValueTallyStatements (tallyObject, tableName, prefix, value) {
     // Don't bother to generate an insert/update/patch if the value is 0. There is no point
-    if (!value) return
+    if (!value) {
+      return
+    }
 
     // For example subjectToMinimumChargeCreditValue
     const propertyName = `subjectToMinimumCharge${prefix}Value`

--- a/test/services/create_transaction_tally.service.test.js
+++ b/test/services/create_transaction_tally.service.test.js
@@ -39,7 +39,7 @@ describe('Create Transaction Tally service', () => {
 
         expect(updateStatements).to.be.length(2)
         expect(updateStatements[0]).to.startWith('debit_line_count')
-        expect(updateStatements[1]).to.startWith('debit_Line_value')
+        expect(updateStatements[1]).to.startWith('debit_line_value')
       })
     })
 
@@ -86,7 +86,7 @@ describe('Create Transaction Tally service', () => {
 
           expect(updateStatements).to.be.length(4)
           expect(updateStatements[0]).to.startWith('debit_line_count')
-          expect(updateStatements[1]).to.startWith('debit_Line_value')
+          expect(updateStatements[1]).to.startWith('debit_line_value')
           expect(updateStatements[2]).to.startWith('subject_to_minimum_charge_count')
           expect(updateStatements[3]).to.startWith('subject_to_minimum_charge_debit_value')
         })


### PR DESCRIPTION
https://trello.com/c/1cZkVwM1

In order to use a PostgreSQL `UPSERT` command, we are going to need to build our own SQL statement. An `UPSERT` statement is

```
  INSERT INTO invoices ([field names]) VALUES ([values to be inserted])
  ON CONFLICT ([constraint field names]) DO UPDATE
  SET [field name] = EXCLUDED.[field name]
```

Basically, we are going to need to create both an 'INSERT' and an 'UPDATE' query. In our case what we are inserting or updating is based on the transaction. Is it a credit or a debit? Is it zero value? Is it subject to minimum charge?

Our current design assumes we'll be patching the invoice and licence records and we use the `CreateTransactionTallyService` to generate the 'patch'. This change builds (explodes!) on the existing functionality in the service to also handle putting together what we need for those insert and update statements. We still just need to 'patch' the bill run when a transaction comes in which means we need to keep what we already have.

So, this change

- expands the functionality of `CreateTransactionTallyService` ready for the switch to `UPSERT`
- ensures the existing functionality can still access the 'patch' object the service generates
