### PR TITLE
Fix Docker local permissions and bump Node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Generate base stage
 #
 # Use alpine version to help reduce size of image and improve security (less things installed from the get go)
-FROM node:12.19.0-alpine AS node_base
+FROM node:14-alpine AS node_base
 
 # Ensure we have updated whatever packages come as part of the alpine image before we start using it. This was a
 # requirement following PEN testing. We also add the dependencies we need to support using PostgreSQL. Finish with

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,11 +19,6 @@ RUN npm i npm@latest -g
 # We have chosen /home/node as our working directory to be consistent with https://github.com/DEFRA/defra-docker-node
 WORKDIR /home/node
 
-# The official node image provides an unprivileged user as a security best practice, But we have to manually enable it.
-# We put it here so npm installs dependencies as the same user who runs the app.
-# https://github.com/nodejs/docker-node/blob/master/docs/BestPractices.md#non-root-user
-USER node
-
 ################################################################################
 # Create development (final stage)
 #
@@ -49,9 +44,7 @@ EXPOSE $PORT 9229 9230
 
 # Install dependencies first, in a different location for easier app bind mounting for local development. To do this we
 # first copy just the package*.json files from the host
-# Note. COPY is always run as the root user in Docker. So, to avoid permission issues we immediately make the node user
-# owner of the copied files
-COPY --chown=node:node package.json package-lock.json* ./
+COPY package.json package-lock.json* ./
 
 RUN npm install
 
@@ -98,6 +91,11 @@ ENV NODE_ENV production
 ARG PORT=3000
 ENV PORT $PORT
 EXPOSE $PORT
+
+# The official node image provides an unprivileged user as a security best practice, But we have to manually enable it.
+# We put it here so npm installs dependencies as the same user who runs the app.
+# https://github.com/nodejs/docker-node/blob/master/docs/BestPractices.md#non-root-user
+USER node
 
 # Install dependencies first, in a different location for easier app bind mounting for local development. To do this we
 # first copy just the package*.json files from the host


### PR DESCRIPTION
We encountered an issue where we were unable to run `npm install` to refresh dependencies in our local container. We tracked this down to the fact that we were enforcing the `node` non-root user for all environments. To resolve this, we've changed `Dockerfile` so that this user is only enforced in production, allowing us to do root user stuff in our local dev environment.

While updating `Dockerfile` we also noticed that the LTS version of Node is now 14, whereas before we were on Node 12. After checking that our unit tests all pass in the new version, we've updated it accordingly.