### PR TITLE
Fix send bill run link to generate file issue

### DIFF
--- a/app/controllers/presroc/bill_runs.controller.js
+++ b/app/controllers/presroc/bill_runs.controller.js
@@ -45,9 +45,9 @@ class BillRunsController {
   }
 
   static async send (req, h) {
-    await SendBillRunReferenceService.go(req.app.regime, req.app.billRun)
+    const sentBillRun = await SendBillRunReferenceService.go(req.app.regime, req.app.billRun)
 
-    SendTransactionFileService.go(req.app.regime, req.app.billRun, req.server.methods.notify)
+    SendTransactionFileService.go(req.app.regime, sentBillRun, req.server.methods.notify)
 
     return h.response().code(204)
   }

--- a/app/services/send_bill_run_reference.service.js
+++ b/app/services/send_bill_run_reference.service.js
@@ -26,13 +26,15 @@ class SendBillRunReferenceService {
    *
    * @param {@module RegimeModel} regime An instance of `RegimeModel` which matches the requested regime
    * @param {@module:BillRunModel} billRun The 'bill run' to send for billing
+   *
+   * @returns {@module:BillRunModel} the 'sent' bill run with an updated file reference (if applicable) and status
    */
   static async go (regime, billRun) {
     this._validate(billRun)
 
     // If we don't await here as well as in the _send() method the call to go() ends. In our tests we have found this
     // means any attempt to check the status has changed immediately after fails
-    await this._send(regime, billRun)
+    return await this._send(regime, billRun)
   }
 
   static _validate (billRun) {
@@ -42,19 +44,20 @@ class SendBillRunReferenceService {
   }
 
   static async _send (regime, billRun) {
-    await BillRunModel.transaction(async trx => {
+    return await BillRunModel.transaction(async trx => {
       const billableCount = await this._updateBillableInvoices(regime, billRun, trx)
 
       // We only generate a file reference for the bill run if there was 1 or more billable invoices. This avoids gaps
       // in the file references and concern about whether something got lost in transit
       const fileReference = billableCount ? await NextFileReferenceService.go(regime, billRun.region, trx) : null
 
-      await BillRunModel.query(trx)
+      return await BillRunModel.query(trx)
         .findById(billRun.id)
         .patch({
           status: 'pending',
           fileReference
         })
+        .returning('*')
     })
   }
 

--- a/app/services/send_bill_run_reference.service.js
+++ b/app/services/send_bill_run_reference.service.js
@@ -34,7 +34,7 @@ class SendBillRunReferenceService {
 
     // If we don't await here as well as in the _send() method the call to go() ends. In our tests we have found this
     // means any attempt to check the status has changed immediately after fails
-    return await this._send(regime, billRun)
+    return this._send(regime, billRun)
   }
 
   static _validate (billRun) {
@@ -44,14 +44,14 @@ class SendBillRunReferenceService {
   }
 
   static async _send (regime, billRun) {
-    return await BillRunModel.transaction(async trx => {
+    return BillRunModel.transaction(async trx => {
       const billableCount = await this._updateBillableInvoices(regime, billRun, trx)
 
       // We only generate a file reference for the bill run if there was 1 or more billable invoices. This avoids gaps
       // in the file references and concern about whether something got lost in transit
       const fileReference = billableCount ? await NextFileReferenceService.go(regime, billRun.region, trx) : null
 
-      return await BillRunModel.query(trx)
+      return BillRunModel.query(trx)
         .findById(billRun.id)
         .patch({
           status: 'pending',

--- a/app/services/send_file_to_s3.service.js
+++ b/app/services/send_file_to_s3.service.js
@@ -16,7 +16,7 @@ class SendFileToS3Service {
    * Send a file to an AWS S3 bucket. We optionally send it to the archive bucket, and based on server config we
    * optionally delete the temp file.
    *
-   * @param {string} filename The name of the file in the temp folder to be sent to S3.
+   * @param {string} localFilenameWithPath The name and path of the file to be sent to S3.
    * @param {string} key The key is the path and filename the file will have in the bucket. For example,
    * 'wrls/transaction/nalai50001.dat'. Note that we prepend this with 'export'.
    * @param {function} notify The server.methods.notify method, which we pass in as server.methods isn't accessible
@@ -25,9 +25,7 @@ class SendFileToS3Service {
    * @returns {boolean} Returns `true` if the file was successfully sent and `false` if it failed.
   */
 
-  static async go (filename, key, notify, copyToArchive = true) {
-    const localFilenameWithPath = path.join(this._temporaryFilePath(), filename)
-
+  static async go (localFilenameWithPath, key, notify, copyToArchive = true) {
     // We always upload into the top-level export folder so prepend the key we've been given with 'export/'
     const exportKey = path.join('export', key)
 

--- a/app/services/send_transaction_file.service.js
+++ b/app/services/send_transaction_file.service.js
@@ -56,7 +56,7 @@ class SendTransactionFileService {
    */
   static async _generateAndSend (billRun, regime, notify) {
     const filename = this._filename(billRun.fileReference)
-    const generatedFile = GenerateTransactionFileService.go(filename, notify)
+    const generatedFile = await GenerateTransactionFileService.go(filename, notify)
 
     // GenerateTransactionFileService will return `false` if file generation failed; if this happens then we return
     // before we attempt to send the file.

--- a/test/services/send_bill_run_reference.service.test.js
+++ b/test/services/send_bill_run_reference.service.test.js
@@ -38,21 +38,17 @@ describe('Send Bill Run Reference service', () => {
     })
 
     it("sets the 'bill run' status to 'pending'", async () => {
-      await SendBillRunReferenceService.go(regime, billRun)
+      const sentBillRun = await SendBillRunReferenceService.go(regime, billRun)
 
-      const refreshedBillRun = await billRun.$query()
-
-      expect(refreshedBillRun.status).to.equal('pending')
+      expect(sentBillRun.status).to.equal('pending')
     })
 
     it("generates a file reference for the 'bill run'", async () => {
       // A bill run needs at least one billable invoice for a file reference to be generated
       await InvoiceHelper.addInvoice(billRun.id, 'CMA0000001', 2020, 0, 0, 1, 501, 0) // standard debit
-      await SendBillRunReferenceService.go(regime, billRun)
+      const sentBillRun = await SendBillRunReferenceService.go(regime, billRun)
 
-      const refreshedBillRun = await billRun.$query()
-
-      expect(refreshedBillRun.fileReference).to.equal('nalai50001')
+      expect(sentBillRun.fileReference).to.equal('nalai50001')
     })
 
     describe("for each 'invoice' linked to the bill run", () => {
@@ -85,19 +81,15 @@ describe('Send Bill Run Reference service', () => {
       })
 
       it("still updates the status to 'pending'", async () => {
-        await SendBillRunReferenceService.go(regime, billRun)
+        const sentBillRun = await SendBillRunReferenceService.go(regime, billRun)
 
-        const refreshedBillRun = await billRun.$query()
-
-        expect(refreshedBillRun.status).to.equal('pending')
+        expect(sentBillRun.status).to.equal('pending')
       })
 
       it("it does not assign a 'file reference'", async () => {
-        await SendBillRunReferenceService.go(regime, billRun)
+        const sentBillRun = await SendBillRunReferenceService.go(regime, billRun)
 
-        const refreshedBillRun = await billRun.$query()
-
-        expect(refreshedBillRun.fileReference).to.be.null()
+        expect(sentBillRun.fileReference).to.be.null()
       })
     })
   })

--- a/test/services/send_file_to_s3.service.test.js
+++ b/test/services/send_file_to_s3.service.test.js
@@ -58,7 +58,7 @@ describe('Send File To S3 service', () => {
     mockFs.restore()
   })
 
-  describe.only('When a valid file is specified', () => {
+  describe('When a valid file is specified', () => {
     it('uploads the file to the S3 bucket', async () => {
       await SendFileToS3Service.go(filenameWithPath, key, notifyFake, false)
 

--- a/test/services/send_file_to_s3.service.test.js
+++ b/test/services/send_file_to_s3.service.test.js
@@ -112,10 +112,9 @@ describe('Send File To S3 service', () => {
 
       await SendFileToS3Service.go(fakeFile, key, notifyFake, false)
 
-      const fakeFilenameWithPath = path.join(testFolder, fakeFile)
       expect(notifyFake.calledOnceWithExactly(
-        `Error sending file ${fakeFilenameWithPath} to bucket TEST_BUCKET: ` +
-        `Error: ENOENT: no such file or directory, open '${fakeFilenameWithPath}'`
+        `Error sending file ${fakeFile} to bucket TEST_BUCKET: ` +
+        `Error: ENOENT: no such file or directory, open '${fakeFile}'`
       )).to.equal(true)
     })
   })

--- a/test/services/send_file_to_s3.service.test.js
+++ b/test/services/send_file_to_s3.service.test.js
@@ -58,9 +58,9 @@ describe('Send File To S3 service', () => {
     mockFs.restore()
   })
 
-  describe('When a valid file is specified', () => {
+  describe.only('When a valid file is specified', () => {
     it('uploads the file to the S3 bucket', async () => {
-      await SendFileToS3Service.go(testFile, key, notifyFake, false)
+      await SendFileToS3Service.go(filenameWithPath, key, notifyFake, false)
 
       // Test that the S3 client was called once
       expect(s3Stub.calledOnce).to.be.true()
@@ -74,7 +74,7 @@ describe('Send File To S3 service', () => {
     })
 
     it("also uploads the file to the archive S3 bucket when copyToArchive is 'true'", async () => {
-      await SendFileToS3Service.go(testFile, key, notifyFake, true)
+      await SendFileToS3Service.go(filenameWithPath, key, notifyFake, true)
 
       // Test that the S3 client was called twice
       expect(s3Stub.calledTwice).to.be.true()
@@ -90,7 +90,7 @@ describe('Send File To S3 service', () => {
     it("deletes the file after uploading if removeTemporary files is 'true'", async () => {
       Sinon.stub(SendFileToS3Service, '_removeTemporaryFiles').returns(true)
 
-      await SendFileToS3Service.go(testFile, key, notifyFake, false)
+      await SendFileToS3Service.go(filenameWithPath, key, notifyFake, false)
 
       const fileExists = fs.existsSync(filenameWithPath)
       expect(fileExists).to.be.false()
@@ -99,7 +99,7 @@ describe('Send File To S3 service', () => {
     it("doesn't delete the file if removeTemporaryFiles is 'false'", async () => {
       Sinon.stub(SendFileToS3Service, '_removeTemporaryFiles').returns(false)
 
-      await SendFileToS3Service.go(testFile, key, notifyFake, false)
+      await SendFileToS3Service.go(filenameWithPath, key, notifyFake, false)
 
       const fileExists = fs.existsSync(filenameWithPath)
       expect(fileExists).to.be.true()


### PR DESCRIPTION
https://trello.com/c/NfozGoQ6

We have spotted an issue in how the `SendBillRunReferenceService` is interacting with the `SendTransactionFileService` service via the `BillRunsController` `send()` action.

The `SendTransactionFileService` because the instance of bill run it is seeing doesn't have a status of `pending`. With this change we ensure the service will see an updated version of the bill run with the correct status.