### PR TITLE
Add new docker helpers for local development

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -49,6 +49,21 @@
       }
     },
     {
+      "label": "Rebuild sroc-cma environment",
+      "detail": "Drop and remove everything, then rebuild with no cache",
+      "type": "shell",
+      "command": "docker-compose down --rmi local -v && docker-compose build --no-cache",
+      "group": "test",
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": true,
+        "panel": "shared",
+        "showReuseMessage": false,
+        "clear": true
+      }
+    },
+    {
       "label": "Run sroc-cma lint checks",
       "detail": "Run lint checks against the code",
       "type": "shell",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -124,10 +124,40 @@
       }
     },
     {
+      "label": "Refresh sroc-cma dev db",
+      "detail": "Will rollback all changes then re-run migrations and seeds for the main db",
+      "type": "shell",
+      "command": "docker-compose exec app /bin/sh -c 'npm run rollbackdb && npm run migratedb && npm run seeddb'",
+      "group": "test",
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": true,
+        "panel": "shared",
+        "showReuseMessage": false,
+        "clear": true
+      }
+    },
+    {
       "label": "Prepare sroc-cma test db",
       "detail": "Will create test db and run migrations. Is safe to call repeatedly",
       "type": "shell",
       "command": "docker-compose exec app /bin/sh -c 'npm run createdbtest && npm run migratedbtest'",
+      "group": "test",
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": true,
+        "panel": "shared",
+        "showReuseMessage": false,
+        "clear": true
+      }
+    },
+    {
+      "label": "Refresh sroc-cma test db",
+      "detail": "Will rollback all changes then re-run migrations and seeds for the test db",
+      "type": "shell",
+      "command": "docker-compose exec app /bin/sh -c 'npm run rollbackdbtest && npm run migratedbtest'",
       "group": "test",
       "presentation": {
         "echo": true,

--- a/db/migrations/20210215154015_alter_transactions_and_invoices.js
+++ b/db/migrations/20210215154015_alter_transactions_and_invoices.js
@@ -33,7 +33,7 @@ exports.down = async function (knex) {
 
   await knex
     .schema
-    .alterTable('transactions', table => {
+    .alterTable('invoices', table => {
       table.dropColumn('transaction_reference')
     })
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "createdbtest": "NODE_ENV=test node db/create_database.js",
     "migratedb": "knex migrate:latest",
     "migratedbtest": "NODE_ENV=test knex migrate:latest",
+    "rollbackdb": "knex migrate:rollback --all",
+    "rollbackdbtest": "NODE_ENV=test knex migrate:rollback --all",
     "seeddb": "knex seed:run",
     "unit-test": "lab --silent-skips --shuffle"
   },


### PR DESCRIPTION
Working with the API in Docker has been awesome. But we have found there are few things that could make our lives easier

- being able to properly scratch and rebuild the image and environment
- being able to reset the database

The first one especially highlighted an incorrect assumption we had made. We assumed that deleting the image meant it was rebuilt from scratch the next time we ran `docker-compose up`. In fact, we found it was reusing cached layers because as far as it could see nothing had changed.

These changes give us a couple more VSCode tasks to allow us to rebuild the environment properly, or just refresh the DB for those times we want to reset the data.
