### PR TITLE
SendTransactionFileService error handling

### DIFF
--- a/app/services/delete_file.service.js
+++ b/app/services/delete_file.service.js
@@ -14,11 +14,7 @@ class DeleteFileService {
   */
 
   static async go (localFilenameWithPath) {
-    try {
-      fs.unlinkSync(localFilenameWithPath)
-    } catch (error) {
-      throw new Error(error)
-    }
+    fs.unlinkSync(localFilenameWithPath)
   }
 }
 

--- a/app/services/generate_transaction_file.service.js
+++ b/app/services/generate_transaction_file.service.js
@@ -6,11 +6,8 @@
 
 const fs = require('fs')
 const path = require('path')
-const stream = require('stream')
-const util = require('util')
+const { Readable } = require('stream')
 const { temporaryFilePath } = require('../../config/server.config')
-
-const finished = util.promisify(stream.finished)
 
 class GenerateTransactionFileService {
   /**
@@ -20,29 +17,43 @@ class GenerateTransactionFileService {
    * @returns {string} The path and filename of the generated file.
    */
   static async go (filename) {
-    try {
-      const filenameWithPath = path.join(temporaryFilePath, filename)
-      const writeStream = await this._openStream(filenameWithPath)
-      await this._writeToStream(writeStream)
-      await this._closeStream(writeStream)
+    const filenameWithPath = path.join(temporaryFilePath, filename)
+    const inputStream = this._inputStream()
+    await this._streamToFile(inputStream, filenameWithPath)
 
-      return filenameWithPath
-    } catch (error) {
-      throw new Error(error)
-    }
+    return filenameWithPath
   }
 
-  static async _openStream (filenameWithPath) {
-    return fs.createWriteStream(filenameWithPath)
+  /**
+   * Accept a stream and pipe it to a file. We wrap this in a promise to streamline event handling. The method returns
+   * a promise so we can simply call it using "await" to wait for it to complete before we continue.
+   *
+   * https://dev.to/cdanielsen/wrap-your-streams-with-promises-for-fun-and-profit-51ka
+   */
+  static _streamToFile (inputStream, filePath) {
+    return new Promise((resolve, reject) => {
+      const fileWriteStream = fs.createWriteStream(filePath)
+      inputStream
+        .pipe(fileWriteStream)
+        .on('finish', resolve)
+        .on('error', reject)
+    })
   }
 
-  static async _writeToStream (writeStream) {
-    await writeStream.write('Hello world!')
-  }
+  /**
+   * Implement a simple readable stream to return our 'Hello world!' string.
+   *
+   * https://www.freecodecamp.org/news/node-js-streams-everything-you-need-to-know-c9141306be93/#implement-a-readable-stream
+   */
+  static _inputStream () {
+    const stream = new Readable({
+      read () {}
+    })
 
-  static async _closeStream (writeStream) {
-    writeStream.end()
-    await finished(writeStream)
+    stream.push('Hello world!')
+    stream.push(null) // No more data
+
+    return stream
   }
 }
 

--- a/app/services/generate_transaction_file.service.js
+++ b/app/services/generate_transaction_file.service.js
@@ -17,23 +17,18 @@ class GenerateTransactionFileService {
    * Writes a file to a given filename in the temp folder.
    *
    * @param {string} filename The name of the file to be written.
-   * @param {function} notify The server.methods.notify method, which we pass in as server.methods isn't accessible
-   * within a service.
-   * @returns {string} The path and filename of the written file. If writing failed then `null` is returned.
    */
-  static async go (filename, notify) {
-    const filenameWithPath = path.join(temporaryFilePath, filename)
-    const writeStream = await this._openStream(filenameWithPath)
-
+  static async go (filename) {
     try {
+      const filenameWithPath = path.join(temporaryFilePath, filename)
+      const writeStream = await this._openStream(filenameWithPath)
+
       await this._writeToStream(writeStream)
       await this._closeStream(writeStream)
+      return filenameWithPath
     } catch (error) {
-      notify(`Error writing file ${filenameWithPath}: ${error}`)
-      return null
+      throw new Error(error)
     }
-
-    return filenameWithPath
   }
 
   static async _openStream (filenameWithPath) {

--- a/app/services/generate_transaction_file.service.js
+++ b/app/services/generate_transaction_file.service.js
@@ -46,9 +46,7 @@ class GenerateTransactionFileService {
    * https://www.freecodecamp.org/news/node-js-streams-everything-you-need-to-know-c9141306be93/#implement-a-readable-stream
    */
   static _inputStream () {
-    const stream = new Readable({
-      read () {}
-    })
+    const stream = new Readable()
 
     stream.push('Hello world!')
     stream.push(null) // No more data

--- a/app/services/generate_transaction_file.service.js
+++ b/app/services/generate_transaction_file.service.js
@@ -14,17 +14,18 @@ const finished = util.promisify(stream.finished)
 
 class GenerateTransactionFileService {
   /**
-   * Writes a file to a given filename in the temp folder.
+   * Generates and writes a transaction file to a given filename in the temp folder.
    *
-   * @param {string} filename The name of the file to be written.
+   * @param {string} filename The name of the file to be generated.
+   * @returns {string} The path and filename of the generated file.
    */
   static async go (filename) {
     try {
       const filenameWithPath = path.join(temporaryFilePath, filename)
       const writeStream = await this._openStream(filenameWithPath)
-
       await this._writeToStream(writeStream)
       await this._closeStream(writeStream)
+
       return filenameWithPath
     } catch (error) {
       throw new Error(error)

--- a/app/services/send_file_to_s3.service.js
+++ b/app/services/send_file_to_s3.service.js
@@ -22,17 +22,13 @@ class SendFileToS3Service {
   */
 
   static async go (localFilenameWithPath, key, copyToArchive = true) {
-    try {
-      // We always upload into the top-level export folder so prepend the key we've been given with 'export/'
-      const exportKey = path.join('export', key)
+    // We always upload into the top-level export folder so prepend the key we've been given with 'export/'
+    const exportKey = path.join('export', key)
 
-      await this._sendFile(this._uploadBucket(), exportKey, localFilenameWithPath)
+    await this._sendFile(this._uploadBucket(), exportKey, localFilenameWithPath)
 
-      if (copyToArchive) {
-        await this._sendFile(this._archiveBucket(), exportKey, localFilenameWithPath)
-      }
-    } catch (error) {
-      throw new Error(error)
+    if (copyToArchive) {
+      await this._sendFile(this._archiveBucket(), exportKey, localFilenameWithPath)
     }
   }
 

--- a/app/services/send_file_to_s3.service.js
+++ b/app/services/send_file_to_s3.service.js
@@ -5,7 +5,7 @@
  */
 
 const { S3Config, ServerConfig } = require('../../config')
-const { removeTemporaryFiles, temporaryFilePath } = ServerConfig
+const { temporaryFilePath } = ServerConfig
 
 const { S3Client, PutObjectCommand } = require('@aws-sdk/client-s3')
 const fs = require('fs')
@@ -13,8 +13,7 @@ const path = require('path')
 
 class SendFileToS3Service {
   /**
-   * Send a file to an AWS S3 bucket. We optionally send it to the archive bucket, and based on server config we
-   * optionally delete the temp file.
+   * Send a file to an AWS S3 bucket. We optionally send it to the archive bucket.
    *
    * @param {string} localFilenameWithPath The name and path of the file to be sent to S3.
    * @param {string} key The key is the path and filename the file will have in the bucket. For example,
@@ -34,14 +33,6 @@ class SendFileToS3Service {
       }
     } catch (error) {
       throw new Error(error)
-    }
-
-    if (this._removeTemporaryFiles()) {
-      try {
-        fs.unlinkSync(localFilenameWithPath)
-      } catch (error) {
-        throw new Error(error)
-      }
     }
   }
 
@@ -74,10 +65,6 @@ class SendFileToS3Service {
 
   static _temporaryFilePath () {
     return temporaryFilePath
-  }
-
-  static _removeTemporaryFiles () {
-    return removeTemporaryFiles
   }
 
   static _uploadBucket () {

--- a/app/services/send_transaction_file.service.js
+++ b/app/services/send_transaction_file.service.js
@@ -26,7 +26,10 @@ class SendTransactionFileService {
    * within a service.
    */
   static async go (regime, billRun, notify) {
-    this._validate(billRun)
+    const validated = this._validate(billRun, notify)
+    if (!validated) {
+      return
+    }
 
     // If we don't need to generate a file then set the bill status to 'billing_not_required' and return early.
     const fileNeeded = this._checkIfFileNeeded(billRun)
@@ -41,10 +44,13 @@ class SendTransactionFileService {
     }
   }
 
-  static _validate (billRun) {
+  static _validate (billRun, notify) {
     if (!billRun.$pending()) {
-      throw Boom.conflict(`Bill run ${billRun.id} does not have a status of 'pending'.`)
+      notify(`Bill run ${billRun.id} does not have a status of 'pending'.`)
+      return false
     }
+
+    return true
   }
 
   static _checkIfFileNeeded (billRun) {

--- a/app/services/send_transaction_file.service.js
+++ b/app/services/send_transaction_file.service.js
@@ -20,7 +20,7 @@ class SendTransactionFileService {
    * - Checks that a transaction file is required;
    * - Calls GenerateTransactionFileService to generate the transaction file;
    * - Calls SendFileToS3Service to send the transaction file to the S3 bucket;
-   * - Deletes the file if removeTemporaryFiles is set to `true`;
+   * - Deletes the file if ServerConfig.removeTemporaryFiles is set to `true`;
    * - Sets the bill run status to 'billed' if everything was successful.
    *
    * @param {module:RegimeModel} regime The regime that the bill run belongs to. The regime slug will form part of the
@@ -69,7 +69,7 @@ class SendTransactionFileService {
   }
 
   /**
-   * Generate and send the transaction file. Returns the local filename and path of the generated file.
+   * Generate and send the transaction file. Returns the path and filename of the generated file.
    */
   static async _generateAndSend (billRun, regime) {
     const filename = this._filename(billRun.fileReference)

--- a/test/services/delete_file.service.test.js
+++ b/test/services/delete_file.service.test.js
@@ -48,7 +48,7 @@ describe('Delete File service', () => {
       const err = await expect(DeleteFileService.go(fakeFile)).to.reject()
 
       expect(err).to.be.an.error()
-      expect(err.message).to.equal(`Error: ENOENT: no such file or directory, unlink '${fakeFile}'`)
+      expect(err.message).to.equal(`ENOENT: no such file or directory, unlink '${fakeFile}'`)
     })
   })
 })

--- a/test/services/generate_transaction_file.service.test.js
+++ b/test/services/generate_transaction_file.service.test.js
@@ -19,15 +19,10 @@ const { temporaryFilePath } = require('../../config/server.config')
 const { GenerateTransactionFileService } = require('../../app/services')
 
 describe('Generate Transaction File service', () => {
-  let notifyFake
-
   const filename = 'test.txt'
   const filenameWithPath = path.join(temporaryFilePath, filename)
 
   beforeEach(async () => {
-    // Create a fake function to stand in place of server.methods.notify
-    notifyFake = Sinon.fake()
-
     // Create mock in-memory file system to avoid temp files being dropped in our filesystem
     mockFs({
       tmp: { }
@@ -41,7 +36,7 @@ describe('Generate Transaction File service', () => {
 
   describe('When writing a file succeeds', () => {
     it('creates a file with expected content', async () => {
-      await GenerateTransactionFileService.go(filename, notifyFake)
+      await GenerateTransactionFileService.go(filename)
 
       const file = fs.readFileSync(filenameWithPath, 'utf-8')
 
@@ -49,7 +44,7 @@ describe('Generate Transaction File service', () => {
     })
 
     it('returns the filename and path', async () => {
-      const returnedFilenameWithPath = await GenerateTransactionFileService.go(filename, notifyFake)
+      const returnedFilenameWithPath = await GenerateTransactionFileService.go(filename)
 
       expect(returnedFilenameWithPath).to.equal(filenameWithPath)
     })
@@ -62,10 +57,11 @@ describe('Generate Transaction File service', () => {
         .throws('TEST')
     })
 
-    it('uses server.notify to log the error', async () => {
-      await GenerateTransactionFileService.go(filename, notifyFake)
+    it('throws an error', async () => {
+      const err = await expect(GenerateTransactionFileService.go(filename)).to.reject()
 
-      expect(notifyFake.calledOnceWithExactly(`Error writing file ${filenameWithPath}: TEST`)).to.equal(true)
+      expect(err).to.be.an.error()
+      expect(err.message).to.equal('TEST')
     })
   })
 })

--- a/test/services/generate_transaction_file.service.test.js
+++ b/test/services/generate_transaction_file.service.test.js
@@ -5,7 +5,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { afterEach, before, beforeEach, describe, it } = exports.lab = Lab.script()
+const { afterEach, beforeEach, describe, it } = exports.lab = Lab.script()
 const { expect } = Code
 
 const mockFs = require('mock-fs')
@@ -51,17 +51,15 @@ describe('Generate Transaction File service', () => {
   })
 
   describe('When writing a file fails', () => {
-    before(async () => {
-      Sinon
-        .stub(GenerateTransactionFileService, '_writeToStream')
-        .throws('TEST')
-    })
-
     it('throws an error', async () => {
-      const err = await expect(GenerateTransactionFileService.go(filename)).to.reject()
+      const fakeFilenameWithPath = path.join('FAKE_DIR', filenameWithPath)
+
+      const err = await expect(GenerateTransactionFileService.go(fakeFilenameWithPath)).to.reject()
 
       expect(err).to.be.an.error()
-      expect(err.message).to.equal('TEST')
+      // The service adds the temp file path to the filename we pass to it so this is the path we expect in the error
+      const errorPath = path.join(temporaryFilePath, fakeFilenameWithPath)
+      expect(err.message).to.equal(`ENOENT, no such file or directory '${errorPath}'`)
     })
   })
 })

--- a/test/services/send_file_to_s3.service.test.js
+++ b/test/services/send_file_to_s3.service.test.js
@@ -90,7 +90,7 @@ describe('Send File To S3 service', () => {
       const err = await expect(SendFileToS3Service.go(fakeFile, key, false)).to.reject()
 
       expect(err).to.be.an.error()
-      expect(err.message).to.equal(`Error: ENOENT: no such file or directory, open '${fakeFile}'`)
+      expect(err.message).to.equal(`ENOENT: no such file or directory, open '${fakeFile}'`)
     })
   })
 })

--- a/test/services/send_file_to_s3.service.test.js
+++ b/test/services/send_file_to_s3.service.test.js
@@ -10,7 +10,6 @@ const { expect } = Code
 
 const mockFs = require('mock-fs')
 
-const fs = require('fs')
 const path = require('path')
 
 // Things we need to stub
@@ -81,24 +80,6 @@ describe('Send File To S3 service', () => {
 
       // Test the bucket the file was sent to
       expect(calledCommand.input.Bucket).to.equal('ARCHIVE_BUCKET')
-    })
-
-    it("deletes the file after uploading if removeTemporary files is 'true'", async () => {
-      Sinon.stub(SendFileToS3Service, '_removeTemporaryFiles').returns(true)
-
-      await SendFileToS3Service.go(filenameWithPath, key, false)
-
-      const fileExists = fs.existsSync(filenameWithPath)
-      expect(fileExists).to.be.false()
-    })
-
-    it("doesn't delete the file if removeTemporaryFiles is 'false'", async () => {
-      Sinon.stub(SendFileToS3Service, '_removeTemporaryFiles').returns(false)
-
-      await SendFileToS3Service.go(filenameWithPath, key, false)
-
-      const fileExists = fs.existsSync(filenameWithPath)
-      expect(fileExists).to.be.true()
     })
   })
 

--- a/test/services/send_file_to_s3.service.test.js
+++ b/test/services/send_file_to_s3.service.test.js
@@ -20,7 +20,6 @@ const { S3Client, PutObjectCommand } = require('@aws-sdk/client-s3')
 const { SendFileToS3Service } = require('../../app/services')
 
 describe('Send File To S3 service', () => {
-  let notifyFake
   let s3Stub
   let key
 
@@ -31,9 +30,6 @@ describe('Send File To S3 service', () => {
   beforeEach(() => {
     // Stub the S3 client's send method, which is used to run the 'put object' command
     s3Stub = Sinon.stub(S3Client.prototype, 'send')
-
-    // Create a fake function to stand in place of server.methods.notify
-    notifyFake = Sinon.fake()
 
     // Define the key we'll 'upload' to. We use the 'test_folder' dir as this exists in our dev bucket so if we want to
     // double-check that files are indeed uploaded successfully, we can un-stub AWS and check the bucket contents
@@ -60,7 +56,7 @@ describe('Send File To S3 service', () => {
 
   describe('When a valid file is specified', () => {
     it('uploads the file to the S3 bucket', async () => {
-      await SendFileToS3Service.go(filenameWithPath, key, notifyFake, false)
+      await SendFileToS3Service.go(filenameWithPath, key, false)
 
       // Test that the S3 client was called once
       expect(s3Stub.calledOnce).to.be.true()
@@ -74,7 +70,7 @@ describe('Send File To S3 service', () => {
     })
 
     it("also uploads the file to the archive S3 bucket when copyToArchive is 'true'", async () => {
-      await SendFileToS3Service.go(filenameWithPath, key, notifyFake, true)
+      await SendFileToS3Service.go(filenameWithPath, key, true)
 
       // Test that the S3 client was called twice
       expect(s3Stub.calledTwice).to.be.true()
@@ -90,7 +86,7 @@ describe('Send File To S3 service', () => {
     it("deletes the file after uploading if removeTemporary files is 'true'", async () => {
       Sinon.stub(SendFileToS3Service, '_removeTemporaryFiles').returns(true)
 
-      await SendFileToS3Service.go(filenameWithPath, key, notifyFake, false)
+      await SendFileToS3Service.go(filenameWithPath, key, false)
 
       const fileExists = fs.existsSync(filenameWithPath)
       expect(fileExists).to.be.false()
@@ -99,7 +95,7 @@ describe('Send File To S3 service', () => {
     it("doesn't delete the file if removeTemporaryFiles is 'false'", async () => {
       Sinon.stub(SendFileToS3Service, '_removeTemporaryFiles').returns(false)
 
-      await SendFileToS3Service.go(filenameWithPath, key, notifyFake, false)
+      await SendFileToS3Service.go(filenameWithPath, key, false)
 
       const fileExists = fs.existsSync(filenameWithPath)
       expect(fileExists).to.be.true()
@@ -107,15 +103,13 @@ describe('Send File To S3 service', () => {
   })
 
   describe('When an invalid file is specified', () => {
-    it('uses server.notify to log the error', async () => {
+    it('throws an error', async () => {
       const fakeFile = 'FAKE_FILE'
 
-      await SendFileToS3Service.go(fakeFile, key, notifyFake, false)
+      const err = await expect(SendFileToS3Service.go(fakeFile, key, false)).to.reject()
 
-      expect(notifyFake.calledOnceWithExactly(
-        `Error sending file ${fakeFile} to bucket TEST_BUCKET: ` +
-        `Error: ENOENT: no such file or directory, open '${fakeFile}'`
-      )).to.equal(true)
+      expect(err).to.be.an.error()
+      expect(err.message).to.equal(`Error: ENOENT: no such file or directory, open '${fakeFile}'`)
     })
   })
 })

--- a/test/services/send_transaction_file.service.test.js
+++ b/test/services/send_transaction_file.service.test.js
@@ -108,7 +108,9 @@ describe('Send Transaction File service', () => {
       it('throws an error', async () => {
         await SendTransactionFileService.go(regime, billRun, notifyFake)
 
-        expect(notifyFake.calledOnceWithExactly(`Bill run ${billRun.id} does not have a status of 'pending'.`)).to.equal(true)
+        expect(notifyFake.calledOnceWithExactly(
+          `Error sending transaction file: Error: Bill run ${billRun.id} does not have a status of 'pending'.`
+        )).to.equal(true)
       })
     })
   })


### PR DESCRIPTION
After discovering an issue with uncaught errors during the process of sending a transaction file, we reviewed the error handling and decided to make a change.

Previously, `SendTransactionFileService` was receiving the `notify` server method (which we use for Airbrake logging) and passing it to each of the services it called: `GenerateTransactionFileService` and `SendFileToS3Service`. We did this because the services were intended to run in the background so we wanted to ensure that any issues during the process of generating and sending files were logged using Airbrake instead of disappearing into the ether.

On reflection, we decided it would be better for these services to throw errors, and for `SendTransactionFileService` to be responsible for catching these and logging them using `notify`.

Implementing this means we don't have to keep passing `notify` around to each service. We also no longer need to return boolean values to signal whether or not we succeeded, as this is implicit in the fact that we didn't throw an error!