### PR TITLE
Create DeleteFileService

### DIFF
--- a/app/services/delete_file.service.js
+++ b/app/services/delete_file.service.js
@@ -1,0 +1,25 @@
+'use strict'
+
+/**
+ * @module DeleteFileService
+ */
+
+const fs = require('fs')
+
+class DeleteFileService {
+  /**
+   * Delete a file.
+   *
+   * @param {string} localFilenameWithPath The name and path of the file to be deleted.
+  */
+
+  static async go (localFilenameWithPath) {
+    try {
+      fs.unlinkSync(localFilenameWithPath)
+    } catch (error) {
+      throw new Error(error)
+    }
+  }
+}
+
+module.exports = DeleteFileService

--- a/app/services/index.js
+++ b/app/services/index.js
@@ -16,6 +16,7 @@ const CreateTransactionTallyService = require('./create_transaction_tally.servic
 const DatabaseHealthCheckService = require('./database_health_check.service')
 const DbErrorsService = require('./db_errors.service')
 const DeleteBillRunService = require('./delete_bill_run.service')
+const DeleteFileService = require('./delete_file.service')
 const DeleteInvoiceService = require('./delete_invoice.service')
 const FetchAndValidateBillRunInvoiceService = require('./fetch_and_validate_bill_run_invoice.service')
 const GenerateBillRunService = require('./generate_bill_run.service')
@@ -55,6 +56,7 @@ module.exports = {
   DatabaseHealthCheckService,
   DbErrorsService,
   DeleteBillRunService,
+  DeleteFileService,
   DeleteInvoiceService,
   FetchAndValidateBillRunInvoiceService,
   GenerateBillRunService,

--- a/test/services/delete_file.service.test.js
+++ b/test/services/delete_file.service.test.js
@@ -1,0 +1,54 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+const mockFs = require('mock-fs')
+
+const fs = require('fs')
+const path = require('path')
+
+// Thing under test
+const { DeleteFileService } = require('../../app/services')
+
+describe('Delete File service', () => {
+  let filenameWithPath
+
+  beforeEach(() => {
+    filenameWithPath = path.join('testFolder', 'testFile')
+
+    mockFs({
+      testFolder: {
+        testFile: 'test content'
+      }
+    })
+  })
+
+  afterEach(() => {
+    mockFs.restore()
+  })
+
+  describe('When a valid file is specified', () => {
+    it('deletes the file', async () => {
+      await DeleteFileService.go(filenameWithPath)
+
+      const fileExists = fs.existsSync(filenameWithPath)
+      expect(fileExists).to.be.false()
+    })
+  })
+
+  describe('When an error occurs', () => {
+    it('throws an error', async () => {
+      const fakeFile = 'FAKE_FILE'
+
+      const err = await expect(DeleteFileService.go(fakeFile)).to.reject()
+
+      expect(err).to.be.an.error()
+      expect(err.message).to.equal(`Error: ENOENT: no such file or directory, unlink '${fakeFile}'`)
+    })
+  })
+})


### PR DESCRIPTION
While working on [`SendTransactionFileService` error handling](https://github.com/DEFRA/sroc-charging-module-api/pull/315), we found a problem with how we wanted to handle errors when deleting the temp file.

When we generate and send the transaction file, we end by deleting the temp file we generated and setting the bill run status to `billed`. If deleting the temp file fails for some reason then we still want to set the status as the file has been sent and the existence of the temp file makes no difference to that.

However, if we include the deletion in `SendFileToS3Service` and it throws an error, we won't reach the step of setting the bill run status and therefore it will be stuck -- the file will have gone but the status won't have changed.

This PR therefore separates out file deletion into a `DeleteFileService` which we intend to use in `SendTransactionFileService` _after_ we set the bill run status.