### PR TITLE
Fix installing react-native as a dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
       # Performs a clean installation of all dependencies in the `package.json` file
       # For more information, see https://docs.npmjs.com/cli/ci.html
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --legacy-peer-deps
 
       # Run linting first. No point running the tests if there is a linting issue
       - name: Run lint check

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ EXPOSE $PORT 9229 9230
 # first copy just the package*.json files from the host
 COPY package.json package-lock.json* ./
 
-RUN npm install
+RUN npm install --legacy-peer-deps
 
 # Update the PATH env var to add any node binaries from our dependencies to it. This should make them discoverable from
 # the command line
@@ -103,7 +103,7 @@ USER node
 # owner of the copied files
 COPY --chown=node:node package.json package-lock.json* ./
 
-RUN npm install
+RUN npm install --legacy-peer-deps
 
 # Update the PATH env var to add any node binaries from our dependencies to it. This should make them discoverable from
 # the command line


### PR DESCRIPTION
To support sending files to AWS S3 we recently added a [Send File To S3 service](https://github.com/DEFRA/sroc-charging-module-api/pull/293). As part of that change, we added `@aws-sdk/client-s3` as a dependency.

Unfortunately, we got hit with 2 things at once. `client-s3` has a dependency on a middleware package that has a **peer** dependency on `react-native`.

Also, npm v7 is out and that automatically installs peer dependencies, even when not really needed.

Until https://github.com/aws/aws-sdk-js-v3/pull/2108 is merged it looks like the workaround is to use the command [`npm install --legacy-peer-deps`](https://github.com/aws/aws-sdk-js-v3/issues/2150#issuecomment-803509600). This tells npm to use pre-v7 behaviours and not automatically install peer dependencies.