### PR TITLE
Add --no-cache arg to DockerHub build

### DIFF
--- a/hooks/build
+++ b/hooks/build
@@ -2,4 +2,4 @@
 
 # Ensure the build args we need are set. The env vars are provided by Docker
 # https://docs.docker.com/docker-hub/builds/advanced/#environment-variables-for-building-and-testing
-docker build --target production -t $IMAGE_NAME . --build-arg GIT_COMMIT=$SOURCE_COMMIT --build-arg DOCKER_TAG=$IMAGE_NAME
+docker build --no-cache --target production -t $IMAGE_NAME . --build-arg GIT_COMMIT=$SOURCE_COMMIT --build-arg DOCKER_TAG=$IMAGE_NAME


### PR DESCRIPTION
Whilst working with our Docker setup recently we stumbled upon an incorrect assumption we had made. We assumed that when we deleted our image locally Docker was rebuilding the new one from scratch.

In fact, where possible it was using previously cached layers to speed up the build time. This was specifically noticed regards our attempt to always use the latest version of NPM.

We have the command `RUN npm i npm@latest -g` near the start of our Dockerfile. We assumed this meant every time we built Docker was installing the latest version of NPM. In fact, it was just using a previously cached layer.

Having checked the DockerHub logs it looks like we are ok and it is always building from scratch. But as we have done with our [VSCode rebuild task](https://github.com/DEFRA/sroc-charging-module-api/pull/314) we'll be adding `--no-cache` to our internal AWS build process and we want to make the DockerHub build consistent with it.