### PR TITLE
Fix unique error messages in Send Trans. file

### DIFF
--- a/app/services/generate_transaction_file.service.js
+++ b/app/services/generate_transaction_file.service.js
@@ -29,7 +29,7 @@ class GenerateTransactionFileService {
       await this._writeToStream(writeStream)
       await this._closeStream(writeStream)
     } catch (error) {
-      notify(`Error writing file ${filenameWithPath}: ${error}`)
+      this._errorNotification(notify, 'Error writing file', filenameWithPath, error)
       return null
     }
 
@@ -47,6 +47,13 @@ class GenerateTransactionFileService {
   static async _closeStream (writeStream) {
     writeStream.end()
     await finished(writeStream)
+  }
+
+  static _errorNotification (notify, message, filename, error) {
+    notify(
+      message,
+      { filename, error }
+    )
   }
 }
 

--- a/app/services/send_file_to_s3.service.js
+++ b/app/services/send_file_to_s3.service.js
@@ -36,7 +36,7 @@ class SendFileToS3Service {
         await this._sendFile(this._archiveBucket(), exportKey, localFilenameWithPath)
       }
     } catch (error) {
-      notify(`Error sending file ${localFilenameWithPath} to bucket ${this._uploadBucket()}: ${error}`)
+      this._errorNotification(notify, 'Error sending file', localFilenameWithPath, this._uploadBucket(), error)
       return false
     }
 
@@ -44,7 +44,7 @@ class SendFileToS3Service {
       try {
         fs.unlinkSync(localFilenameWithPath)
       } catch (error) {
-        notify(`Error deleting file ${localFilenameWithPath}: ${error}`)
+        this._errorNotification(notify, 'Error deleting file', localFilenameWithPath, null, error)
       }
     }
 
@@ -93,6 +93,13 @@ class SendFileToS3Service {
 
   static _archiveBucket () {
     return S3Config.archiveBucket
+  }
+
+  static _errorNotification (notify, message, filename, bucket, error) {
+    notify(
+      message,
+      { filename, bucket, error }
+    )
   }
 }
 

--- a/test/services/generate_transaction_file.service.test.js
+++ b/test/services/generate_transaction_file.service.test.js
@@ -56,16 +56,23 @@ describe('Generate Transaction File service', () => {
   })
 
   describe('When writing a file fails', () => {
+    const error = new Error('TEST')
+
     before(async () => {
       Sinon
         .stub(GenerateTransactionFileService, '_writeToStream')
-        .throws('TEST')
+        .throws(error)
     })
 
     it('uses server.notify to log the error', async () => {
+      const notifyData = {
+        filename: filenameWithPath,
+        error: error
+      }
+
       await GenerateTransactionFileService.go(filename, notifyFake)
 
-      expect(notifyFake.calledOnceWithExactly(`Error writing file ${filenameWithPath}: TEST`)).to.equal(true)
+      expect(notifyFake.calledOnceWithExactly('Error writing file', notifyData)).to.equal(true)
     })
   })
 })

--- a/test/services/send_file_to_s3.service.test.js
+++ b/test/services/send_file_to_s3.service.test.js
@@ -18,7 +18,6 @@ const { S3Client, PutObjectCommand } = require('@aws-sdk/client-s3')
 
 // Thing under test
 const { SendFileToS3Service } = require('../../app/services')
-const { ENOENT } = require('constants')
 
 describe('Send File To S3 service', () => {
   let notifyFake


### PR DESCRIPTION
https://trello.com/c/NfozGoQ6

We overlooked when we completed the [Send File To S3 service](https://github.com/DEFRA/sroc-charging-module-api/pull/293) that we were sending notifications to Errbit that contained unique error messages, for example, `Error sending file /tmp/nalai50003.dat to bucket file-uploads-pre-sroc-service-gov-uk`.

The reason we avoid using unique errors messages to so [Errbit](https://github.com/errbit/errbit) can group the same errors. It has the concept of unique errors, with multiple reported instances. If our error messages are unique it leads to multiple 'error' in Errbit all with a single reported instance.

This can make it difficult to track, triage and prioritise errors. So, this change updates what we pass to the notification to make the errors standard but still pass unique credentials for the instance.

<details>
<summary>Errbit screenshot</summary>

<img width="813" alt="Screenshot 2021-03-22 at 17 37 07" src="https://user-images.githubusercontent.com/1789650/112033436-51fd1480-8b35-11eb-8e1e-34e3fb68a0a8.png">

</details>