### PR TITLE
Add credit and debit line values back to invoices

### DIFF
--- a/app/presenters/view_bill_run_invoice.presenter.js
+++ b/app/presenters/view_bill_run_invoice.presenter.js
@@ -20,6 +20,8 @@ class ViewBillRunInvoicePresenter extends BasePresenter {
       zeroValueInvoice: data.zeroValueInvoice,
       minimumChargeInvoice: data.minimumChargeInvoice,
       transactionReference: data.transactionReference,
+      creditLineValue: data.creditLineValue,
+      debitLineValue: data.debitLineValue,
       netTotal: data.netTotal,
       licences: data.licences
     }

--- a/app/presenters/view_invoice.presenter.js
+++ b/app/presenters/view_invoice.presenter.js
@@ -22,6 +22,8 @@ class ViewInvoicePresenter extends BasePresenter {
         zeroValueInvoice: data.zeroValueInvoice,
         minimumChargeInvoice: data.minimumChargeInvoice,
         transactionReference: data.transactionReference,
+        creditLineValue: data.creditLineValue,
+        debitLineValue: data.debitLineValue,
         netTotal: data.netTotal,
         licences: data.licences.map(licence => {
           const presenter = new ViewLicencePresenter(licence)

--- a/test/presenters/view_bill.presenter.test.js
+++ b/test/presenters/view_bill.presenter.test.js
@@ -81,6 +81,8 @@ describe('View Bill Run Presenter', () => {
       'zeroValueInvoice',
       'minimumChargeInvoice',
       'transactionReference',
+      'creditLineValue',
+      'debitLineValue',
       'netTotal'
     ])
   })

--- a/test/presenters/view_invoice.presenter.test.js
+++ b/test/presenters/view_invoice.presenter.test.js
@@ -74,6 +74,8 @@ describe('View Invoice Presenter', () => {
       'zeroValueInvoice',
       'minimumChargeInvoice',
       'transactionReference',
+      'creditLineValue',
+      'debitLineValue',
       'netTotal'
     ])
   })


### PR DESCRIPTION
https://trello.com/c/TvlmPtZ4
https://trello.com/c/qldEb08U

Recently we [Removed tally fields from invoices in view bill run](https://github.com/DEFRA/sroc-charging-module-api/pull/313) and from [invoices in view /invoices](https://github.com/DEFRA/sroc-charging-module-api/pull/306).

We had confirmed this with the WRLS team, but an overlooked piece of functionality has been highlighted in recent testing which relies on them.

For annual and two-part tariff bill runs all the underlying invoices are all debits. So, in their UI they don't bother showing the breakdown. But for supplementary bill runs, invoices (we should probably use a more generic name 😁) can have a mix of credit and debit lines. So, in their UI they _do_ like to show the breakdown.

> [..] Bills in a supplementary run can contain a mix of credits/charges. TPT and annual are charges only

When we removed the fields, we broke the function which grabbed this information for the UI view. This change adds them back into `GET /bill-runs` and `GET /invoices` giving them the flexibility to decide where to grab the info from, and helping keep the `invoice` schema consistent across the 2 responses.

<details>
<summary>Bill run response</summary>

<img width="547" alt="Screenshot 2021-03-23 at 11 14 54" src="https://user-images.githubusercontent.com/1789650/112138417-64289280-8bc9-11eb-8d99-e23ce57a2eef.png">

</details>

<details>
<summary>Invoice response</summary>

<img width="492" alt="Screenshot 2021-03-23 at 11 15 16" src="https://user-images.githubusercontent.com/1789650/112138474-74d90880-8bc9-11eb-9f57-f594bf47e442.png">

</details>