### PR TITLE
Fix unique error messages in Send Trans. file

### DIFF
--- a/app/services/send_transaction_file.service.js
+++ b/app/services/send_transaction_file.service.js
@@ -50,12 +50,8 @@ class SendTransactionFileService {
         await DeleteFileService.go(generatedFile)
       }
     } catch (error) {
-      notify(this._errorMessage(error))
+      this._notifyError(notify, 'Error sending transaction file', generatedFile, error)
     }
-  }
-
-  static _errorMessage (error) {
-    return `Error sending transaction file: ${error}`
   }
 
   static _validate (billRun) {
@@ -99,6 +95,13 @@ class SendTransactionFileService {
   static async _setBilledStatus (billRun) {
     await billRun.$query()
       .patch({ status: 'billed' })
+  }
+
+  static _notifyError (notifier, message, filename, error) {
+    notifier(
+      message,
+      { filename, error }
+    )
   }
 }
 

--- a/test/services/send_transaction_file.service.test.js
+++ b/test/services/send_transaction_file.service.test.js
@@ -134,9 +134,9 @@ describe('Send Transaction File service', () => {
       it('throws an error', async () => {
         await SendTransactionFileService.go(regime, billRun, notifyFake)
 
-        expect(notifyFake.calledOnceWithExactly(
-          `Error sending transaction file: Error: Bill run ${billRun.id} does not have a status of 'pending'.`
-        )).to.equal(true)
+        expect(notifyFake.firstArg).to.equal('Error sending transaction file')
+        expect(notifyFake.lastArg.filename).to.be.undefined()
+        expect(notifyFake.lastArg.error.message).to.equal(`Bill run ${billRun.id} does not have a status of 'pending'.`)
       })
     })
   })


### PR DESCRIPTION
https://trello.com/c/NfozGoQ6

We overlooked when we completed the [Send File To S3 service](https://github.com/DEFRA/sroc-charging-module-api/pull/293) that we were sending notifications to Errbit that contained unique error messages, for example, `Error sending file /tmp/nalai50003.dat to bucket file-uploads-pre-sroc-service-gov-uk`.

The reason we avoid using unique errors messages to so [Errbit](https://github.com/errbit/errbit) can group the same errors. It has the concept of unique errors, with multiple reported instances. If our error messages are unique it leads to multiple 'error' in Errbit all with a single reported instance.

This can make it difficult to track, triage and prioritise errors. So, this change updates what we pass to the notification to make the errors standard but still pass unique credentials for the instance.

<details>
<summary>Errbit screenshot</summary>

<img width="813" alt="Screenshot 2021-03-22 at 17 37 07" src="https://user-images.githubusercontent.com/1789650/112033436-51fd1480-8b35-11eb-8e1e-34e3fb68a0a8.png">

</details>