### PR TITLE
Add new Notifier plugin

### DIFF
--- a/app/lib/index.js
+++ b/app/lib/index.js
@@ -1,0 +1,7 @@
+'use strict'
+
+const Notifier = require('./notifier')
+
+module.exports = {
+  Notifier
+}

--- a/app/lib/notifier.js
+++ b/app/lib/notifier.js
@@ -1,0 +1,22 @@
+'use strict'
+
+class Notifier {
+  #logger
+  #notifier
+
+  constructor (logger, notifier) {
+    this.#logger = logger
+    this.#notifier = notifier
+  }
+
+  omg (message) {
+    this.#logger.info(message)
+  }
+
+  omfg (message, data = {}) {
+    this.#logger.error({ message, data })
+    this.#notifier(message, data)
+  }
+}
+
+module.exports = Notifier

--- a/app/lib/notifier.js
+++ b/app/lib/notifier.js
@@ -1,15 +1,75 @@
 'use strict'
 
+/**
+ * @module Notifier
+ */
+
+/**
+ * Our combined logging and Airbrake (Errbit) notification manager.
+ *
+ * This is used in conjunction with the `NotifierPlugin` to make both logging via
+ * {@link https://github.com/pinojs/pino|pino} and sending notifications to Errbit via
+ * {@link https://github.com/airbrake/airbrake-js|airbrake-js} available to our controllers and their underlying
+ * services.
+ *
+ * > ***So, `omg()` and `omfg()`. What's that all about!?***
+ * >
+ * > This is a very 'serious' project dealing with very dry finance and regulation rules. We love what we do but having
+ * > the opportunity to use `omg('The bill run looks fantastic!')` in our work day can only help us smile more!
+ */
 class Notifier {
+  /**
+   * Instantiate a new instance
+   *
+   * @param {Object} logger An instance of {@link https://github.com/pinojs/pino|pino}, a Node JSON logger
+   * which the {@link https://github.com/pinojs/hapi-pino|hapi-pino} plugin adds to Hapi
+   * @param {Object} notifier An instance of the {@link https://github.com/airbrake/airbrake-js|airbrake-js} `notify()`
+   * method which our 'AirbrakePlugin` adds to Hapi
+   */
   constructor (logger, notifier) {
     this._logger = logger
     this._notifier = notifier
   }
 
+  /**
+   * Use to add a message to the log
+   *
+   * The message will be added as an `INFO` level log message.
+   *
+   * @param {string} message Message to add to the log
+   */
   omg (message) {
     this._logger.info(message)
   }
 
+  /**
+   * Use to add an 'error' message to the log and send a notification to Errbit
+   *
+   * Intended to be used when we want to record an error both in the logs and in Errbit.
+   *
+   * ## Notifications to Errbit
+   *
+   * Other than making errors more visible and accessible, the main benefit of Errbit is its ability to group instances
+   * of the same error. But it can only do this if the 'error signature' is consistent. It is important that what we
+   * send has a consistent 'message'. We can send whatever we like in the data as this is not used to generate the
+   * signature.
+   *
+   * So, you should avoid
+   *
+   * ```
+   * notifier.omfg(`Bill run id ${billRun.id} failed to generate.`)
+   * ```
+   *
+   * Instead use
+   *
+   * ```
+   * notifier.omfg('Bill run failed to generate.', { id: billRun.id })
+   * ```
+   *
+   * @param {string} message Message to add to the log
+   * @param {Object} data Any params or values, for example, a bill run ID to be included with the log message and sent
+   * with the notification to Errbit
+   */
   omfg (message, data = {}) {
     this._logger.error({ message, data })
     this._notifier(message, data)

--- a/app/lib/notifier.js
+++ b/app/lib/notifier.js
@@ -1,21 +1,18 @@
 'use strict'
 
 class Notifier {
-  #logger
-  #notifier
-
   constructor (logger, notifier) {
-    this.#logger = logger
-    this.#notifier = notifier
+    this._logger = logger
+    this._notifier = notifier
   }
 
   omg (message) {
-    this.#logger.info(message)
+    this._logger.info(message)
   }
 
   omfg (message, data = {}) {
-    this.#logger.error({ message, data })
-    this.#notifier(message, data)
+    this._logger.error({ message, data })
+    this._notifier(message, data)
   }
 }
 

--- a/app/plugins/index.js
+++ b/app/plugins/index.js
@@ -10,6 +10,7 @@ const HapiNowAuthPlugin = require('./hapi_now_auth.plugin')
 const HapiPinoPlugin = require('./hapi_pino.plugin')
 const InvalidCharactersPlugin = require('./invalid_characters.plugin')
 const MissingPayloadPlugin = require('./missing_payload.plugin')
+const NotifierPlugin = require('./notifier.plugin')
 const PayloadCleanerPlugin = require('./payload_cleaner.plugin')
 const RouterPlugin = require('./router.plugin')
 const StopPlugin = require('./stop.plugin')
@@ -40,6 +41,7 @@ module.exports = {
   HapiPinoPlugin,
   InvalidCharactersPlugin,
   MissingPayloadPlugin,
+  NotifierPlugin,
   PayloadCleanerPlugin,
   RouterPlugin,
   StopPlugin,

--- a/app/plugins/notifier.plugin.js
+++ b/app/plugins/notifier.plugin.js
@@ -1,0 +1,20 @@
+'use strict'
+
+/**
+ * @module NotifierPlugin
+ */
+
+const { Notifier } = require('../lib')
+
+const NotifierPlugin = {
+  name: 'Notifier',
+  register: (server, _options) => {
+    server.ext('onRequest', (request, h) => {
+      request.app.notifier = new Notifier(server.logger, server.methods.notify)
+
+      return h.continue
+    })
+  }
+}
+
+module.exports = NotifierPlugin

--- a/app/plugins/notifier.plugin.js
+++ b/app/plugins/notifier.plugin.js
@@ -1,6 +1,11 @@
 'use strict'
 
 /**
+ * Add an instance of `Notifier` to the `request.app` as part of every request.
+ *
+ * This makes writing to the log and sending notifications to Errbit more accesible, easier to use, and more consistent
+ * in the controllers and their underlying services.
+ *
  * @module NotifierPlugin
  */
 

--- a/server.js
+++ b/server.js
@@ -14,6 +14,7 @@ const {
   HapiPinoPlugin,
   InvalidCharactersPlugin,
   MissingPayloadPlugin,
+  NotifierPlugin,
   PayloadCleanerPlugin,
   RouterPlugin,
   StopPlugin,
@@ -35,12 +36,13 @@ exports.deployment = async start => {
   await server.register(AuthorisationPlugin)
   await server.register(RouterPlugin)
   await server.register(AirbrakePlugin)
+  await server.register(HapiPinoPlugin(TestConfig.logInTest))
+  await server.register(NotifierPlugin)
   await server.register(MissingPayloadPlugin)
   await server.register(InvalidCharactersPlugin)
   await server.register(PayloadCleanerPlugin)
   await server.register(DbErrorsPlugin)
   await server.register(VersionInfoPlugin)
-  await server.register(HapiPinoPlugin(TestConfig.logInTest))
   await server.register(BillRunPlugin)
 
   // Register non-production plugins

--- a/test/features/add_notifier_to_requests.test.js
+++ b/test/features/add_notifier_to_requests.test.js
@@ -1,0 +1,41 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, before } = exports.lab = Lab.script()
+const { expect } = Code
+
+// For running our service
+const { deployment } = require('../../server')
+
+// Test helpers
+const { RouteHelper } = require('../support/helpers')
+
+const options = (url) => {
+  return {
+    method: 'GET',
+    url: url
+  }
+}
+
+describe("Adding a 'Notifier' instance to all requests to support logging and Errbit notifications", () => {
+  let server
+
+  // Create server before each test
+  before(async () => {
+    server = await deployment()
+    RouteHelper.addNotifierRoute(server)
+  })
+
+  describe('When a request is made', () => {
+    it("adds an instance of 'Notifier' to the request", async () => {
+      const response = await server.inject(options('/test/notifier'))
+      const responsePayload = JSON.parse(response.payload)
+
+      expect(response.statusCode).to.equal(200)
+      expect(responsePayload.exists).to.equal('yes')
+    })
+  })
+})

--- a/test/lib/notifier.test.js
+++ b/test/lib/notifier.test.js
@@ -1,0 +1,77 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Thing under test
+const { Notifier } = require('../../app/lib')
+
+describe('Notifier class', () => {
+  let loggerFake
+  let notifyFake
+  let notifier
+
+  beforeEach(async () => {
+    loggerFake = {
+      info: Sinon.fake(),
+      error: Sinon.fake()
+    }
+    notifyFake = Sinon.fake()
+
+    notifier = new Notifier(loggerFake, notifyFake)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe('#omg()', () => {
+    const message = 'say what test'
+
+    it("logs an 'info' message", () => {
+      notifier.omg(message)
+
+      expect(loggerFake.info.calledOnceWith(message)).to.be.true()
+    })
+
+    it("does not send a notification to 'Errbit'", () => {
+      notifier.omg(message)
+
+      expect(notifyFake.notCalled).to.be.true()
+    })
+
+    it("does not log an 'error' message", () => {
+      notifier.omg(message)
+
+      expect(loggerFake.error.notCalled).to.be.true()
+    })
+  })
+
+  describe('#omfg()', () => {
+    const message = 'hell no test'
+    const data = { offTheChart: true }
+
+    it("does not log an 'info' message", () => {
+      notifier.omfg(message, data)
+
+      expect(loggerFake.info.notCalled).to.be.true()
+    })
+
+    it("sends a notification to 'Errbit'", () => {
+      notifier.omfg(message, data)
+
+      expect(notifyFake.calledOnceWith(message, data)).to.be.true()
+    })
+
+    it("logs an 'error' message", () => {
+      notifier.omfg(message, data)
+
+      expect(loggerFake.error.calledOnceWith({ message, data })).to.be.true()
+    })
+  })
+})

--- a/test/support/helpers/route.helper.js
+++ b/test/support/helpers/route.helper.js
@@ -141,6 +141,26 @@ class RouteHelper {
       }
     })
   }
+
+  /**
+   * Adds a route to a Hapi server instance which is used to test the 'Notifier' plugin
+   *
+   * This is used to confirm that an instance of `Notifier` was added to `request.app` by the plugin for all requests.
+   *
+   * @param {Object} server A Hapi server instance
+   */
+  static addNotifierRoute (server) {
+    server.route({
+      method: 'GET',
+      path: '/test/notifier',
+      handler: (request, _h) => {
+        return { exists: request.app.notifier ? 'yes' : 'no' }
+      },
+      options: {
+        auth: false
+      }
+    })
+  }
 }
 
 module.exports = RouteHelper


### PR DESCRIPTION
Recently, we added support for sending files to AWS S3. This task will be done in the background, whilst the API ensures a response is sent to the client.

Should the process fail, we still want to see an error logged in Errbit. So, we also ensured the service was able to do this. In review, we also agreed it would be useful to see any errors recorded in the log. For this, the service would also need access to the `logger`, for example, as used by `GenerateBillRunService`.

We then had another thought; wouldn't it be nice if we could see bill run timings recorded in Errbit!? 😁

This has all coalesced into the idea that what we really need is something that makes logging and sending notifications to Errbit accessible in one place.

So, behold the **Notifier** plugin which aims to do just that!

This first change will add the new plugin. We'll migrate across to using it in subsequent changes.