### PR TITLE
Implement stream services for generating transaction files

### DIFF
--- a/app/services/index.js
+++ b/app/services/index.js
@@ -36,6 +36,11 @@ const SendTransactionFileService = require('./send_transaction_file.service')
 const ShowAuthorisedSystemService = require('./show_authorised_system.service')
 const ShowRegimeService = require('./show_regime.service')
 const ShowTransactionService = require('./show_transaction.service')
+const StreamReadableDataService = require('./streams/stream_readable_data.service')
+const StreamReadableRecordsService = require('./streams/stream_readable_records.service')
+const StreamTransformCSVService = require('./streams/stream_transform_csv.service')
+const StreamTransformUsingPresenterService = require('./streams/stream_transform_using_presenter.service')
+const StreamWritableFileService = require('./streams/stream_writable_file.service')
 const ViewBillRunService = require('./view_bill_run.service')
 const ViewBillRunInvoiceService = require('./view_bill_run_invoice.service')
 
@@ -76,6 +81,11 @@ module.exports = {
   ShowAuthorisedSystemService,
   ShowRegimeService,
   ShowTransactionService,
+  StreamReadableDataService,
+  StreamReadableRecordsService,
+  StreamTransformCSVService,
+  StreamTransformUsingPresenterService,
+  StreamWritableFileService,
   ViewBillRunService,
   ViewBillRunInvoiceService
 }

--- a/app/services/streams/stream_readable_data.service.js
+++ b/app/services/streams/stream_readable_data.service.js
@@ -1,0 +1,24 @@
+'use strict'
+
+/**
+ * @module StreamReadableDataService
+ */
+
+const { Readable } = require('stream')
+
+/**
+ * Returns a Readable stream of the data passed to it in a single 'chunk'.
+ *
+ * Note that the data is passed to Readable in an array, as Readable requires an Iterable.
+ *
+ * @param {object} data Data object to be streamed back.
+ * @returns {ReadableStream} A stream of data.
+ */
+class StreamReadableDataService {
+  static go (data) {
+    return Readable
+      .from([data])
+  }
+}
+
+module.exports = StreamReadableDataService

--- a/app/services/streams/stream_readable_records.service.js
+++ b/app/services/streams/stream_readable_records.service.js
@@ -1,0 +1,26 @@
+'use strict'
+
+/**
+ * @module StreamReadableRecordsService
+ */
+
+/**
+ * Returns a Readable stream of database records when given an Objection QueryBuilder object.
+ *
+ * Note that we must pass in a query and not the result of a query -- therefore it should be instantiated _without_
+ * `await` ie:
+ *  const query = TransactionModel.query().select('*')
+ *  StreamReadableRecordsService.go(query)
+ *
+ * @param {module:QueryBuilder} query Objection QueryBuilder object of the query you wish to stream.
+ * @returns {ReadableStream} A stream of database records.
+ */
+class StreamReadableRecordsService {
+  static go (query) {
+    return query
+      .toKnexQuery()
+      .stream()
+  }
+}
+
+module.exports = StreamReadableRecordsService

--- a/app/services/streams/stream_transform_csv.service.js
+++ b/app/services/streams/stream_transform_csv.service.js
@@ -1,0 +1,29 @@
+'use strict'
+
+/**
+ * @module StreamTransformCSVService
+ */
+
+const { Transform } = require('stream')
+
+/**
+ * Returns a Transform stream which turns an incoming array into a CSV row, ie. comma-separated, with each element
+ * wrapped in double quotes, and ending with a newline.
+ *
+ * @returns {TransformStream} A stream of data.
+ */
+class StreamTransformCSVService {
+  static go () {
+    return new Transform({
+      objectMode: true,
+      transform: function (array, _encoding, callback) {
+        const wrapped = array.map(element => `"${element}"`)
+        const csv = wrapped.join()
+
+        callback(null, csv.concat('\n'))
+      }
+    })
+  }
+}
+
+module.exports = StreamTransformCSVService

--- a/app/services/streams/stream_transform_using_presenter.service.js
+++ b/app/services/streams/stream_transform_using_presenter.service.js
@@ -1,0 +1,63 @@
+'use strict'
+
+/**
+ * @module StreamTransformUsingPresenterService
+ */
+
+const { Transform } = require('stream')
+
+/**
+ * Returns a Transform stream which processes an object supplied to it using the supplied Presenter. It adds a field
+ * `index` to the object which can be used by the Presenter to read the row number. It optionally accepts additional
+ * data which will be added to the object before it is passed to the Presenter.
+ *
+ * The object supplied could be a row streamed from the database or an object from elsewhere. The Presenter is used to
+ * transform the data, then an array is created from the resulting values, ensuring the values are first sorted in
+ * alphabetical order of key, on the basis that the presenter will have its items named 'col01', 'col02' etc.
+ *
+ * While we should in theory receive the data from the presenter in the correct order, we sort it to ensure this is
+ * the case as the order we store the data in the array is critical to producing the resulting file correctly.
+ *
+ * We are also able to pass an object containing additional data which will be added to each record before it's
+ * passed to the presenter. For example, the bill run's file reference is required for each row of a transaction file
+ * but this isn't present in the transaction records we pull from the db. We therefore pass it in when writing these
+ * records so that it's available to us.
+ *
+ * To ensure that rows in a file are numbered correctly, we optionally accept indexStart which is the number that the
+ * index will start at. Say for example we have written the header and body of a file, with the rows numbered 1-19. When
+ * this service is called to write the tail, an indexStart value of 20 will be passed in, ensuring that the tail row has
+ * the correct number 20.
+ *
+ * @param {module:Presenter} Presenter Presenter to be used to transform data.
+ * @param {object} [additionalData] Optional data object which will be combined with the incoming data before being
+ * transformed.
+ * @param {integer} [indexStart] The start value for the index. Used to ensure that we use the correct consecutive
+ * numbering for each row of the data file. Defaults to 0.
+ * @returns {TransformStream} A stream of data.
+ */
+class StreamTransformUsingPresenterService {
+  static go (Presenter, additionalData = {}, indexStart = 0) {
+    let index = indexStart
+
+    return new Transform({
+      objectMode: true,
+      transform: function (currentRow, _encoding, callback) {
+        const presenter = new Presenter({ ...currentRow, ...additionalData, index })
+        const dataObject = presenter.go()
+
+        // Object.keys() gives us an array of keys in the object. We then sort it, and use map to create a new array by
+        // iterating over the keys in their sorted order and retrieving the value of each one from dataObject.
+        const sortedArray = Object
+          .keys(dataObject)
+          .sort()
+          .map(key => dataObject[key])
+
+        index++
+
+        callback(null, sortedArray)
+      }
+    })
+  }
+}
+
+module.exports = StreamTransformUsingPresenterService

--- a/app/services/streams/stream_writable_file.service.js
+++ b/app/services/streams/stream_writable_file.service.js
@@ -1,0 +1,22 @@
+'use strict'
+
+/**
+ * @module StreamWritableFileService
+ */
+
+const fs = require('fs')
+
+class StreamWritableFileService {
+/**
+ * Returns a Writable stream which writes data supplied to it to a file.
+ *
+ * @param {string} filenameWithPath The path and filename to be written to.
+ * @param {boolean} [append] Whether incoming data should be appended to an existing file. Defaults to `false`.
+ * @returns {WritableStream} A Writable stream.
+ */
+  static go (filenameWithPath, append = false) {
+    return fs.createWriteStream(filenameWithPath, append ? { flags: 'a' } : {})
+  }
+}
+
+module.exports = StreamWritableFileService

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "sroc-charging-module-api",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.6.1",
+      "version": "0.6.2",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@airbrake/node": "^2.1.3",
@@ -24,6 +24,7 @@
         "objection": "^2.2.15",
         "pg": "^8.5.1",
         "pg-hstore": "^2.3.3",
+        "pg-query-stream": "^4.0.0",
         "sanitizer": "^0.1.3",
         "sinon": "^9.2.4",
         "tunnel": "0.0.6"
@@ -11432,6 +11433,11 @@
       "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.4.0.tgz",
       "integrity": "sha512-3iBXuv7XKvxeMrIgym7njT+HlZkwZqqGX4Bu9cci8xHZNT+Um1gWKqCsAzcC0d95rcKMU5WBg6YRUcHyV0HZKQ=="
     },
+    "node_modules/pg-cursor": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-2.5.2.tgz",
+      "integrity": "sha512-yS0lxXA5WoIVK7BUgJr1uOJDJe5JxVezItTLvqnTXj6bF3di4UtQOrPx8RW3GpFmom2NTQfpEc2N6vvdpopQSw=="
+    },
     "node_modules/pg-hstore": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/pg-hstore/-/pg-hstore-2.3.3.tgz",
@@ -11463,6 +11469,14 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.4.0.tgz",
       "integrity": "sha512-El+aXWcwG/8wuFICMQjM5ZSAm6OWiJicFdNYo+VY3QP+8vI4SvLIWVe51PppTzMhikUJR+PsyIFKqfdXPz/yxA=="
+    },
+    "node_modules/pg-query-stream": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pg-query-stream/-/pg-query-stream-4.0.0.tgz",
+      "integrity": "sha512-Jftit2EUBn+ilh4JtAgw0JXKR54vATmYHlZ4fmIlbZgL1qT/GKUuwMzLFT8QQm+qJHZwlRIIfkMUOP7soY38ag==",
+      "dependencies": {
+        "pg-cursor": "^2.5.2"
+      }
     },
     "node_modules/pg-types": {
       "version": "2.2.0",
@@ -23533,6 +23547,7 @@
       "integrity": "sha512-HcZ0RWQRuJfpPiaHyFQJzcym+/dDIVUPwUAXWoub/C4GkGu+mPjp8vqK6g0FxokCnnI2TK0gZTza2IDfiNNscQ==",
       "peer": true,
       "requires": {
+        "@babel/core": "^7.0.0",
         "@babel/plugin-proposal-class-properties": "^7.0.0",
         "@babel/plugin-proposal-export-default-from": "^7.0.0",
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.0.0",
@@ -23579,6 +23594,7 @@
       "integrity": "sha512-K1sHO3ODBFCr7uEiCQ4RvVr+cQg0EHQF8ChVPnecGh/WDD8udrTq9ECwB0dRfMjAvlsHtRUlJm6ZSI8UPgum2w==",
       "peer": true,
       "requires": {
+        "@babel/core": "^7.0.0",
         "babel-preset-fbjs": "^3.3.0",
         "metro-babel-transformer": "0.64.0",
         "metro-react-native-babel-preset": "0.64.0",
@@ -24570,6 +24586,11 @@
       "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.4.0.tgz",
       "integrity": "sha512-3iBXuv7XKvxeMrIgym7njT+HlZkwZqqGX4Bu9cci8xHZNT+Um1gWKqCsAzcC0d95rcKMU5WBg6YRUcHyV0HZKQ=="
     },
+    "pg-cursor": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-2.5.2.tgz",
+      "integrity": "sha512-yS0lxXA5WoIVK7BUgJr1uOJDJe5JxVezItTLvqnTXj6bF3di4UtQOrPx8RW3GpFmom2NTQfpEc2N6vvdpopQSw=="
+    },
     "pg-hstore": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/pg-hstore/-/pg-hstore-2.3.3.tgz",
@@ -24593,6 +24614,14 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.4.0.tgz",
       "integrity": "sha512-El+aXWcwG/8wuFICMQjM5ZSAm6OWiJicFdNYo+VY3QP+8vI4SvLIWVe51PppTzMhikUJR+PsyIFKqfdXPz/yxA=="
+    },
+    "pg-query-stream": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pg-query-stream/-/pg-query-stream-4.0.0.tgz",
+      "integrity": "sha512-Jftit2EUBn+ilh4JtAgw0JXKR54vATmYHlZ4fmIlbZgL1qT/GKUuwMzLFT8QQm+qJHZwlRIIfkMUOP7soY38ag==",
+      "requires": {
+        "pg-cursor": "^2.5.2"
+      }
     },
     "pg-types": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "objection": "^2.2.15",
     "pg": "^8.5.1",
     "pg-hstore": "^2.3.3",
+    "pg-query-stream": "^4.0.0",
     "sanitizer": "^0.1.3",
     "sinon": "^9.2.4",
     "tunnel": "0.0.6"

--- a/test/services/streams/stream_readable_data.service.test.js
+++ b/test/services/streams/stream_readable_data.service.test.js
@@ -30,7 +30,7 @@ describe('Stream Readable Data service', () => {
 
       const readableStream = StreamReadableDataService.go(testData)
       // We use destructuring to pull the sole element of the array into result
-      const [result] = await StreamHelper.returnReadableStreamData(readableStream)
+      const [result] = await StreamHelper.testReadableStream(readableStream)
 
       expect(result).to.equal(testData)
     })

--- a/test/services/streams/stream_readable_data.service.test.js
+++ b/test/services/streams/stream_readable_data.service.test.js
@@ -10,9 +10,7 @@ const { expect } = Code
 const stream = require('stream')
 
 // Test helpers
-const {
-  StreamHelper
-} = require('../../support/helpers')
+const { StreamHelper } = require('../../support/helpers')
 
 // Thing under test
 const { StreamReadableDataService } = require('../../../app/services')
@@ -31,9 +29,10 @@ describe('Stream Readable Data service', () => {
       const testData = 'TEST'
 
       const readableStream = StreamReadableDataService.go(testData)
-      const result = await StreamHelper.returnReadableStreamData(readableStream)
+      // We use destructuring to pull the sole element of the array into result
+      const [result] = await StreamHelper.returnReadableStreamData(readableStream)
 
-      expect(result[0]).to.equal(testData)
+      expect(result).to.equal(testData)
     })
   })
 })

--- a/test/services/streams/stream_readable_data.service.test.js
+++ b/test/services/streams/stream_readable_data.service.test.js
@@ -4,53 +4,36 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { describe, it } = exports.lab = Lab.script()
 const { expect } = Code
 
 const stream = require('stream')
 
 // Test helpers
 const {
-  BillRunHelper,
-  DatabaseHelper,
-  GeneralHelper,
-  StreamHelper,
-  TransactionHelper
+  StreamHelper
 } = require('../../support/helpers')
 
-const { TransactionModel } = require('../../../app/models')
-
 // Thing under test
-const { StreamReadableRecordsService } = require('../../../app/services')
+const { StreamReadableDataService } = require('../../../app/services')
 
-describe.only('Stream Readable Records service', () => {
-  let billRun
-  let transaction
-
-  beforeEach(async () => {
-    await DatabaseHelper.clean()
-
-    billRun = await BillRunHelper.addBillRun(GeneralHelper.uuid4(), GeneralHelper.uuid4())
-
-    transaction = await TransactionHelper.addTransaction(billRun.id)
-  })
-
-  describe('When a valid query builder object specified', () => {
+describe('Stream Readable Data service', () => {
+  describe('When data is passed to it', () => {
     it('returns a stream', async () => {
-      const query = TransactionModel.query().select('*')
+      const testData = 'TEST'
 
-      const result = StreamReadableRecordsService.go(query)
+      const result = StreamReadableDataService.go(testData)
 
       expect(result).to.be.an.instanceof(stream.Stream)
     })
 
     it('streams the correct data', async () => {
-      const query = TransactionModel.query().select('*')
+      const testData = 'TEST'
 
-      const readableStream = StreamReadableRecordsService.go(query)
+      const readableStream = StreamReadableDataService.go(testData)
       const result = await StreamHelper.returnReadableStreamData(readableStream)
 
-      expect(result[0].id).to.equal(transaction.id)
+      expect(result[0]).to.equal(testData)
     })
   })
 })

--- a/test/services/streams/stream_readable_data.service.test.js
+++ b/test/services/streams/stream_readable_data.service.test.js
@@ -1,0 +1,56 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+const stream = require('stream')
+
+// Test helpers
+const {
+  BillRunHelper,
+  DatabaseHelper,
+  GeneralHelper,
+  StreamHelper,
+  TransactionHelper
+} = require('../../support/helpers')
+
+const { TransactionModel } = require('../../../app/models')
+
+// Thing under test
+const { StreamReadableRecordsService } = require('../../../app/services')
+
+describe.only('Stream Readable Records service', () => {
+  let billRun
+  let transaction
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+
+    billRun = await BillRunHelper.addBillRun(GeneralHelper.uuid4(), GeneralHelper.uuid4())
+
+    transaction = await TransactionHelper.addTransaction(billRun.id)
+  })
+
+  describe('When a valid query builder object specified', () => {
+    it('returns a stream', async () => {
+      const query = TransactionModel.query().select('*')
+
+      const result = StreamReadableRecordsService.go(query)
+
+      expect(result).to.be.an.instanceof(stream.Stream)
+    })
+
+    it('streams the correct data', async () => {
+      const query = TransactionModel.query().select('*')
+
+      const readableStream = StreamReadableRecordsService.go(query)
+      const result = await StreamHelper.returnReadableStreamData(readableStream)
+
+      expect(result[0].id).to.equal(transaction.id)
+    })
+  })
+})

--- a/test/services/streams/stream_readable_records.service.test.js
+++ b/test/services/streams/stream_readable_records.service.test.js
@@ -14,6 +14,7 @@ const {
   BillRunHelper,
   DatabaseHelper,
   GeneralHelper,
+  StreamHelper,
   TransactionHelper
 } = require('../../support/helpers')
 
@@ -24,22 +25,32 @@ const { StreamReadableRecordsService } = require('../../../app/services')
 
 describe.only('Stream Readable Records service', () => {
   let billRun
+  let transaction
 
   beforeEach(async () => {
     await DatabaseHelper.clean()
 
     billRun = await BillRunHelper.addBillRun(GeneralHelper.uuid4(), GeneralHelper.uuid4())
 
-    await TransactionHelper.addTransaction(billRun.id)
+    transaction = await TransactionHelper.addTransaction(billRun.id)
   })
 
   describe('When a valid query builder object specified', () => {
     it('returns a stream', async () => {
       const query = TransactionModel.query().select('*')
 
-      const result = await StreamReadableRecordsService.go(query)
+      const result = StreamReadableRecordsService.go(query)
 
       expect(result).to.be.an.instanceof(stream.Stream)
+    })
+
+    it('streams the correct data', async () => {
+      const query = TransactionModel.query().select('*')
+
+      const readableStream = StreamReadableRecordsService.go(query)
+      const result = await StreamHelper.returnReadableStreamData(readableStream)
+
+      expect(result[0].id).to.equal(transaction.id)
     })
   })
 })

--- a/test/services/streams/stream_readable_records.service.test.js
+++ b/test/services/streams/stream_readable_records.service.test.js
@@ -49,7 +49,7 @@ describe('Stream Readable Records service', () => {
 
       const readableStream = StreamReadableRecordsService.go(query)
       // We use destructuring to pull the sole element of the array into result
-      const [result] = await StreamHelper.returnReadableStreamData(readableStream)
+      const [result] = await StreamHelper.testReadableStream(readableStream)
 
       expect(result.id).to.equal(transaction.id)
     })

--- a/test/services/streams/stream_readable_records.service.test.js
+++ b/test/services/streams/stream_readable_records.service.test.js
@@ -1,0 +1,45 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+const stream = require('stream')
+
+// Test helpers
+const {
+  BillRunHelper,
+  DatabaseHelper,
+  GeneralHelper,
+  TransactionHelper
+} = require('../../support/helpers')
+
+const { TransactionModel } = require('../../../app/models')
+
+// Thing under test
+const { StreamReadableRecordsService } = require('../../../app/services')
+
+describe.only('Stream Readable Records service', () => {
+  let billRun
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+
+    billRun = await BillRunHelper.addBillRun(GeneralHelper.uuid4(), GeneralHelper.uuid4())
+
+    await TransactionHelper.addTransaction(billRun.id)
+  })
+
+  describe('When a valid query builder object specified', () => {
+    it('returns a stream', async () => {
+      const query = TransactionModel.query().select('*')
+
+      const result = await StreamReadableRecordsService.go(query)
+
+      expect(result).to.be.an.instanceof(stream.Stream)
+    })
+  })
+})

--- a/test/services/streams/stream_readable_records.service.test.js
+++ b/test/services/streams/stream_readable_records.service.test.js
@@ -48,9 +48,10 @@ describe('Stream Readable Records service', () => {
       const query = TransactionModel.query().select('*')
 
       const readableStream = StreamReadableRecordsService.go(query)
-      const result = await StreamHelper.returnReadableStreamData(readableStream)
+      // We use destructuring to pull the sole element of the array into result
+      const [result] = await StreamHelper.returnReadableStreamData(readableStream)
 
-      expect(result[0].id).to.equal(transaction.id)
+      expect(result.id).to.equal(transaction.id)
     })
   })
 })

--- a/test/services/streams/stream_readable_records.service.test.js
+++ b/test/services/streams/stream_readable_records.service.test.js
@@ -23,7 +23,7 @@ const { TransactionModel } = require('../../../app/models')
 // Thing under test
 const { StreamReadableRecordsService } = require('../../../app/services')
 
-describe.only('Stream Readable Records service', () => {
+describe('Stream Readable Records service', () => {
   let billRun
   let transaction
 

--- a/test/services/streams/stream_transform_csv.service.test.js
+++ b/test/services/streams/stream_transform_csv.service.test.js
@@ -26,9 +26,9 @@ describe('Stream Transform CSV service', () => {
     it('streams the correct data', async () => {
       const testData = ['first', '2', 'false']
 
-      const stream = StreamTransformCSVService.go()
+      const transformStream = StreamTransformCSVService.go()
       // We use destructuring to pull the sole element of the array into result
-      const [result] = await StreamHelper.returnTransformStreamData(stream, testData)
+      const [result] = await StreamHelper.returnTransformStreamData(transformStream, testData)
 
       expect(result).to.equal('"first","2","false"\n')
     })

--- a/test/services/streams/stream_transform_csv.service.test.js
+++ b/test/services/streams/stream_transform_csv.service.test.js
@@ -28,7 +28,7 @@ describe('Stream Transform CSV service', () => {
 
       const transformStream = StreamTransformCSVService.go()
       // We use destructuring to pull the sole element of the array into result
-      const [result] = await StreamHelper.returnTransformStreamData(transformStream, testData)
+      const [result] = await StreamHelper.testTransformStream(transformStream, testData)
 
       expect(result).to.equal('"first","2","false"\n')
     })

--- a/test/services/streams/stream_transform_csv.service.test.js
+++ b/test/services/streams/stream_transform_csv.service.test.js
@@ -1,0 +1,35 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it } = exports.lab = Lab.script()
+const { expect } = Code
+
+const stream = require('stream')
+
+// Test helpers
+const { StreamHelper } = require('../../support/helpers')
+
+// Thing under test
+const { StreamTransformCSVService } = require('../../../app/services')
+
+describe.only('Stream Transform CSV service', () => {
+  describe('When data is passed to it', () => {
+    it('returns a stream', async () => {
+      const result = StreamTransformCSVService.go()
+
+      expect(result).to.be.an.instanceof(stream.Stream)
+    })
+
+    it('streams the correct data', async () => {
+      const testData = ['first', '2', 'false']
+
+      const stream = StreamTransformCSVService.go()
+      const result = await StreamHelper.returnTransformStreamData(stream, testData)
+
+      expect(result[0]).to.equal('"first","2","false"\n')
+    })
+  })
+})

--- a/test/services/streams/stream_transform_csv.service.test.js
+++ b/test/services/streams/stream_transform_csv.service.test.js
@@ -15,7 +15,7 @@ const { StreamHelper } = require('../../support/helpers')
 // Thing under test
 const { StreamTransformCSVService } = require('../../../app/services')
 
-describe.only('Stream Transform CSV service', () => {
+describe('Stream Transform CSV service', () => {
   describe('When data is passed to it', () => {
     it('returns a stream', async () => {
       const result = StreamTransformCSVService.go()
@@ -27,9 +27,10 @@ describe.only('Stream Transform CSV service', () => {
       const testData = ['first', '2', 'false']
 
       const stream = StreamTransformCSVService.go()
-      const result = await StreamHelper.returnTransformStreamData(stream, testData)
+      // We use destructuring to pull the sole element of the array into result
+      const [result] = await StreamHelper.returnTransformStreamData(stream, testData)
 
-      expect(result[0]).to.equal('"first","2","false"\n')
+      expect(result).to.equal('"first","2","false"\n')
     })
   })
 })

--- a/test/services/streams/stream_transform_using_presenter.service.test.js
+++ b/test/services/streams/stream_transform_using_presenter.service.test.js
@@ -47,9 +47,9 @@ describe('Stream Transform CSV service', () => {
     })
 
     it('streams the correct data', async () => {
-      const stream = StreamTransformUsingPresenterService.go(testPresenter)
+      const transformStream = StreamTransformUsingPresenterService.go(testPresenter)
       // We use destructuring to pull the sole element of the array into result
-      const [result] = await StreamHelper.returnTransformStreamData(stream, testData)
+      const [result] = await StreamHelper.returnTransformStreamData(transformStream, testData)
 
       // Note this tests not just the content but the order of the array
       expect(result[0]).to.equal(testData.element01)
@@ -58,22 +58,22 @@ describe('Stream Transform CSV service', () => {
     })
 
     it('accepts additional data', async () => {
-      const stream = StreamTransformUsingPresenterService.go(testPresenter, { additionalElement: 'EXTRA' })
-      const [result] = await StreamHelper.returnTransformStreamData(stream, testData)
+      const transformStream = StreamTransformUsingPresenterService.go(testPresenter, { additionalElement: 'EXTRA' })
+      const [result] = await StreamHelper.returnTransformStreamData(transformStream, testData)
 
       expect(result[3]).to.equal('EXTRA')
     })
 
     it('passes in the index starting at 0', async () => {
-      const stream = StreamTransformUsingPresenterService.go(testPresenter)
-      const [result] = await StreamHelper.returnTransformStreamData(stream, testData)
+      const transformStream = StreamTransformUsingPresenterService.go(testPresenter)
+      const [result] = await StreamHelper.returnTransformStreamData(transformStream, testData)
 
       expect(result[4]).to.equal(0)
     })
 
     it('increments the index', async () => {
-      const stream = StreamTransformUsingPresenterService.go(testPresenter)
-      const resultArray = await StreamHelper.returnTransformStreamData(stream, testData, 3)
+      const transformStream = StreamTransformUsingPresenterService.go(testPresenter)
+      const resultArray = await StreamHelper.returnTransformStreamData(transformStream, testData, 3)
 
       expect(resultArray[0][4]).to.equal(0)
       expect(resultArray[1][4]).to.equal(1)
@@ -81,8 +81,8 @@ describe('Stream Transform CSV service', () => {
     })
 
     it('accepts different index start numbers', async () => {
-      const stream = StreamTransformUsingPresenterService.go(testPresenter, null, 10)
-      const resultArray = await StreamHelper.returnTransformStreamData(stream, testData, 3)
+      const transformStream = StreamTransformUsingPresenterService.go(testPresenter, null, 10)
+      const resultArray = await StreamHelper.returnTransformStreamData(transformStream, testData, 3)
 
       expect(resultArray[0][4]).to.equal(10)
       expect(resultArray[1][4]).to.equal(11)

--- a/test/services/streams/stream_transform_using_presenter.service.test.js
+++ b/test/services/streams/stream_transform_using_presenter.service.test.js
@@ -1,0 +1,92 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it } = exports.lab = Lab.script()
+const { expect } = Code
+
+const stream = require('stream')
+
+// Test helpers
+const { StreamHelper } = require('../../support/helpers')
+
+// Thing under test
+const { StreamTransformUsingPresenterService } = require('../../../app/services')
+
+describe('Stream Transform CSV service', () => {
+  class testPresenter {
+    constructor (data) {
+      this.data = data
+    }
+
+    // We put the elements in the "wrong" sequence so we can test that the stream sorts them into the correct order
+    go () {
+      return {
+        col02: this.data.element02,
+        col01: this.data.element01,
+        col03: this.data.element03,
+        col04: this.data.additionalElement,
+        col05: this.data.index
+      }
+    }
+  }
+
+  const testData = {
+    element01: 'A',
+    element02: 2,
+    element03: true
+  }
+
+  describe('When data is passed to it', () => {
+    it('returns a stream', async () => {
+      const result = StreamTransformUsingPresenterService.go(testPresenter)
+
+      expect(result).to.be.an.instanceof(stream.Stream)
+    })
+
+    it('streams the correct data', async () => {
+      const stream = StreamTransformUsingPresenterService.go(testPresenter)
+      // We use destructuring to pull the sole element of the array into result
+      const [result] = await StreamHelper.returnTransformStreamData(stream, testData)
+
+      // Note this tests not just the content but the order of the array
+      expect(result[0]).to.equal(testData.element01)
+      expect(result[1]).to.equal(testData.element02)
+      expect(result[2]).to.equal(testData.element03)
+    })
+
+    it('accepts additional data', async () => {
+      const stream = StreamTransformUsingPresenterService.go(testPresenter, { additionalElement: 'EXTRA' })
+      const [result] = await StreamHelper.returnTransformStreamData(stream, testData)
+
+      expect(result[3]).to.equal('EXTRA')
+    })
+
+    it('passes in the index starting at 0', async () => {
+      const stream = StreamTransformUsingPresenterService.go(testPresenter)
+      const [result] = await StreamHelper.returnTransformStreamData(stream, testData)
+
+      expect(result[4]).to.equal(0)
+    })
+
+    it('increments the index', async () => {
+      const stream = StreamTransformUsingPresenterService.go(testPresenter)
+      const resultArray = await StreamHelper.returnTransformStreamData(stream, testData, 3)
+
+      expect(resultArray[0][4]).to.equal(0)
+      expect(resultArray[1][4]).to.equal(1)
+      expect(resultArray[2][4]).to.equal(2)
+    })
+
+    it('accepts different index start numbers', async () => {
+      const stream = StreamTransformUsingPresenterService.go(testPresenter, null, 10)
+      const resultArray = await StreamHelper.returnTransformStreamData(stream, testData, 3)
+
+      expect(resultArray[0][4]).to.equal(10)
+      expect(resultArray[1][4]).to.equal(11)
+      expect(resultArray[2][4]).to.equal(12)
+    })
+  })
+})

--- a/test/services/streams/stream_transform_using_presenter.service.test.js
+++ b/test/services/streams/stream_transform_using_presenter.service.test.js
@@ -49,7 +49,7 @@ describe('Stream Transform CSV service', () => {
     it('streams the correct data', async () => {
       const transformStream = StreamTransformUsingPresenterService.go(testPresenter)
       // We use destructuring to pull the sole element of the array into result
-      const [result] = await StreamHelper.returnTransformStreamData(transformStream, testData)
+      const [result] = await StreamHelper.testTransformStream(transformStream, testData)
 
       // Note this tests not just the content but the order of the array
       expect(result[0]).to.equal(testData.element01)
@@ -59,21 +59,21 @@ describe('Stream Transform CSV service', () => {
 
     it('accepts additional data', async () => {
       const transformStream = StreamTransformUsingPresenterService.go(testPresenter, { additionalElement: 'EXTRA' })
-      const [result] = await StreamHelper.returnTransformStreamData(transformStream, testData)
+      const [result] = await StreamHelper.testTransformStream(transformStream, testData)
 
       expect(result[3]).to.equal('EXTRA')
     })
 
     it('passes in the index starting at 0', async () => {
       const transformStream = StreamTransformUsingPresenterService.go(testPresenter)
-      const [result] = await StreamHelper.returnTransformStreamData(transformStream, testData)
+      const [result] = await StreamHelper.testTransformStream(transformStream, testData)
 
       expect(result[4]).to.equal(0)
     })
 
     it('increments the index', async () => {
       const transformStream = StreamTransformUsingPresenterService.go(testPresenter)
-      const resultArray = await StreamHelper.returnTransformStreamData(transformStream, testData, 3)
+      const resultArray = await StreamHelper.testTransformStream(transformStream, testData, 3)
 
       expect(resultArray[0][4]).to.equal(0)
       expect(resultArray[1][4]).to.equal(1)
@@ -82,7 +82,7 @@ describe('Stream Transform CSV service', () => {
 
     it('accepts different index start numbers', async () => {
       const transformStream = StreamTransformUsingPresenterService.go(testPresenter, null, 10)
-      const resultArray = await StreamHelper.returnTransformStreamData(transformStream, testData, 3)
+      const resultArray = await StreamHelper.testTransformStream(transformStream, testData, 3)
 
       expect(resultArray[0][4]).to.equal(10)
       expect(resultArray[1][4]).to.equal(11)

--- a/test/services/streams/stream_writable_file.service.js
+++ b/test/services/streams/stream_writable_file.service.js
@@ -1,0 +1,82 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+const stream = require('stream')
+const fs = require('fs')
+const path = require('path')
+
+// Test helpers
+const { StreamHelper } = require('../../support/helpers')
+const mockFs = require('mock-fs')
+
+// Thing under test
+const { StreamWritableFileService } = require('../../../app/services')
+
+describe('Stream Writable File service', () => {
+  let filenameWithPath
+
+  beforeEach(async () => {
+    // Create mock in-memory file system to avoid temp files being dropped in our filesystem
+    filenameWithPath = path.join('testFolder', 'testFile')
+
+    mockFs({
+      testFolder: {
+        testFile: 'test content'
+      }
+    })
+  })
+
+  afterEach(async () => {
+    mockFs.restore()
+  })
+
+  describe('When a filename is specified', () => {
+    it('returns a stream', async () => {
+      const result = StreamWritableFileService.go(filenameWithPath)
+
+      expect(result).to.be.an.instanceof(stream.Stream)
+    })
+
+    it('writes the correct data to the file', async () => {
+      const testData = 'TEST_DATA'
+
+      const writableStream = StreamWritableFileService.go(filenameWithPath)
+      await StreamHelper.testWritableStream(writableStream, testData)
+
+      const file = fs.readFileSync(filenameWithPath, 'utf-8')
+      expect(file).to.equal(testData)
+    })
+
+    it('overwrites the file if `append` is not specified', async () => {
+      const testData = 'TEST_DATA'
+
+      // Note that we instantiate two streams and don't re-use the first as this reflects how we would use the stream,
+      // ie. instantiating it each time we wish to write data to a file.
+      const firstStream = StreamWritableFileService.go(filenameWithPath)
+      await StreamHelper.testWritableStream(firstStream, 'WRONG_DATA')
+      const secondStream = StreamWritableFileService.go(filenameWithPath)
+      await StreamHelper.testWritableStream(secondStream, testData)
+
+      const file = fs.readFileSync(filenameWithPath, 'utf-8')
+      expect(file).to.equal(testData)
+    })
+
+    it('appends data to the file if `append` is `true`', async () => {
+      const testData = 'TEST_DATA'
+
+      const firstStream = StreamWritableFileService.go(filenameWithPath, false)
+      await StreamHelper.testWritableStream(firstStream, testData)
+      const secondStream = StreamWritableFileService.go(filenameWithPath, true)
+      await StreamHelper.testWritableStream(secondStream, testData)
+
+      const file = fs.readFileSync(filenameWithPath, 'utf-8')
+      expect(file).to.equal(`${testData}${testData}`)
+    })
+  })
+})

--- a/test/support/helpers/index.js
+++ b/test/support/helpers/index.js
@@ -11,6 +11,7 @@ const RegimeHelper = require('./regime.helper')
 const RouteHelper = require('./route.helper')
 const RulesServiceHelper = require('./rules_service.helper')
 const SequenceCounterHelper = require('./sequence_counter.helper')
+const StreamHelper = require('./stream.helper')
 const TransactionHelper = require('./transaction.helper')
 
 module.exports = {
@@ -25,5 +26,6 @@ module.exports = {
   RouteHelper,
   RulesServiceHelper,
   SequenceCounterHelper,
+  StreamHelper,
   TransactionHelper
 }

--- a/test/support/helpers/stream.helper.js
+++ b/test/support/helpers/stream.helper.js
@@ -10,7 +10,7 @@ class StreamHelper {
    * @param {ReadableStream} inputStream The stream we want to capture the output of.
    * @returns {array} An array of the stream's output.
    */
-  static async returnReadableStreamData (inputStream) {
+  static async testReadableStream (inputStream) {
     const result = []
 
     // Create a Writable stream that captures data coming into it and pushes it to the result array
@@ -22,7 +22,8 @@ class StreamHelper {
       }
     })
 
-    // Create a promisifed pipline that runs asynchronously then use it to stream data from inputStream to outputStream
+    // Create a promisifed pipline that runs asynchronously then use it to stream data
+    // inputStream > outputStream
     const promisifiedPipeline = this._promisifiedPipeline()
     await promisifiedPipeline(
       inputStream,
@@ -40,7 +41,7 @@ class StreamHelper {
    * @param {integer} [times] The optional number of times the data will be passed through the pipeline. Defaults to 1.
    * @returns {array} An array of the stream's output.
    */
-  static async returnTransformStreamData (transformStream, data, times = 1) {
+  static async testTransformStream (transformStream, data, times = 1) {
     const result = []
 
     const dataArray = new Array(times).fill(data)
@@ -57,7 +58,8 @@ class StreamHelper {
       }
     })
 
-    // Create a promisifed pipline that runs asynchronously then use it to stream data from inputStream to outputStream
+    // Create a promisifed pipline that runs asynchronously then use it to stream data
+    // inputStream > transformStream > outputStream
     const promisifiedPipeline = this._promisifiedPipeline()
     await promisifiedPipeline(
       inputStream,
@@ -66,6 +68,21 @@ class StreamHelper {
     )
 
     return result
+  }
+
+  static async testWritableStream (outputStream, data, times = 1) {
+    const dataArray = new Array(times).fill(data)
+
+    // Create a Readable stream that sends provided data
+    const inputStream = Readable.from(dataArray)
+
+    // Create a promisifed pipline that runs asynchronously then use it to stream data
+    // inputStream > outputStream
+    const promisifiedPipeline = this._promisifiedPipeline()
+    await promisifiedPipeline(
+      inputStream,
+      outputStream
+    )
   }
 
   static _promisifiedPipeline () {

--- a/test/support/helpers/stream.helper.js
+++ b/test/support/helpers/stream.helper.js
@@ -37,13 +37,16 @@ class StreamHelper {
    *
    * @param {TransformStream} transformStream The stream we want to capture the output of.
    * @param {object} data The data the stream will receive.
+   * @param {integer} [times] The optional number of times the data will be passed through the pipeline. Defaults to 1.
    * @returns {array} An array of the stream's output.
    */
-  static async returnTransformStreamData (transformStream, data) {
+  static async returnTransformStreamData (transformStream, data, times = 1) {
     const result = []
 
+    const dataArray = new Array(times).fill(data)
+
     // Create a Readable stream that sends provided data
-    const inputStream = Readable.from([data])
+    const inputStream = Readable.from(dataArray)
 
     // Create a Writable stream that captures data coming into it and pushes it to the result array
     const outputStream = new Writable({

--- a/test/support/helpers/stream.helper.js
+++ b/test/support/helpers/stream.helper.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { pipeline, Writable } = require('stream')
+const { pipeline, Readable, Writable } = require('stream')
 const util = require('util')
 
 class StreamHelper {
@@ -26,6 +26,39 @@ class StreamHelper {
     const promisifiedPipeline = this._promisifiedPipeline()
     await promisifiedPipeline(
       inputStream,
+      outputStream
+    )
+
+    return result
+  }
+
+  /**
+   * Runs a Transform stream using the provided data and returns an array of its output.
+   *
+   * @param {TransformStream} transformStream The stream we want to capture the output of.
+   * @param {object} data The data the stream will receive.
+   * @returns {array} An array of the stream's output.
+   */
+  static async returnTransformStreamData (transformStream, data) {
+    const result = []
+
+    // Create a Readable stream that sends provided data
+    const inputStream = Readable.from([data])
+
+    // Create a Writable stream that captures data coming into it and pushes it to the result array
+    const outputStream = new Writable({
+      objectMode: true,
+      write (chunk, encoding, callback) {
+        result.push(chunk)
+        callback()
+      }
+    })
+
+    // Create a promisifed pipline that runs asynchronously then use it to stream data from inputStream to outputStream
+    const promisifiedPipeline = this._promisifiedPipeline()
+    await promisifiedPipeline(
+      inputStream,
+      transformStream,
       outputStream
     )
 

--- a/test/support/helpers/stream.helper.js
+++ b/test/support/helpers/stream.helper.js
@@ -1,0 +1,40 @@
+'use strict'
+
+const { pipeline, Writable } = require('stream')
+const util = require('util')
+
+class StreamHelper {
+  /**
+   * Runs a Readable stream and returns an array of its output.
+   *
+   * @param {ReadableStream} inputStream The stream we want to capture the output of.
+   * @returns {array} An array of the stream's output.
+   */
+  static async returnReadableStreamData (inputStream) {
+    const result = []
+
+    // Create a Writable stream that captures data coming into it and pushes it to the result array
+    const outputStream = new Writable({
+      objectMode: true,
+      write (chunk, encoding, callback) {
+        result.push(chunk)
+        callback()
+      }
+    })
+
+    // Create a promisifed pipline that runs asynchronously then use it to stream data from inputStream to outputStream
+    const promisifiedPipeline = this._promisifiedPipeline()
+    await promisifiedPipeline(
+      inputStream,
+      outputStream
+    )
+
+    return result
+  }
+
+  static _promisifiedPipeline () {
+    return util.promisify(pipeline)
+  }
+}
+
+module.exports = StreamHelper


### PR DESCRIPTION
https://trello.com/c/hyWyM8RL/1940-m-develop-include-required-content-in-transaction-files-v2

The first thing to pull from the [dev spike branch](https://github.com/DEFRA/sroc-charging-module-api/pull/325) are the stream services, which each return an instance of the required stream.

This PR implements the following streams:
- `StreamReadableDataService`: This is invoked with an array of data and returns a `Readable` stream that streams the array one element at a time. It is intended for use when writing a single line of data to a file, eg. header line.
- `StreamReadableRecordsService`: This is invoked with an Objection `QueryBuilder` object and returns a `Readable` stream that streams the results one row at a time.
- `StreamTransformUsingPresenterService`: This is invoked with a presenter and returns a `Transform` stream which receives data, transforms it using the presenter, sorts the elements by key name, and streams an array of the values in the key-sorted order.
- `StreamTransformCSVService`: This returns a `Transform` stream which receives an array of elements, wraps each one in double quotes, joins them together with a comma, adds a newline, and streams the resulting string.
- `StreamWritableFileService`: This is invoked with a file path and name and returns a `Writable` stream which writes the data it receives to that file.