### PR TITLE
Presenters for writing transaction file

### DIFF
--- a/app/presenters/base.presenter.js
+++ b/app/presenters/base.presenter.js
@@ -12,6 +12,27 @@ class BasePresenter {
   _presentation () {
     throw new Error('You need to specify _presentation in the child presenter')
   }
+
+  /**
+   * Converts a date into the format required by output files, eg 25/03/2021 becomes 25-MAR-2021
+   */
+  _formatDate (date) {
+    const dateObject = new Date(date)
+
+    // We use .toLocaleString() to convert the date into a format close to the one we need, eg. "25 Mar 2021"
+    // Passing 'en-GB' ensures it returns the elements in the correct order.
+    const dateString = dateObject.toLocaleString('en-GB', {
+      day: '2-digit',
+      month: 'short',
+      year: 'numeric'
+    })
+
+    // Make the string upper case and replace the spaces with dashes
+    return dateString
+      .toUpperCase()
+      .split(' ')
+      .join('-')
+  }
 }
 
 module.exports = BasePresenter

--- a/app/presenters/base.presenter.js
+++ b/app/presenters/base.presenter.js
@@ -33,6 +33,15 @@ class BasePresenter {
       .split(' ')
       .join('-')
   }
+
+  /**
+   * Pads a number to a given length with leading zeroes and returns the result as a string.
+   */
+  _leftPadZeroes (number, length) {
+    return number
+      .toString()
+      .padStart(length, '0')
+  }
 }
 
 module.exports = BasePresenter

--- a/app/presenters/index.js
+++ b/app/presenters/index.js
@@ -7,6 +7,9 @@ const CreateBillRunPresenter = require('./create_bill_run.presenter')
 const CreateTransactionPresenter = require('./create_transaction.presenter')
 const JsonPresenter = require('./json.presenter')
 const RulesServicePresenter = require('./rules_service.presenter')
+const TransactionFileBodyPresenter = require('./transaction_file_body.presenter')
+const TransactionFileHeaderPresenter = require('./transaction_file_header.presenter')
+const TransactionFileTailPresenter = require('./transaction_file_tail.presenter')
 const ViewBillRunPresenter = require('./view_bill_run.presenter')
 const ViewBillRunInvoicePresenter = require('./view_bill_run_invoice.presenter')
 const ViewInvoicePresenter = require('./view_invoice.presenter')
@@ -21,6 +24,9 @@ module.exports = {
   CreateTransactionPresenter,
   JsonPresenter,
   RulesServicePresenter,
+  TransactionFileBodyPresenter,
+  TransactionFileTailPresenter,
+  TransactionFileHeaderPresenter,
   ViewBillRunPresenter,
   ViewBillRunInvoicePresenter,
   ViewInvoicePresenter,

--- a/app/presenters/index.js
+++ b/app/presenters/index.js
@@ -8,7 +8,7 @@ const CreateTransactionPresenter = require('./create_transaction.presenter')
 const JsonPresenter = require('./json.presenter')
 const RulesServicePresenter = require('./rules_service.presenter')
 const TransactionFileBodyPresenter = require('./transaction_file_body.presenter')
-const TransactionFileHeaderPresenter = require('./transaction_file_header.presenter')
+const TransactionFileHeadPresenter = require('./transaction_file_head.presenter')
 const TransactionFileTailPresenter = require('./transaction_file_tail.presenter')
 const ViewBillRunPresenter = require('./view_bill_run.presenter')
 const ViewBillRunInvoicePresenter = require('./view_bill_run_invoice.presenter')
@@ -25,8 +25,8 @@ module.exports = {
   JsonPresenter,
   RulesServicePresenter,
   TransactionFileBodyPresenter,
+  TransactionFileHeadPresenter,
   TransactionFileTailPresenter,
-  TransactionFileHeaderPresenter,
   ViewBillRunPresenter,
   ViewBillRunInvoicePresenter,
   ViewInvoicePresenter,

--- a/app/presenters/transaction_file_body.presenter.js
+++ b/app/presenters/transaction_file_body.presenter.js
@@ -1,0 +1,96 @@
+'use strict'
+
+/**
+ * @module TransactionFileBodyPresenter
+ */
+
+const BasePresenter = require('./base.presenter')
+
+/**
+ * Formats data for saving to the body of a transaction file.
+ *
+ * Note that data.index and data.transactionReference are added by StreamTransformUsingPresenter and are not part of the
+ * data originally read from the source transaction record.
+ *
+ * With reference to the existing v1 charging module transaction file presenter:
+ * https://github.com/DEFRA/charging-module-api/blob/main/app/schema/pre_sroc/wrls/transaction_file_presenter.js
+ */
+
+class TransactionFileBodyPresenter extends BasePresenter {
+  _presentation (data) {
+    return {
+      col01: 'D',
+      col02: this._leftPadZeroes(data.index, 7),
+      col03: data.customerReference,
+      col04: this._formatDate(data.transactionDate),
+      col05: this._transactionType(data),
+      col06: data.transactionReference,
+      col07: '',
+      col08: 'GBP',
+      col09: '',
+      col10: this._formatDate(data.headerAttr1),
+      col11: '',
+      col12: '',
+      col13: '',
+      col14: '',
+      col15: '',
+      col16: '',
+      col17: '',
+      col18: '',
+      col19: '',
+      col20: data.chargeValue,
+      col21: '',
+      col22: data.lineAreaCode,
+      col23: data.lineDescription,
+      col24: 'A',
+      col25: '',
+      col26: this._blankIfCompensationChargeOrMinimumCharge(data.lineAttr1, data),
+      col27: this._blankIfCompensationChargeOrMinimumCharge(data.lineAttr2, data),
+      col28: this._blankIfCompensationChargeOrMinimumCharge(data.lineAttr3, data),
+      col29: this._blankIfCompensationChargeOrMinimumCharge(data.lineAttr4, data),
+      col30: this._blankIfCompensationChargeOrMinimumCharge(this._volumeInMegaLitres(data.lineAttr5), data),
+      col31: this._blankIfCompensationChargeOrMinimumCharge(data.lineAttr6, data),
+      col32: this._blankIfCompensationChargeOrMinimumCharge(data.lineAttr7, data),
+      col33: this._blankIfCompensationChargeOrMinimumCharge(data.lineAttr8, data),
+      col34: this._blankIfCompensationChargeOrMinimumCharge(data.lineAttr9, data),
+      col35: this._blankIfCompensationChargeOrMinimumCharge(data.lineAttr10, data),
+      col36: '',
+      col37: '',
+      col38: this._blankIfNotCompensationCharge(data.lineAttr13, data),
+      col39: this._blankIfNotCompensationCharge(data.lineAttr14, data),
+      col40: '',
+      col41: '1',
+      col42: 'Each',
+      col43: data.chargeValue
+    }
+  }
+
+  // Returns a negative or positive value for chargeValue dependent on whether credit is true or false
+  _transactionType (data) {
+    return data.chargeCredit ? 'C' : 'I'
+  }
+
+  /**
+   * Returns an empty string if this is a compensation charge, ie. if regimeValue17 is `true`
+   * Also returns an empty string if this is a minimum charge adjustment
+   */
+  _blankIfCompensationChargeOrMinimumCharge (value, data) {
+    return data.regimeValue17 || data.minimumChargeAdjustment ? '' : value
+  }
+
+  /**
+   * Returns an empty string if this is not a compensation charge, ie. if regimeValue17 is `false`
+   */
+  _blankIfNotCompensationCharge (value, data) {
+    return data.regimeValue17 ? value : ''
+  }
+
+  /**
+   * Returns the provided value with ' Ml' appended.
+   */
+  _volumeInMegaLitres (value) {
+    return `${value} Ml`
+  }
+}
+
+module.exports = TransactionFileBodyPresenter

--- a/app/presenters/transaction_file_body.presenter.js
+++ b/app/presenters/transaction_file_body.presenter.js
@@ -7,7 +7,7 @@
 const BasePresenter = require('./base.presenter')
 
 /**
- * Formats data for saving to the body of a transaction file.
+ * Formats data for the body of a transaction file.
  *
  * Note that data.index and data.transactionReference are added by StreamTransformUsingPresenter and are not part of the
  * data originally read from the source transaction record.

--- a/app/presenters/transaction_file_head.presenter.js
+++ b/app/presenters/transaction_file_head.presenter.js
@@ -1,13 +1,13 @@
 'use strict'
 
 /**
- * @module TransactionFileHeaderPresenter
+ * @module TransactionFileHeadPresenter
  */
 
 const BasePresenter = require('./base.presenter')
 
 /**
- * Formats data for saving to the header of a transaction file.
+ * Formats data for the head of a transaction file.
  *
  * Note that data.index is added by StreamTransformUsingPresenter and is not part of the data originally read from the
  * source transaction record.
@@ -16,7 +16,7 @@ const BasePresenter = require('./base.presenter')
  * https://github.com/DEFRA/charging-module-api/blob/main/app/schema/pre_sroc/wrls/transaction_file_presenter.js
  */
 
-class TransactionFileHeaderPresenter extends BasePresenter {
+class TransactionFileHeadPresenter extends BasePresenter {
   _presentation (data) {
     return {
       col01: 'H',
@@ -52,4 +52,4 @@ class TransactionFileHeaderPresenter extends BasePresenter {
   }
 }
 
-module.exports = TransactionFileHeaderPresenter
+module.exports = TransactionFileHeadPresenter

--- a/app/presenters/transaction_file_head.presenter.js
+++ b/app/presenters/transaction_file_head.presenter.js
@@ -29,27 +29,6 @@ class TransactionFileHeadPresenter extends BasePresenter {
       col08: this._formatDate(data.updatedAt)
     }
   }
-
-  /**
-   * Converts a date into the format required by the transaction file, eg 25/03/2021 becomes 25-MAR-2021
-   */
-  _formatDate (date) {
-    const dateObject = new Date(date)
-
-    // We use .toLocaleString() to convert the date into a format close to the one we need, eg. "25 Mar 2021"
-    // Passing 'en-GB' ensures it returns the elements in the correct order.
-    const dateString = dateObject.toLocaleString('en-GB', {
-      day: '2-digit',
-      month: 'short',
-      year: 'numeric'
-    })
-
-    // Make the string upper case and replace the spaces with dashes
-    return dateString
-      .toUpperCase()
-      .split(' ')
-      .join('-')
-  }
 }
 
 module.exports = TransactionFileHeadPresenter

--- a/app/presenters/transaction_file_header.presenter.js
+++ b/app/presenters/transaction_file_header.presenter.js
@@ -1,0 +1,55 @@
+'use strict'
+
+/**
+ * @module TransactionFileHeaderPresenter
+ */
+
+const BasePresenter = require('./base.presenter')
+
+/**
+ * Formats data for saving to the header of a transaction file.
+ *
+ * Note that data.index is added by StreamTransformUsingPresenter and is not part of the data originally read from the
+ * source transaction record.
+ *
+ * With reference to the existing v1 charging module transaction file presenter:
+ * https://github.com/DEFRA/charging-module-api/blob/main/app/schema/pre_sroc/wrls/transaction_file_presenter.js
+ */
+
+class TransactionFileHeaderPresenter extends BasePresenter {
+  _presentation (data) {
+    return {
+      col01: 'H',
+      col02: this._leftPadZeroes(data.index, 7),
+      col03: 'NAL',
+      col04: data.region,
+      col05: 'I',
+      col06: data.fileId,
+      col07: data.id,
+      col08: this._formatDate(data.updatedAt)
+    }
+  }
+
+  /**
+   * Converts a date into the format required by the transaction file, eg 25/03/2021 becomes 25-MAR-2021
+   */
+  _formatDate (date) {
+    const dateObject = new Date(date)
+
+    // We use .toLocaleString() to convert the date into a format close to the one we need, eg. "25 Mar 2021"
+    // Passing 'en-GB' ensures it returns the elements in the correct order.
+    const dateString = dateObject.toLocaleString('en-GB', {
+      day: '2-digit',
+      month: 'short',
+      year: 'numeric'
+    })
+
+    // Make the string upper case and replace the spaces with dashes
+    return dateString
+      .toUpperCase()
+      .split(' ')
+      .join('-')
+  }
+}
+
+module.exports = TransactionFileHeaderPresenter

--- a/app/presenters/transaction_file_tail.presenter.js
+++ b/app/presenters/transaction_file_tail.presenter.js
@@ -7,19 +7,15 @@
 const BasePresenter = require('./base.presenter')
 
 /**
- * Formats data for saving to the tail of a transaction file.
+ * Formats data for the tail of a transaction file.
+ *
+ * Note that data.index is added by StreamTransformUsingPresenter and is not part of the data originally read from the
+ * source transaction record.
  *
  * With reference to the existing v1 charging module transaction file presenter:
  * https://github.com/DEFRA/charging-module-api/blob/main/app/schema/pre_sroc/wrls/transaction_file_presenter.js
  */
 
-/**
- * 'T',
- * seq,
- * this.sequenceNumber,
- * this.invoiceTotal,
- * this.creditTotal
- */
 class TransactionFileTailPresenter extends BasePresenter {
   _presentation (data) {
     return {
@@ -31,7 +27,9 @@ class TransactionFileTailPresenter extends BasePresenter {
     }
   }
 
-  // The line index starts at 0, so the number of lines in the file is index + 1
+  /**
+   * Returns the number of lines in the file, which we calculate as the current row index + 1 (since index starts at 0)
+   */
   _numberOfLinesInFile (index) {
     return index + 1
   }

--- a/app/presenters/transaction_file_tail.presenter.js
+++ b/app/presenters/transaction_file_tail.presenter.js
@@ -1,0 +1,40 @@
+'use strict'
+
+/**
+ * @module TransactionFileTailPresenter
+ */
+
+const BasePresenter = require('./base.presenter')
+
+/**
+ * Formats data for saving to the tail of a transaction file.
+ *
+ * With reference to the existing v1 charging module transaction file presenter:
+ * https://github.com/DEFRA/charging-module-api/blob/main/app/schema/pre_sroc/wrls/transaction_file_presenter.js
+ */
+
+/**
+ * 'T',
+ * seq,
+ * this.sequenceNumber,
+ * this.invoiceTotal,
+ * this.creditTotal
+ */
+class TransactionFileTailPresenter extends BasePresenter {
+  _presentation (data) {
+    return {
+      col01: 'T',
+      col02: this._leftPadZeroes(data.index, 7),
+      col03: this._numberOfLinesInFile(data.index),
+      col04: data.invoiceTotal,
+      col05: data.creditTotal
+    }
+  }
+
+  // The line index starts at 0, so the number of lines in the file is index + 1
+  _numberOfLinesInFile (index) {
+    return index + 1
+  }
+}
+
+module.exports = TransactionFileTailPresenter

--- a/test/presenters/base.presenter.test.js
+++ b/test/presenters/base.presenter.test.js
@@ -35,4 +35,15 @@ describe('Base presenter', () => {
 
     expect(() => testPresenter.go()).to.throw('You need to specify _presentation in the child presenter')
   })
+
+  describe('_formatDate method', () => {
+    it('correctly formats dates', async () => {
+      const date = '2021-01-12T14:41:10.511Z'
+      const presenter = new BasePresenter()
+
+      const result = presenter._formatDate(date)
+
+      expect(result).to.equal('12-JAN-2021')
+    })
+  })
 })

--- a/test/presenters/base.presenter.test.js
+++ b/test/presenters/base.presenter.test.js
@@ -46,4 +46,15 @@ describe('Base presenter', () => {
       expect(result).to.equal('12-JAN-2021')
     })
   })
+
+  describe('_leftPadZeroes method', () => {
+    it('correctly pads numbers', async () => {
+      const number = 123
+      const presenter = new BasePresenter()
+
+      const result = presenter._leftPadZeroes(number, 7)
+
+      expect(result).to.equal('0000123')
+    })
+  })
 })

--- a/test/presenters/transaction_file_body.presenter.test.js
+++ b/test/presenters/transaction_file_body.presenter.test.js
@@ -1,0 +1,179 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Thing under test
+const { TransactionFileBodyPresenter } = require('../../app/presenters')
+
+describe('Transaction File Body Presenter', () => {
+  const data = {
+    index: 1,
+    customerReference: 'CUSTOMER_REF',
+    transactionDate: '2021-01-01T12:05:54.651Z',
+    chargeCredit: false,
+    transactionReference: 'TRANSACTION_REF',
+    headerAttr1: '2021-12-31T12:05:54.651Z',
+    chargeValue: 772,
+    lineAreaCode: 'ARCA',
+    lineDescription: 'Well at Chigley Town Hall',
+    lineAttr1: 'LINE_ATTR_1',
+    lineAttr2: '01-APR-2020 - 31-MAR-2021',
+    lineAttr3: 'TEST',
+    lineAttr4: '1234',
+    lineAttr5: '1.23',
+    lineAttr6: '123',
+    lineAttr7: '2.34',
+    lineAttr8: '3.45',
+    lineAttr9: 'TEST',
+    lineAttr10: 'TEST',
+    lineAttr13: '0',
+    lineAttr14: '0',
+    regimeValue17: 'false',
+    minimumChargeAdjustment: false
+  }
+
+  it('returns the required columns', () => {
+    const presenter = new TransactionFileBodyPresenter(data)
+    const result = presenter.go()
+
+    // To avoid writing out col01...col43 we generate an array of them
+    const expectedFields = []
+    for (let fieldNumber = 1; fieldNumber <= 43; fieldNumber++) {
+      const paddedNumber = fieldNumber.toString().padStart(2, '0')
+      expectedFields.push(`col${paddedNumber}`)
+    }
+
+    expect(result).to.only.include(expectedFields)
+  })
+
+  it('returns the correct values for static fields', () => {
+    const presenter = new TransactionFileBodyPresenter(data)
+    const result = presenter.go()
+
+    expect(result.col01).to.equal('D')
+    expect(result.col07).to.equal('')
+    expect(result.col08).to.equal('GBP')
+    expect(result.col09).to.equal('')
+    expect(result.col11).to.equal('')
+    expect(result.col12).to.equal('')
+    expect(result.col13).to.equal('')
+    expect(result.col14).to.equal('')
+    expect(result.col15).to.equal('')
+    expect(result.col16).to.equal('')
+    expect(result.col17).to.equal('')
+    expect(result.col18).to.equal('')
+    expect(result.col19).to.equal('')
+    expect(result.col21).to.equal('')
+    expect(result.col24).to.equal('A')
+    expect(result.col25).to.equal('')
+    expect(result.col36).to.equal('')
+    expect(result.col37).to.equal('')
+    expect(result.col40).to.equal('')
+    expect(result.col41).to.equal('1')
+    expect(result.col42).to.equal('Each')
+  })
+
+  it('returns the correct values for dynamic fields', () => {
+    const presenter = new TransactionFileBodyPresenter(data)
+    const result = presenter.go()
+
+    expect(result.col02).to.equal('0000001')
+    expect(result.col03).to.equal(data.customerReference)
+    expect(result.col06).to.equal(data.transactionReference)
+    expect(result.col20).to.equal(data.chargeValue)
+    expect(result.col22).to.equal(data.lineAreaCode)
+    expect(result.col23).to.equal(data.lineDescription)
+    expect(result.col43).to.equal(data.chargeValue)
+  })
+
+  it('returns the correct values for col05 (transactionType) when given a credit', () => {
+    const presenter = new TransactionFileBodyPresenter({ ...data, chargeCredit: true })
+    const result = presenter.go()
+
+    expect(result.col05).to.equal('C')
+  })
+
+  it('returns the correct values for col05 (transactionType) when given a debit', () => {
+    const presenter = new TransactionFileBodyPresenter({ ...data, chargeCredit: false })
+    const result = presenter.go()
+
+    expect(result.col05).to.equal('I')
+  })
+
+  it('correctly formats dates', () => {
+    const presenter = new TransactionFileBodyPresenter(data)
+    const result = presenter.go()
+
+    expect(result.col04).to.equal('01-JAN-2021')
+    expect(result.col10).to.equal('31-DEC-2021')
+  })
+
+  it('returns correct values when compensation charge and minimum charge adjustment are false', () => {
+    const presenter = new TransactionFileBodyPresenter({ ...data, regimeValue17: false, minimumChargeAdjustment: false })
+    const result = presenter.go()
+
+    expect(result.col26).to.equal(data.lineAttr1)
+    expect(result.col27).to.equal(data.lineAttr2)
+    expect(result.col28).to.equal(data.lineAttr3)
+    expect(result.col29).to.equal(data.lineAttr4)
+    expect(result.col30).to.not.equal('') // We test col30's content in a separate test
+    expect(result.col31).to.equal(data.lineAttr6)
+    expect(result.col32).to.equal(data.lineAttr7)
+    expect(result.col33).to.equal(data.lineAttr8)
+    expect(result.col34).to.equal(data.lineAttr9)
+    expect(result.col35).to.equal(data.lineAttr10)
+
+    expect(result.col38).to.equal('')
+    expect(result.col39).to.equal('')
+  })
+
+  it('returns correct values when compensation charge is true', () => {
+    const presenter = new TransactionFileBodyPresenter({ ...data, regimeValue17: true, minimumChargeAdjustment: false })
+    const result = presenter.go()
+
+    expect(result.col26).to.equal('')
+    expect(result.col27).to.equal('')
+    expect(result.col28).to.equal('')
+    expect(result.col29).to.equal('')
+    expect(result.col30).to.equal('')
+    expect(result.col31).to.equal('')
+    expect(result.col32).to.equal('')
+    expect(result.col33).to.equal('')
+    expect(result.col34).to.equal('')
+    expect(result.col35).to.equal('')
+
+    expect(result.col38).to.equal(data.lineAttr13)
+    expect(result.col39).to.equal(data.lineAttr14)
+  })
+
+  it('returns correct values when minimum charge adjustment is true', () => {
+    const presenter = new TransactionFileBodyPresenter({ ...data, regimeValue17: false, minimumChargeAdjustment: true })
+    const result = presenter.go()
+
+    expect(result.col26).to.equal('')
+    expect(result.col27).to.equal('')
+    expect(result.col28).to.equal('')
+    expect(result.col29).to.equal('')
+    expect(result.col30).to.equal('')
+    expect(result.col31).to.equal('')
+    expect(result.col32).to.equal('')
+    expect(result.col33).to.equal('')
+    expect(result.col34).to.equal('')
+    expect(result.col35).to.equal('')
+
+    expect(result.col38).to.equal('')
+    expect(result.col39).to.equal('')
+  })
+
+  it('returns the correct value for col30', () => {
+    const presenter = new TransactionFileBodyPresenter({ ...data, regimeValue17: false, minimumChargeAdjustment: false })
+    const result = presenter.go()
+
+    expect(result.col30).to.equal('1.23 Ml')
+  })
+})

--- a/test/presenters/transaction_file_header.presenter.test.js
+++ b/test/presenters/transaction_file_header.presenter.test.js
@@ -13,7 +13,7 @@ const { GeneralHelper } = require('../support/helpers')
 // Thing under test
 const { TransactionFileHeaderPresenter } = require('../../app/presenters')
 
-describe.only('Transaction File Header presenter', () => {
+describe('Transaction File Header presenter', () => {
   const data = {
     index: 0,
     region: 'A',

--- a/test/presenters/transaction_file_header.presenter.test.js
+++ b/test/presenters/transaction_file_header.presenter.test.js
@@ -11,9 +11,9 @@ const { expect } = Code
 const { GeneralHelper } = require('../support/helpers')
 
 // Thing under test
-const { TransactionFileHeaderPresenter } = require('../../app/presenters')
+const { TransactionFileHeadPresenter } = require('../../app/presenters')
 
-describe('Transaction File Header presenter', () => {
+describe('Transaction File Head presenter', () => {
   const data = {
     index: 0,
     region: 'A',
@@ -23,7 +23,7 @@ describe('Transaction File Header presenter', () => {
   }
 
   it('returns the required columns', () => {
-    const testPresenter = new TransactionFileHeaderPresenter(data)
+    const testPresenter = new TransactionFileHeadPresenter(data)
     const result = testPresenter.go()
 
     // To avoid writing out col01...col08 we generate an array of them
@@ -37,7 +37,7 @@ describe('Transaction File Header presenter', () => {
   })
 
   it('correctly presents the data', () => {
-    const testPresenter = new TransactionFileHeaderPresenter(data)
+    const testPresenter = new TransactionFileHeadPresenter(data)
     const result = testPresenter.go()
 
     expect(result.col01).to.equal('H')

--- a/test/presenters/transaction_file_header.presenter.test.js
+++ b/test/presenters/transaction_file_header.presenter.test.js
@@ -13,16 +13,30 @@ const { GeneralHelper } = require('../support/helpers')
 // Thing under test
 const { TransactionFileHeaderPresenter } = require('../../app/presenters')
 
-describe('Transaction File Header presenter', () => {
-  it('correctly presents the data', () => {
-    const data = {
-      index: 0,
-      region: 'A',
-      fileId: 'FILE_ID',
-      id: GeneralHelper.uuid4(),
-      updatedAt: '2021-01-12T14:41:10.511Z'
+describe.only('Transaction File Header presenter', () => {
+  const data = {
+    index: 0,
+    region: 'A',
+    fileId: 'FILE_ID',
+    id: GeneralHelper.uuid4(),
+    updatedAt: '2021-01-12T14:41:10.511Z'
+  }
+
+  it('returns the required columns', () => {
+    const testPresenter = new TransactionFileHeaderPresenter(data)
+    const result = testPresenter.go()
+
+    // To avoid writing out col01...col08 we generate an array of them
+    const expectedFields = []
+    for (let fieldNumber = 1; fieldNumber <= 8; fieldNumber++) {
+      const paddedNumber = fieldNumber.toString().padStart(2, '0')
+      expectedFields.push(`col${paddedNumber}`)
     }
 
+    expect(result).to.only.include(expectedFields)
+  })
+
+  it('correctly presents the data', () => {
     const testPresenter = new TransactionFileHeaderPresenter(data)
     const result = testPresenter.go()
 

--- a/test/presenters/transaction_file_header.presenter.test.js
+++ b/test/presenters/transaction_file_header.presenter.test.js
@@ -1,0 +1,38 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const { GeneralHelper } = require('../support/helpers')
+
+// Thing under test
+const { TransactionFileHeaderPresenter } = require('../../app/presenters')
+
+describe('Transaction File Header presenter', () => {
+  it('correctly presents the data', () => {
+    const data = {
+      index: 0,
+      region: 'A',
+      fileId: 'FILE_ID',
+      id: GeneralHelper.uuid4(),
+      updatedAt: '2021-01-12T14:41:10.511Z'
+    }
+
+    const testPresenter = new TransactionFileHeaderPresenter(data)
+    const result = testPresenter.go()
+
+    expect(result.col01).to.equal('H')
+    expect(result.col02).to.equal('0000000')
+    expect(result.col03).to.equal('NAL')
+    expect(result.col04).to.equal(data.region)
+    expect(result.col05).to.equal('I')
+    expect(result.col06).to.equal(data.fileId)
+    expect(result.col07).to.equal(data.id)
+    expect(result.col08).to.equal('12-JAN-2021')
+  })
+})

--- a/test/presenters/transaction_file_tail.presenter.test.js
+++ b/test/presenters/transaction_file_tail.presenter.test.js
@@ -1,0 +1,44 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Thing under test
+const { TransactionFileTailPresenter } = require('../../app/presenters')
+
+describe('Transaction File Tail Presenter', () => {
+  const data = {
+    index: 3,
+    invoiceTotal: 12345,
+    creditTotal: 67890
+  }
+
+  it('returns the required columns', () => {
+    const presenter = new TransactionFileTailPresenter(data)
+    const result = presenter.go()
+
+    // To avoid writing out col01...col05 we generate an array of them
+    const expectedFields = []
+    for (let fieldNumber = 1; fieldNumber <= 5; fieldNumber++) {
+      const paddedNumber = fieldNumber.toString().padStart(2, '0')
+      expectedFields.push(`col${paddedNumber}`)
+    }
+
+    expect(result).to.only.include(expectedFields)
+  })
+
+  it('returns the correct values', () => {
+    const presenter = new TransactionFileTailPresenter(data)
+    const result = presenter.go()
+
+    expect(result.col01).to.equal('T')
+    expect(result.col02).to.equal('0000003')
+    expect(result.col03).to.equal(4)
+    expect(result.col04).to.equal(data.invoiceTotal)
+    expect(result.col05).to.equal(data.creditTotal)
+  })
+})


### PR DESCRIPTION
https://trello.com/c/hyWyM8RL/1940-m-develop-include-required-content-in-transaction-files-v2

The next thing to pull from the [dev spike branch](https://github.com/DEFRA/sroc-charging-module-api/pull/325) are the presenters, which we will use to present data in the format required for the transaction files.

This change introduces 3 presenters:
- `TransactionFileHeadPresenter`
- `TransactionFileBodyPresenter`
- `TransactionFileTailPresenter`

It also adds `_formatDate` and `_leftPadZeroes` methods to `BasePresenter`.