### PR TITLE
Transform Records to File service

### DIFF
--- a/app/services/index.js
+++ b/app/services/index.js
@@ -41,6 +41,7 @@ const StreamReadableRecordsService = require('./streams/stream_readable_records.
 const StreamTransformCSVService = require('./streams/stream_transform_csv.service')
 const StreamTransformUsingPresenterService = require('./streams/stream_transform_using_presenter.service')
 const StreamWritableFileService = require('./streams/stream_writable_file.service')
+const TransformRecordsToFileService = require('./transform_records_to_file.service')
 const ViewBillRunService = require('./view_bill_run.service')
 const ViewBillRunInvoiceService = require('./view_bill_run_invoice.service')
 
@@ -86,6 +87,7 @@ module.exports = {
   StreamTransformCSVService,
   StreamTransformUsingPresenterService,
   StreamWritableFileService,
+  TransformRecordsToFileService,
   ViewBillRunService,
   ViewBillRunInvoiceService
 }

--- a/app/services/transform_records_to_file.service.js
+++ b/app/services/transform_records_to_file.service.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const { QueryBuilder } = require('knex')
 /**
  * @module TransformRecordsToFileService
  */

--- a/app/services/transform_records_to_file.service.js
+++ b/app/services/transform_records_to_file.service.js
@@ -1,0 +1,163 @@
+'use strict'
+
+const { QueryBuilder } = require('knex')
+/**
+ * @module TransformRecordsToFileService
+ */
+
+const path = require('path')
+const { pipeline } = require('stream')
+const util = require('util')
+const { temporaryFilePath } = require('../../config/server.config')
+
+const StreamReadableDataService = require('./streams/stream_readable_data.service')
+const StreamReadableRecordsService = require('./streams/stream_readable_records.service')
+const StreamTransformCSVService = require('./streams/stream_transform_csv.service')
+const StreamTransformUsingPresenterService = require('./streams/stream_transform_using_presenter.service')
+const StreamWritableFileService = require('./streams/stream_writable_file.service')
+
+class TransformRecordsToFileService {
+  /**
+   * Takes an Objection QueryBuilder object and passes its results through the provided presenters in order to generate
+   * a file. The filename will be fileReference with .dat appended, ie. 'nalai50001.dat'.
+   *
+   * The file comprises 3 parts:
+   *
+   * The bulk of the file is comprised of the body. Each line of the body is a database record selected by the passed-in
+   * query. An additionalData object is passed in to the service and is made available to each line; allowing eg.
+   * bill run-level data to be available to a query selecting transaction records.
+   *
+   * The head and the tail are a single line each, at the top and bottom of the file respectively. They take their data
+   * from the additonalData object.
+   *
+   * @param {module:QueryBuilder} query The Objection query which will be run and the results passed to `bodyPresenter`
+   * @param {module:Presenter} headPresenter The presenter used for the file head
+   * @param {module:Presenter} bodyPresenter The presenter used for the file body
+   * @param {module:Presenter} tailPresenter The presenter used for the file tail
+   * @param {string} fileReference The reference to be used for the filename
+   * @param {object} additionalData Additional data to be used for the head and tail, and to be passed
+   * @returns {string} The full path and filename of the generated file
+   */
+  static async go (query, headPresenter, bodyPresenter, tailPresenter, fileReference, additionalData) {
+    const filenameWithPath = this._filenameWithPath(fileReference)
+
+    // We track the number of lines written as each line of the generated file includes a line number
+    let lineCount
+
+    lineCount = await this._writeHead(additionalData, headPresenter, filenameWithPath)
+    lineCount = await this._writeBody(query, bodyPresenter, filenameWithPath, additionalData, lineCount)
+    await this._writeTail(additionalData, tailPresenter, filenameWithPath, lineCount)
+
+    return filenameWithPath
+  }
+
+  static _filenameWithPath (fileReference) {
+    // We use path.normalize to remove any double forward slashes that occur when assembling the path
+    return path.normalize(
+      path.format({
+        dir: temporaryFilePath,
+        name: fileReference,
+        ext: '.dat'
+      })
+    )
+  }
+
+  /**
+   * Transforms a stream of data and writes it to a file in CSV format. Intended to be used to write a "section" of a
+   * file, ie. head, body or tail.
+   *
+   * @param {ReadableStream} inputStream The stream of data to be written.
+   * @param {module:Presenter} presenter The presenter to use to transform the data.
+   * @param {string} filenameWithPath The filename and path to be written to.
+   * @param {boolean} append Whether data should be appended to the file.
+   * @param {object} additionalData Any additional data to be added to the presenter
+   * @param {integer} [lineCount] The number of records written so far. We pass it in from previous sections so we can
+   * keep a correct count of rows. Defaults to 0.
+   * @returns {integer} The number of records written.
+   */
+  static async _writeSection (inputStream, presenter, filenameWithPath, append, additionalData, lineCount = 0) {
+    // Add an event listener to inputStream to increment recordCount each time a record passes through the pipeline. We
+    // add it to inputStream as only Readable streams emit the 'data' event.
+    inputStream.on('data', () => lineCount++)
+
+    const promisifiedPipeline = this._promisifiedPipeline()
+
+    await promisifiedPipeline(
+      inputStream,
+      this._presenterTransformStream(presenter, additionalData, lineCount),
+      this._csvTransformStream(),
+      this._writeToFileStream(filenameWithPath, append)
+    )
+
+    return lineCount
+  }
+
+  /**
+   * Write the file head, passing the supplied data to the supplied presenter. Overwrites the content of the file if
+   * it exists.
+   */
+  static async _writeHead (data, presenter, filenameWithPath) {
+    return this._writeSection(this._dataStream(data), presenter, filenameWithPath, false, null)
+  }
+
+  /**
+   * Write the file body, using the supplied query to read records from the database and passing them to the supplied
+   * presenter. Appends the data to the existing file. Returns the number of records written.
+   */
+  static async _writeBody (query, presenter, filenameWithPath, additionalData, lineCount) {
+    return this._writeSection(this._recordStream(query), presenter, filenameWithPath, true, { ...additionalData }, lineCount)
+  }
+
+  /**
+   * Write the file tail, passing the supplied data to the supplied presenter. Appends the data to the existing file.
+   */
+  static async _writeTail (data, presenter, filenameWithPath, lineCount) {
+    return this._writeSection(this._dataStream(data), presenter, filenameWithPath, true, null, lineCount)
+  }
+
+  /**
+   * Wrap stream.pipeline in a promise so we can easily 'await' it.
+   */
+  static _promisifiedPipeline () {
+    return util.promisify(pipeline)
+  }
+
+  /**
+   * Readable stream which simply outputs the data passed to it.
+   */
+  static _dataStream (data) {
+    return StreamReadableDataService.go(data)
+  }
+
+  /**
+   * Readble stream which outputs the records returned by the passed-in Objection QueryBuilder object.
+   */
+  static _recordStream (query) {
+    return StreamReadableRecordsService.go(query)
+  }
+
+  /**
+   * Transform stream which processes an object supplied to it using the supplied Presenter, and optionally combining
+   * each chunk of data it receives with additionalData, which allows us to eg. use bill run-level data when handling
+   * transaction records.
+   */
+  static _presenterTransformStream (Presenter, additionalData, lineCount) {
+    return StreamTransformUsingPresenterService.go(Presenter, additionalData, lineCount)
+  }
+
+  /**
+   * Transform stream which returns a comma-separated row of data, terminating in a newline.
+   */
+  static _csvTransformStream () {
+    return StreamTransformCSVService.go()
+  }
+
+  /**
+   * Writable stream that writes to a given file.
+   */
+  static _writeToFileStream (filenameWithPath, append) {
+    return StreamWritableFileService.go(filenameWithPath, append)
+  }
+}
+
+module.exports = TransformRecordsToFileService

--- a/app/services/transform_records_to_file.service.js
+++ b/app/services/transform_records_to_file.service.js
@@ -93,7 +93,7 @@ class TransformRecordsToFileService {
 
   /**
    * Write the file head, passing the supplied data to the supplied presenter. Overwrites the content of the file if
-   * it exists.
+   * it exists. Returns the number of records written.
    */
   static async _writeHead (data, presenter, filenameWithPath) {
     return this._writeSection(this._dataStream(data), presenter, filenameWithPath, false, null)
@@ -101,14 +101,16 @@ class TransformRecordsToFileService {
 
   /**
    * Write the file body, using the supplied query to read records from the database and passing them to the supplied
-   * presenter. Appends the data to the existing file. Returns the number of records written.
+   * presenter, along with additionalData. Appends the data if the file already exists, or creates it if not. Returns
+   * the number of records written.
    */
   static async _writeBody (query, presenter, filenameWithPath, additionalData, lineCount) {
     return this._writeSection(this._recordStream(query), presenter, filenameWithPath, true, { ...additionalData }, lineCount)
   }
 
   /**
-   * Write the file tail, passing the supplied data to the supplied presenter. Appends the data to the existing file.
+   * Write the file tail, passing the supplied data to the supplied presenter. Appends the data if the file already
+   * exists, or creates it if not. Returns the number of records written.
    */
   static async _writeTail (data, presenter, filenameWithPath, lineCount) {
     return this._writeSection(this._dataStream(data), presenter, filenameWithPath, true, null, lineCount)

--- a/test/services/transform_records_to_file.service.test.js
+++ b/test/services/transform_records_to_file.service.test.js
@@ -1,0 +1,236 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { afterEach, beforeEach, describe, it } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const {
+  BillRunHelper,
+  DatabaseHelper,
+  GeneralHelper,
+  TransactionHelper
+} = require('../support/helpers')
+
+const { InvoiceModel, TransactionModel, LicenceModel } = require('../../app/models')
+
+// const mockFs = require('mock-fs')
+
+const fs = require('fs')
+const path = require('path')
+
+const { temporaryFilePath } = require('../../config/server.config')
+
+// Thing under test
+const { TransformRecordsToFileService } = require('../../app/services')
+
+const testTransaction = {
+  id: '94420d4e-eb4b-414e-a99d-3cbfd9928a02',
+  bill_run_id: '03e8856e-277b-433e-aa51-7eecbcec4d09',
+  charge_value: 21528,
+  charge_credit: false,
+  created_at: '2021-03-24 08:46:41.21913+00',
+  updated_at: '2021-03-24 08:46:41.21913+00',
+  created_by: '59c74a73-e551-4657-80df-7667a5ebb2bb',
+  regime_id: '73b23fda-05cf-49a9-ba19-58ac8f9e6ed7',
+  ruleset: 'presroc',
+  status: 'unbilled',
+  transaction_date: null,
+  subject_to_minimum_charge: false,
+  minimum_charge_adjustment: false,
+  net_zero_value_invoice: false,
+  customer_reference: 'A51541393A',
+  client_id: null,
+  region: 'W',
+  line_area_code: 'AGY4N',
+  line_description: 'First Part Spray Irrigation Charge SPRAY IRRIGATION AT NORWOOD FARM COBHAM SURREY',
+  charge_period_start: '2017-04-01',
+  charge_period_end: '2018-03-31',
+  charge_financial_year: 2017,
+  header_attr_1: null,
+  header_attr_2: null,
+  header_attr_3: null,
+  header_attr_4: null,
+  header_attr_5: null,
+  header_attr_6: null,
+  header_attr_7: null,
+  header_attr_8: null,
+  header_attr_9: null,
+  header_attr_10: null,
+  line_attr_1: '28/39/32/0048',
+  line_attr_2: '01-APR-2017 - 31-MAR-2018',
+  line_attr_3: '245/245',
+  line_attr_4: '1495',
+  line_attr_5: '1',
+  line_attr_6: '9',
+  line_attr_7: '1.6',
+  line_attr_8: '1',
+  line_attr_9: null,
+  line_attr_10: null,
+  line_attr_11: null,
+  line_attr_12: null,
+  line_attr_13: '0',
+  line_attr_14: '0',
+  line_attr_15: null,
+  regime_value_1: 'T00013486A28/39/32/0048',
+  regime_value_2: null,
+  regime_value_3: '1',
+  regime_value_4: '245',
+  regime_value_5: '245',
+  regime_value_6: 'Kielder',
+  regime_value_7: 'Summer',
+  regime_value_8: 'High',
+  regime_value_9: 'false',
+  regime_value_10: null,
+  regime_value_11: '1',
+  regime_value_12: 'false',
+  regime_value_13: '0',
+  regime_value_14: 'false',
+  regime_value_15: 'Midlands',
+  regime_value_16: 'false',
+  regime_value_17: 'false',
+  regime_value_18: null,
+  regime_value_19: null,
+  regime_value_20: null,
+  charge_calculation: 'IGNORE_ME',
+  invoice_id: '6a88c3f9-ef2c-4ea7-9582-2a65cf7d5266',
+  licence_id: 'f5238030-50c1-4296-adf9-3bd042be6fe4'
+}
+
+describe.only('Transform Records To File service', () => {
+  let billRun
+  let invoice
+  let licence
+  let firstTransaction
+  let secondTransaction
+  let thirdTransaction
+
+  const filename = 'test'
+
+  // We use path.normalize to remove any double forward slashes that occur when assembling the path
+  const filenameWithPath = path.normalize(
+    path.format({
+      dir: temporaryFilePath,
+      name: filename,
+      ext: '.dat'
+    })
+  )
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+
+    billRun = await BillRunHelper.addBillRun(GeneralHelper.uuid4(), GeneralHelper.uuid4())
+    billRun.fileReference = filename
+
+    firstTransaction = await TransactionHelper.addTransaction(billRun.id)
+    invoice = await InvoiceModel.query().findOne({ billRunId: billRun.id })
+    licence = await LicenceModel.query().findOne({ billRunId: billRun.id })
+    secondTransaction = await TransactionHelper.addTransaction(billRun.id, { invoiceId: invoice.id, licenceId: licence.id })
+    thirdTransaction = await TransactionHelper.addTransaction(billRun.id, { invoiceId: invoice.id, licenceId: licence.id })
+
+    // // Create mock in-memory file system to avoid temp files being dropped in our filesystem
+    // mockFs({
+    //   tmp: { }
+    // })
+  })
+
+  afterEach(async () => {
+    Sinon.restore()
+    // mockFs.restore()
+  })
+
+  describe('When writing a file succeeds', () => {
+    it.only('creates a file with expected content', async () => {
+      const query = TransactionModel.query().select('*')
+
+      class headPresenter {
+        constructor (data) {
+          this.data = data
+        }
+
+        go () {
+          return {
+            col01: '---HEAD---',
+            col02: this.data.headTest,
+            col03: this.data.index
+          }
+        }
+      }
+
+      class bodyPresenter {
+        constructor (data) {
+          this.data = data
+          this.row = 0
+        }
+
+        // Note the order, which ensures we're also testing that the order of items is sorted correctly as col01, col02
+        go () {
+          return {
+            col02: this.data.billRunId,
+            col04: this.data.invoiceId,
+            col03: this.data.bodyTest,
+            col01: this.data.id,
+            col05: this.data.index
+          }
+        }
+      }
+
+      class tailPresenter {
+        constructor (data) {
+          this.data = data
+        }
+
+        go () {
+          return {
+            col01: '---TAIL---',
+            col02: this.data.tailTest,
+            col03: this.data.index
+          }
+        }
+      }
+
+      const additionalData = {
+        headTest: 'HEAD_TEST',
+        bodyTest: 'BODY_TEST',
+        tailTest: 'TAIL_TEST'
+      }
+
+      await TransformRecordsToFileService.go(query, headPresenter, bodyPresenter, tailPresenter, filename, additionalData)
+
+      const file = fs.readFileSync(filenameWithPath, 'utf-8')
+
+      const head = '"---HEAD---","HEAD_TEST","0"\n'
+      const bodyFirstRow = `"${firstTransaction.id}","${firstTransaction.billRunId}","BODY_TEST","${invoice.id}","1"\n`
+      const bodySecondRow = `"${secondTransaction.id}","${secondTransaction.billRunId}","BODY_TEST","${invoice.id}","2"\n`
+      const bodyThirdRow = `"${thirdTransaction.id}","${thirdTransaction.billRunId}","BODY_TEST","${invoice.id}","3"\n`
+      const body = bodyFirstRow.concat(bodySecondRow).concat(bodyThirdRow)
+      const tail = '"---TAIL---","TAIL_TEST","4"\n'
+
+      expect(file).to.equal(head.concat(body).concat(tail))
+    })
+
+    // it('returns the filename and path', async () => {
+    //   const returnedFilenameWithPath = await GenerateTransactionFileService.go(filename)
+
+    //   expect(returnedFilenameWithPath).to.equal(filenameWithPath)
+    // })
+  })
+
+  // describe('When writing a file fails', () => {
+  //   it('throws an error', async () => {
+  //     const fakeFile = path.format({
+  //       dir: 'FAKE_DIR',
+  //       name: 'FAKE_FILE'
+  //     })
+
+  //     const err = await expect(GenerateTransactionFileService.go(fakeFile)).to.reject()
+
+  //     expect(err).to.be.an.error()
+  //     expect(err.message).to.include('ENOENT, no such file or directory')
+  //   })
+  // })
+})


### PR DESCRIPTION
https://trello.com/c/hyWyM8RL/1940-m-develop-include-required-content-in-transaction-files-v2

The next thing to pull from the [dev spike branch](https://github.com/DEFRA/sroc-charging-module-api/pull/325) is the `TransformRecordsToFileService`, which takes an Objection query and passes it through the provided presenters in order to produce a file.
