### PR TITLE
Create initial Generate Customer File Service

### DIFF
--- a/app/services/generate_customer_file.service.js
+++ b/app/services/generate_customer_file.service.js
@@ -1,0 +1,79 @@
+'use strict'
+
+/**
+ * @module GenerateCustomerFileService
+ */
+
+const { CustomerModel } = require('../models')
+const TransformRecordsToFileService = require('./transform_records_to_file.service')
+
+class GenerateCustomerFileService {
+  /**
+   * Generates and writes a customer file for a region to a given filename in the temp folder.
+   *
+   * @param {string} region The region to generate the customer file for.
+   * @param {string} filename The name of the file to be generated.
+   * @returns {string} The path and filename of the generated file.
+   */
+  static async go (region, filename) {
+    const query = this._query(region)
+
+    const additionalData = this._additionalData()
+
+    return TransformRecordsToFileService.go(
+      query,
+      this._dummyHeadTailPresenter(),
+      this._dummyBodyPresenter(),
+      this._dummyHeadTailPresenter(),
+      filename,
+      additionalData
+    )
+  }
+
+  static _query (region) {
+    return CustomerModel.query()
+      .select('*')
+      .where('region', region)
+  }
+
+  static _additionalData () {
+    return {
+      additionalData: 'additionalData'
+    }
+  }
+
+  static _dummyBodyPresenter () {
+    return _dummyBodyPresenterClass
+  }
+
+  static _dummyHeadTailPresenter () {
+    return _dummyHeadTailPresenterClass
+  }
+}
+
+class _dummyBodyPresenterClass {
+  constructor (data) {
+    this.data = data
+  }
+
+  go () {
+    return {
+      col01: this.data.id,
+      col02: this.data.customerReference
+    }
+  }
+}
+
+class _dummyHeadTailPresenterClass {
+  constructor (data) {
+    this.data = data
+  }
+
+  go () {
+    return {
+      col01: this.data.additionalData
+    }
+  }
+}
+
+module.exports = GenerateCustomerFileService

--- a/app/services/generate_customer_file.service.js
+++ b/app/services/generate_customer_file.service.js
@@ -11,12 +11,13 @@ class GenerateCustomerFileService {
   /**
    * Generates and writes a customer file for a region to a given filename in the temp folder.
    *
+   * @param {string} regimeId Id of the regime to generate the customer file for.
    * @param {string} region The region to generate the customer file for.
    * @param {string} filename The name of the file to be generated.
    * @returns {string} The path and filename of the generated file.
    */
-  static async go (region, filename) {
-    const query = this._query(region)
+  static async go (regimeId, region, filename) {
+    const query = this._query(regimeId, region)
 
     const additionalData = this._additionalData()
 
@@ -30,9 +31,10 @@ class GenerateCustomerFileService {
     )
   }
 
-  static _query (region) {
+  static _query (regimeId, region) {
     return CustomerModel.query()
       .select('*')
+      .where('regimeId', regimeId)
       .where('region', region)
   }
 

--- a/app/services/index.js
+++ b/app/services/index.js
@@ -21,6 +21,7 @@ const DeleteInvoiceService = require('./delete_invoice.service')
 const FetchAndValidateBillRunInvoiceService = require('./fetch_and_validate_bill_run_invoice.service')
 const GenerateBillRunService = require('./generate_bill_run.service')
 const GenerateBillRunValidationService = require('./generate_bill_run_validation.service')
+const GenerateCustomerFileService = require('./generate_customer_file.service')
 const GenerateTransactionFileService = require('./generate_transaction_file.service')
 const ListAuthorisedSystemsService = require('./list_authorised_systems.service')
 const ListRegimesService = require('./list_regimes.service')
@@ -67,6 +68,7 @@ module.exports = {
   FetchAndValidateBillRunInvoiceService,
   GenerateBillRunService,
   GenerateBillRunValidationService,
+  GenerateCustomerFileService,
   GenerateTransactionFileService,
   ListAuthorisedSystemsService,
   ListRegimesService,

--- a/test/services/generate_customer_file.service.test.js
+++ b/test/services/generate_customer_file.service.test.js
@@ -53,7 +53,7 @@ describe('Generate Customer File service', () => {
   })
 
   it('creates a file with the correct content', async () => {
-    const returnedFilenameWithPath = await GenerateCustomerFileService.go(payload.region, filename)
+    const returnedFilenameWithPath = await GenerateCustomerFileService.go(regime.id, payload.region, filename)
 
     const file = fs.readFileSync(returnedFilenameWithPath, 'utf-8')
     const expectedContent = _expectedContent()
@@ -62,7 +62,7 @@ describe('Generate Customer File service', () => {
   })
 
   it('returns the filename and path', async () => {
-    const returnedFilenameWithPath = await GenerateCustomerFileService.go(payload.region, filename)
+    const returnedFilenameWithPath = await GenerateCustomerFileService.go(regime.id, payload.region, filename)
 
     expect(returnedFilenameWithPath).to.equal(filenameWithPath)
   })

--- a/test/services/generate_customer_file.service.test.js
+++ b/test/services/generate_customer_file.service.test.js
@@ -1,0 +1,77 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { afterEach, beforeEach, describe, it } = exports.lab = Lab.script()
+const { expect } = Code
+
+const fs = require('fs')
+const path = require('path')
+
+// Test helpers
+const { DatabaseHelper, RegimeHelper } = require('../support/helpers')
+
+const { temporaryFilePath } = require('../../config/server.config')
+
+const { CreateCustomerDetailsService } = require('../../app/services')
+
+// Thing under test
+const { GenerateCustomerFileService } = require('../../app/services')
+
+describe('Generate Customer File service', () => {
+  const filename = 'test.txt'
+  const filenameWithPath = path.join(temporaryFilePath, filename)
+
+  let customer
+  let regime
+
+  const payload = {
+    region: 'A',
+    customerReference: 'AB12345678',
+    customerName: 'CUSTOMER_NAME',
+    addressLine1: 'ADDRESS_LINE_1',
+    addressLine2: 'ADDRESS_LINE_2',
+    addressLine3: 'ADDRESS_LINE_3',
+    addressLine4: 'ADDRESS_LINE_4',
+    addressLine5: 'ADDRESS_LINE_5',
+    addressLine6: 'ADDRESS_LINE_6',
+    postcode: 'POSTCODE'
+  }
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+
+    regime = await RegimeHelper.addRegime('wrls', 'WRLS')
+    customer = await CreateCustomerDetailsService.go(payload, regime)
+  })
+
+  afterEach(async () => {
+    Sinon.restore()
+  })
+
+  it('creates a file with the correct content', async () => {
+    const returnedFilenameWithPath = await GenerateCustomerFileService.go(payload.region, filename)
+
+    const file = fs.readFileSync(returnedFilenameWithPath, 'utf-8')
+    const expectedContent = _expectedContent()
+
+    expect(file).to.equal(expectedContent)
+  })
+
+  it('returns the filename and path', async () => {
+    const returnedFilenameWithPath = await GenerateCustomerFileService.go(payload.region, filename)
+
+    expect(returnedFilenameWithPath).to.equal(filenameWithPath)
+  })
+
+  function _expectedContent () {
+    const head = ['"additionalData"'].join(',').concat('\n')
+    const body = [`"${customer.id}"`, `"${payload.customerReference}"`].join(',').concat('\n')
+    const tail = ['"additionalData"'].join(',').concat('\n')
+
+    return head.concat(body).concat(tail)
+  }
+})


### PR DESCRIPTION
https://trello.com/c/CSrOSDTP/1942-s-develop-generate-customer-files-v2

This change is the first stage of developing Generate Customer Files, which is the initial `GenerateCustomerFileService` which creates dummy files. We set it up with dummy presenters within the service instead of using `JsonPresenter` (for example) to ensure that the output file remains small and easily testable.