### PR TITLE
Revert Dependabot SonarCloud workaround

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,6 @@ jobs:
           sed -i 's/\/home\/runner\/work\/sroc-charging-module-api\/sroc-charging-module-api\//\/github\/workspace\//g' coverage/lcov.info
 
       - name: Analyze with SonarCloud
-        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != ''}}
         uses: sonarsource/sonarcloud-github-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This is provided automatically by GitHub


### PR DESCRIPTION
In [PR #292](https://github.com/DEFRA/sroc-charging-module-api/pull/292) we attempted to work around an issue with Dependabot builds failing because the SonarCloud token was missing.

As part of the change, we learnt that it was actually just to do with a change by GitHub about where the token now needs to be stored. We left the workaround in because we believed it would be a good fallback should the token be missing.

Since then though we have seen every Dependabot PR still fail because the token is flagged as missing. The CI check passes but the SonarCloud step is left unresolved because we skip it. But we know having the token in the right place works on all our other projects.

This has led us to believe that our check for a token is always returning false so the SonarCloud step is never done on Dependabot PR's. This change reverts the workaround so we can confirm that the token is there and the PR's can now build properly as per our other projects.