### PR TITLE
Switch to using Notifier plugin

### DIFF
--- a/app/controllers/admin/test/test_bill_runs.controller.js
+++ b/app/controllers/admin/test/test_bill_runs.controller.js
@@ -19,7 +19,7 @@ class TestBillRunController {
       billRun,
       req.auth.credentials.user,
       req.app.regime,
-      req.server.logger
+      req.app.notifier
     )
 
     return h.response(result).code(201)

--- a/app/controllers/presroc/bill_runs.controller.js
+++ b/app/controllers/presroc/bill_runs.controller.js
@@ -27,7 +27,7 @@ class BillRunsController {
 
   static async generate (req, h) {
     await GenerateBillRunValidationService.go(req.app.billRun)
-    GenerateBillRunService.go(req.app.billRun, req.server.logger)
+    GenerateBillRunService.go(req.app.billRun, req.app.notifier)
 
     return h.response().code(204)
   }

--- a/app/controllers/presroc/bill_runs.controller.js
+++ b/app/controllers/presroc/bill_runs.controller.js
@@ -47,7 +47,7 @@ class BillRunsController {
   static async send (req, h) {
     const sentBillRun = await SendBillRunReferenceService.go(req.app.regime, req.app.billRun)
 
-    SendTransactionFileService.go(req.app.regime, sentBillRun, req.server.methods.notify)
+    SendTransactionFileService.go(req.app.regime, sentBillRun, req.app.notifier)
 
     return h.response().code(204)
   }

--- a/app/services/generate_bill_run.service.js
+++ b/app/services/generate_bill_run.service.js
@@ -17,18 +17,18 @@ class GenerateBillRunService {
   * Note! Nothing is returned from the service -- the intention is that it will be called and left to run.
   *
   * @param {@module:BillRunModel} billRun Instance of the bill run to be generated
-  * @param {object} [logger] Server logger object. If passed in then logger.info will be called to log the time taken.
+  * @param {@module:Notifier} [notifier] Instance of `Notifier` class. If passed in it will be used to log the time taken.
   */
-  static async go (billRun, logger = '') {
+  static async go (billRun, notifier = '') {
     try {
       // Mark the start time for later logging
       const startTime = process.hrtime.bigint()
 
       await this._generateBillRun(billRun)
 
-      await this._calculateAndLogTime(logger, billRun.id, startTime)
+      await this._calculateAndLogTime(notifier, billRun.id, startTime)
     } catch (error) {
-      this._logError(logger, billRun.id, error)
+      this._notifyError(notifier, billRun.id, error)
     }
   }
 
@@ -157,17 +157,16 @@ class GenerateBillRunService {
   /**
    * Log the time taken to generate the bill run using the passed in logger
    *
-   * If `logger` is not set then it will do nothing. If it is set this will get the current time and then calculate the
+   * If `notifier` is not set then it will do nothing. If it is set this will get the current time and then calculate the
    * difference from `startTime`. This and the `billRunId` are then used to generate a log message.
    *
-   * @param {function} logger Logger with an 'info' method we use to log the time taken (assumed to be the one added to
-   * the Hapi server instance by hapi-pino)
+   * @param {@module:Notifier} notifier Use to log the time taken
    * @param {string} billRunId Id of the bill run currently being 'generated'
    * @param {BigInt} startTime The time the generate process kicked off. It is expected to be the result of a call to
    * `process.hrtime.bigint()`
    */
-  static async _calculateAndLogTime (logger, billRunId, startTime) {
-    if (!logger) {
+  static async _calculateAndLogTime (notifier, billRunId, startTime) {
+    if (!notifier) {
       return
     }
 
@@ -175,26 +174,25 @@ class GenerateBillRunService {
     const timeTakenNs = endTime - startTime
     const timeTakenMs = timeTakenNs / 1000000n
 
-    logger.info(`Time taken to generate bill run '${billRunId}': ${timeTakenMs}ms`)
+    notifier.omg(`Time taken to generate bill run '${billRunId}': ${timeTakenMs}ms`)
   }
 
   /**
-   * Log an error if the generate process fails
+   * Log and record in Errbit if the generate process fails
    *
-   * If `logger` is not set then it will do nothing. If it is set this will log an error message based on the
-   * `billRunId` and error provided.
+   * If `notifier` is not set then it will do nothing. If it is set this will log an error message based on the
+   * `billRunId` and error provided plus record the event in Errbit.
    *
-   * @param {function} logger Logger with an 'info' method we use to log the error (assumed to be the one added to
-   * the Hapi server instance by hapi-pino)
+   * @param {@module:Notifier} notifier Use to both log the error in the server logs and record the event in Errbit
    * @param {string} billRunId Id of the bill run currently being 'generated'
    * @param {Object} error The error that was thrown
    */
-  static async _logError (logger, billRunId, error) {
-    if (!logger) {
+  static async _notifyError (notifier, billRunId, error) {
+    if (!notifier) {
       return
     }
 
-    logger.info(`Generate bill run '${billRunId}' failed: ${error.message} - ${error}`)
+    notifier.omfg('Generate bill run failed', { billRunId, error })
   }
 }
 

--- a/app/services/send_transaction_file.service.js
+++ b/app/services/send_transaction_file.service.js
@@ -26,10 +26,9 @@ class SendTransactionFileService {
    * @param {module:RegimeModel} regime The regime that the bill run belongs to. The regime slug will form part of the
    * path we upload to.
    * @param {module:BillRunModel} billRun The bill run we want to send the transaction file for.
-   * @param {function} notify The server.methods.notify method, which we pass in as server.methods isn't accessible
-   * within a service.
+   * @param {@module:Notifier} [notifier] Instance of `Notifier` class. Used to report any errors that occur
    */
-  static async go (regime, billRun, notify) {
+  static async go (regime, billRun, notifier) {
     let generatedFile
 
     try {
@@ -50,7 +49,7 @@ class SendTransactionFileService {
         await DeleteFileService.go(generatedFile)
       }
     } catch (error) {
-      this._notifyError(notify, 'Error sending transaction file', generatedFile, error)
+      notifier.omfg('Error sending transaction file', { generatedFile, error })
     }
   }
 
@@ -95,13 +94,6 @@ class SendTransactionFileService {
   static async _setBilledStatus (billRun) {
     await billRun.$query()
       .patch({ status: 'billed' })
-  }
-
-  static _notifyError (notifier, message, filename, error) {
-    notifier(
-      message,
-      { filename, error }
-    )
   }
 }
 

--- a/test/services/generate_bill_run.service.test.js
+++ b/test/services/generate_bill_run.service.test.js
@@ -42,7 +42,7 @@ describe('Generate Bill Run service', () => {
   let regime
   let payload
   let rulesServiceStub
-  let loggerFake
+  let notifierFake
 
   beforeEach(async () => {
     await DatabaseHelper.clean()
@@ -50,7 +50,7 @@ describe('Generate Bill Run service', () => {
     authorisedSystem = await AuthorisedSystemHelper.addSystem('1234546789', 'system1', [regime])
 
     // Create a fake for use in tests that want to know if the service attempted to log anything
-    loggerFake = { info: Sinon.fake() }
+    notifierFake = { omg: Sinon.fake(), omfg: Sinon.fake() }
 
     // We clone the request fixture as our payload so we have it available for modification in the invalid tests. For
     // the valid tests we can use it straight as
@@ -128,12 +128,12 @@ describe('Generate Bill Run service', () => {
       expect(result.creditNoteValue).to.equal(50000)
     })
 
-    it('calls the info method of the provided logger', async () => {
+    it("logs the time taken using the provided 'notifier'", async () => {
       await CreateTransactionService.go(payload, billRun, authorisedSystem, regime)
 
-      await GenerateBillRunService.go(billRun, loggerFake)
+      await GenerateBillRunService.go(billRun, notifierFake)
 
-      expect(loggerFake.info.callCount).to.equal(1)
+      expect(notifierFake.omg.callCount).to.equal(1)
     })
 
     // These tests are for zero value invoices, ie. which only contain zero-value transactions
@@ -675,11 +675,11 @@ describe('Generate Bill Run service', () => {
   })
 
   describe('If an error is thrown', () => {
-    it("gets logged but is not allowed to 'bubble' up", async () => {
-      const spy = Sinon.spy(GenerateBillRunService, '_logError')
+    it("gets logged and recorded but is not allowed to 'bubble' up", async () => {
+      const spy = Sinon.spy(GenerateBillRunService, '_notifyError')
 
-      await expect(GenerateBillRunService.go({}, loggerFake)).not.to.reject()
-      expect(loggerFake.info.callCount).to.equal(1)
+      await expect(GenerateBillRunService.go({}, notifierFake)).not.to.reject()
+      expect(notifierFake.omfg.callCount).to.equal(1)
       expect(spy.calledOnce).to.be.true()
     })
   })

--- a/test/services/send_transaction_file.service.test.js
+++ b/test/services/send_transaction_file.service.test.js
@@ -28,7 +28,7 @@ describe('Send Transaction File service', () => {
   let deleteStub
   let generateStub
   let sendStub
-  let notifyFake
+  let notifierFake
 
   beforeEach(async () => {
     await DatabaseHelper.clean()
@@ -40,8 +40,8 @@ describe('Send Transaction File service', () => {
     generateStub = Sinon.stub(GenerateTransactionFileService, 'go').returns('stubFilename')
     sendStub = Sinon.stub(SendFileToS3Service, 'go').returns(true)
 
-    // Create a fake function to stand in place of server.methods.notify
-    notifyFake = Sinon.fake()
+    // Create a fake function to stand in place of Notifier.omfg()
+    notifierFake = { omfg: Sinon.fake() }
   })
 
   afterEach(() => {
@@ -132,11 +132,13 @@ describe('Send Transaction File service', () => {
   describe('When an invalid bill run is specified', () => {
     describe("because the status is not 'pending'", () => {
       it('throws an error', async () => {
-        await SendTransactionFileService.go(regime, billRun, notifyFake)
+        await SendTransactionFileService.go(regime, billRun, notifierFake)
 
-        expect(notifyFake.firstArg).to.equal('Error sending transaction file')
-        expect(notifyFake.lastArg.filename).to.be.undefined()
-        expect(notifyFake.lastArg.error.message).to.equal(`Bill run ${billRun.id} does not have a status of 'pending'.`)
+        expect(notifierFake.omfg.callCount).to.equal(1)
+
+        expect(notifierFake.omfg.firstArg).to.equal('Error sending transaction file')
+        expect(notifierFake.omfg.lastArg.filename).to.be.undefined()
+        expect(notifierFake.omfg.lastArg.error.message).to.equal(`Bill run ${billRun.id} does not have a status of 'pending'.`)
       })
     })
   })


### PR DESCRIPTION
In [Add new Notifier plugin](https://github.com/DEFRA/sroc-charging-module-api/pull/324) we created a new class to be used by services for recording logs entries and sending notifications to Errbit.

It is intended to unify our notifications plus make them available to all services via the [Hapi request](https://hapi.dev/api/?v=20.1.2#request) object.

This change covers switching our existing log and airbrake uses to use the `Notifier` instance instead.