### PR TITLE
Add Hapi request ID to Notifier

### DIFF
--- a/app/plugins/notifier.plugin.js
+++ b/app/plugins/notifier.plugin.js
@@ -15,7 +15,7 @@ const NotifierPlugin = {
   name: 'Notifier',
   register: (server, _options) => {
     server.ext('onRequest', (request, h) => {
-      request.app.notifier = new Notifier(server.logger, server.methods.notify)
+      request.app.notifier = new Notifier(request.info.id, server.logger, server.methods.notify)
 
       return h.continue
     })

--- a/test/lib/notifier.test.js
+++ b/test/lib/notifier.test.js
@@ -8,22 +8,28 @@ const Sinon = require('sinon')
 const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
 const { expect } = Code
 
+// Test helpers
+const { GeneralHelper } = require('../support/helpers')
+
 // Thing under test
 const { Notifier } = require('../../app/lib')
 
 describe('Notifier class', () => {
+  let id
   let loggerFake
   let notifyFake
   let notifier
 
   beforeEach(async () => {
+    id = GeneralHelper.uuid4()
+
     loggerFake = {
       info: Sinon.fake(),
       error: Sinon.fake()
     }
     notifyFake = Sinon.fake()
 
-    notifier = new Notifier(loggerFake, notifyFake)
+    notifier = new Notifier(id, loggerFake, notifyFake)
   })
 
   afterEach(() => {
@@ -34,9 +40,15 @@ describe('Notifier class', () => {
     const message = 'say what test'
 
     it("logs an 'info' message", () => {
+      const expectedArgs = {
+        message,
+        req: {
+          id: id
+        }
+      }
       notifier.omg(message)
 
-      expect(loggerFake.info.calledOnceWith(message)).to.be.true()
+      expect(loggerFake.info.calledOnceWith(expectedArgs)).to.be.true()
     })
 
     it("does not send a notification to 'Errbit'", () => {
@@ -65,13 +77,21 @@ describe('Notifier class', () => {
     it("sends a notification to 'Errbit'", () => {
       notifier.omfg(message, data)
 
-      expect(notifyFake.calledOnceWith(message, data)).to.be.true()
+      expect(notifyFake.calledOnceWith(message, { id, data })).to.be.true()
     })
 
     it("logs an 'error' message", () => {
+      const expectedArgs = {
+        message,
+        ...data,
+        req: {
+          id: id
+        }
+      }
+
       notifier.omfg(message, data)
 
-      expect(loggerFake.error.calledOnceWith({ message, data })).to.be.true()
+      expect(loggerFake.error.calledOnceWith(expectedArgs)).to.be.true()
     })
   })
 })


### PR DESCRIPTION
Each [Hapi request](https://hapi.dev/api/?v=20.1.2#request) is assigned a unique ID that is a mix of actual details about the host and environment plus unique values.

For example, when running the service locally using Docker an ID will look like `1617652737349:533c1e381364:1315:kn50o8hf:10000`.

Currently, we assume the link between our log or error messages and the logged request based on context and timing. But if the `Notifier` instance we add to the request is aware of the request ID, it can ensure this is always included so we can be certain what links with what.

This change ensures whenever `Notifier` is used it includes the request ID in the output.