### PR TITLE
Remove transaction level status

### DIFF
--- a/app/presenters/view_transaction.presenter.js
+++ b/app/presenters/view_transaction.presenter.js
@@ -16,7 +16,6 @@ class ViewTransactionPresenter extends BasePresenter {
       clientId: data.clientId,
       chargeValue: data.chargeValue,
       credit: data.chargeCredit,
-      status: data.status,
       subjectToMinimumCharge: data.subjectToMinimumCharge,
       minimumChargeAdjustment: data.minimumChargeAdjustment,
       lineDescription: data.lineDescription,

--- a/app/services/view_bill_run_invoice.service.js
+++ b/app/services/view_bill_run_invoice.service.js
@@ -54,7 +54,6 @@ class ViewBillRunInvoiceService {
           'clientId',
           'chargeValue',
           'chargeCredit',
-          'status',
           'subjectToMinimumCharge',
           'minimumChargeAdjustment',
           'lineDescription',

--- a/db/migrations/20210406075137_alter_transactions.js
+++ b/db/migrations/20210406075137_alter_transactions.js
@@ -1,0 +1,21 @@
+'use strict'
+
+const tableName = 'transactions'
+
+exports.up = async function (knex) {
+  await knex
+    .schema
+    .alterTable(tableName, table => {
+      // Drop the redundant field
+      table.dropColumns('status')
+    })
+}
+
+exports.down = async function (knex) {
+  await knex
+    .schema
+    .alterTable(tableName, table => {
+      // Add dropped field
+      table.string('status').defaultTo('unbilled').notNullable()
+    })
+}

--- a/test/presenters/view_invoice.presenter.test.js
+++ b/test/presenters/view_invoice.presenter.test.js
@@ -46,7 +46,6 @@ describe('View Invoice Presenter', () => {
             clientId: null,
             chargeValue: 2093,
             chargeCredit: false,
-            status: 'unbilled',
             subjectToMinimumCharge: false,
             minimumChargeAdjustment: false,
             lineDescription: 'Well at Chigley Town Hall',
@@ -103,7 +102,6 @@ describe('View Invoice Presenter', () => {
       'clientId',
       'chargeValue',
       'credit',
-      'status',
       'subjectToMinimumCharge',
       'minimumChargeAdjustment',
       'calculation'

--- a/test/presenters/view_transaction.presenter.test.js
+++ b/test/presenters/view_transaction.presenter.test.js
@@ -19,7 +19,6 @@ describe('View Transaction Presenter', () => {
     clientId: null,
     chargeValue: 2093,
     chargeCredit: false,
-    status: 'unbilled',
     subjectToMinimumCharge: false,
     minimumChargeAdjustment: false,
     lineDescription: 'Well at Chigley Town Hall',
@@ -38,7 +37,6 @@ describe('View Transaction Presenter', () => {
       'clientId',
       'chargeValue',
       'credit',
-      'status',
       'subjectToMinimumCharge',
       'minimumChargeAdjustment',
       'lineDescription',
@@ -57,7 +55,6 @@ describe('View Transaction Presenter', () => {
     expect(result.clientId).to.equal(data.clientId)
     expect(result.chargeValue).to.equal(data.chargeValue)
     expect(result.credit).to.equal(data.chargeCredit)
-    expect(result.status).to.equal(data.status)
     expect(result.subjectToMinimumCharge).to.equal(data.subjectToMinimumCharge)
     expect(result.minimumChargeAdjustment).to.equal(data.minimumChargeAdjustment)
     expect(result.lineDescription).to.equal(data.lineDescription)


### PR DESCRIPTION
We added a status field to the transaction based on [V1 of the API](https://github.com/DEFRA/charging-module-api) right back at the start of V2.

However, as we have iterated we have ensured that the bill run status is the primary indicator for it and all things linked to it. We have now had confirmation from the WRLS team that the status field on the transaction _is_ ignored (currently displayed in `GET /invoices/{id}`).

So, this change is about removing the defunct field.