### PR TITLE
Simplify the VSCode tasks

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,7 @@
   "version": "2.0.0",
   "tasks": [
     {
-      "label": "UP (CMA)",
+      "label": "⬆️ UP (CMA)",
       "detail": "Build if needed then run a local docker environment",
       "type": "shell",
       "command": "GIT_COMMIT=$(git rev-parse HEAD) docker-compose up",
@@ -19,7 +19,7 @@
       }
     },
     {
-      "label": "DOWN (CMA)",
+      "label": "⬇️ DOWN (CMA)",
       "detail": "Drop any stopped containers",
       "type": "shell",
       "command": "docker-compose down",
@@ -34,7 +34,7 @@
       }
     },
     {
-      "label": "CLEAN (CMA)",
+      "label": "🧹 CLEAN (CMA)",
       "detail": "Will drop the containers, then remove the related images and volumes",
       "type": "shell",
       "command": "docker-compose down --rmi local -v",
@@ -49,7 +49,7 @@
       }
     },
     {
-      "label": "REBUILD (CMA)",
+      "label": "🏗️ REBUILD (CMA)",
       "detail": "Drop and remove everything, then rebuild with no cache",
       "type": "shell",
       "command": "docker-compose down --rmi local -v && docker-compose build --no-cache",
@@ -64,7 +64,7 @@
       }
     },
     {
-      "label": "LINT (CMA)",
+      "label": "🔎 LINT (CMA)",
       "detail": "Run lint checks against the code",
       "type": "shell",
       "command": "docker-compose exec app npm run lint",
@@ -79,7 +79,7 @@
       }
     },
     {
-      "label": "TEST (CMA)",
+      "label": "✅ TEST (CMA)",
       "detail": "Run unit tests in docker",
       "type": "shell",
       "command": "docker-compose exec app npm run unit-test",
@@ -94,7 +94,7 @@
       }
     },
     {
-      "label": "DB (CMA)",
+      "label": "🗄️ DB (CMA)",
       "detail": "Will rollback all changes then re-run migrations and seeds for the main db",
       "type": "shell",
       "command": "docker-compose exec app /bin/sh -c 'npm run rollbackdb && npm run migratedb && npm run seeddb'",
@@ -109,7 +109,7 @@
       }
     },
     {
-      "label": "DB TEST (CMA)",
+      "label": "🗄️✅ DB TEST (CMA)",
       "detail": "Will rollback all changes then re-run migrations and seeds for the test db",
       "type": "shell",
       "command": "docker-compose exec app /bin/sh -c 'npm run createdbtest && npm run rollbackdbtest && npm run migratedbtest'",
@@ -124,7 +124,7 @@
       }
     },
     {
-      "label": "OPEN (CMA)",
+      "label": "💻 OPEN (CMA)",
       "detail": "Will open /bin/sh in the running 'app' container",
       "type": "shell",
       "command": "docker-compose exec app /bin/sh",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,7 @@
   "version": "2.0.0",
   "tasks": [
     {
-      "label": "Start sroc-cma environment",
+      "label": "UP (CMA)",
       "detail": "Build if needed then run a local docker environment",
       "type": "shell",
       "command": "GIT_COMMIT=$(git rev-parse HEAD) docker-compose up",
@@ -19,7 +19,7 @@
       }
     },
     {
-      "label": "Drop sroc-cma containers",
+      "label": "DOWN (CMA)",
       "detail": "Drop any stopped containers",
       "type": "shell",
       "command": "docker-compose down",
@@ -34,7 +34,7 @@
       }
     },
     {
-      "label": "Clean sroc-cma environment",
+      "label": "CLEAN (CMA)",
       "detail": "Will drop the containers, then remove the related images and volumes",
       "type": "shell",
       "command": "docker-compose down --rmi local -v",
@@ -49,7 +49,7 @@
       }
     },
     {
-      "label": "Rebuild sroc-cma environment",
+      "label": "REBUILD (CMA)",
       "detail": "Drop and remove everything, then rebuild with no cache",
       "type": "shell",
       "command": "docker-compose down --rmi local -v && docker-compose build --no-cache",
@@ -64,7 +64,7 @@
       }
     },
     {
-      "label": "Run sroc-cma lint checks",
+      "label": "LINT (CMA)",
       "detail": "Run lint checks against the code",
       "type": "shell",
       "command": "docker-compose exec app npm run lint",
@@ -79,7 +79,7 @@
       }
     },
     {
-      "label": "Run sroc-cma unit tests",
+      "label": "TEST (CMA)",
       "detail": "Run unit tests in docker",
       "type": "shell",
       "command": "docker-compose exec app npm run unit-test",
@@ -94,37 +94,7 @@
       }
     },
     {
-      "label": "Run sroc-cma dev migrations",
-      "detail": "Will run the migrations for the main db",
-      "type": "shell",
-      "command": "docker-compose exec app npm run migratedb",
-      "group": "test",
-      "presentation": {
-        "echo": true,
-        "reveal": "always",
-        "focus": true,
-        "panel": "shared",
-        "showReuseMessage": false,
-        "clear": true
-      }
-    },
-    {
-      "label": "Run sroc-cma dev seeds",
-      "detail": "Will run the seeds for the main db",
-      "type": "shell",
-      "command": "docker-compose exec app npm run seeddb",
-      "group": "test",
-      "presentation": {
-        "echo": true,
-        "reveal": "always",
-        "focus": true,
-        "panel": "shared",
-        "showReuseMessage": false,
-        "clear": true
-      }
-    },
-    {
-      "label": "Refresh sroc-cma dev db",
+      "label": "DB (CMA)",
       "detail": "Will rollback all changes then re-run migrations and seeds for the main db",
       "type": "shell",
       "command": "docker-compose exec app /bin/sh -c 'npm run rollbackdb && npm run migratedb && npm run seeddb'",
@@ -139,25 +109,10 @@
       }
     },
     {
-      "label": "Prepare sroc-cma test db",
-      "detail": "Will create test db and run migrations. Is safe to call repeatedly",
-      "type": "shell",
-      "command": "docker-compose exec app /bin/sh -c 'npm run createdbtest && npm run migratedbtest'",
-      "group": "test",
-      "presentation": {
-        "echo": true,
-        "reveal": "always",
-        "focus": true,
-        "panel": "shared",
-        "showReuseMessage": false,
-        "clear": true
-      }
-    },
-    {
-      "label": "Refresh sroc-cma test db",
+      "label": "DB TEST (CMA)",
       "detail": "Will rollback all changes then re-run migrations and seeds for the test db",
       "type": "shell",
-      "command": "docker-compose exec app /bin/sh -c 'npm run rollbackdbtest && npm run migratedbtest'",
+      "command": "docker-compose exec app /bin/sh -c 'npm run createdbtest && npm run rollbackdbtest && npm run migratedbtest'",
       "group": "test",
       "presentation": {
         "echo": true,
@@ -169,7 +124,7 @@
       }
     },
     {
-      "label": "Open shell in sroc-cma container",
+      "label": "OPEN (CMA)",
       "detail": "Will open /bin/sh in the running 'app' container",
       "type": "shell",
       "command": "docker-compose exec app /bin/sh",

--- a/README.md
+++ b/README.md
@@ -48,26 +48,21 @@ As [Docker](https://www.docker.com/) is our chosen solution for deploying and ma
 
 Open the project in VSCode and then use the [Command palette](https://code.visualstudio.com/docs/getstarted/userinterface#_command-palette) to access the tasks we have provided in [tasks.json](.vscode/tasks.json)
 
-With the palette open search for **Run test task** and once highlighted select it. From the list that's presented select **Start sroc-cma environment**
+With the palette open search for **Run test task** and once highlighted select it. From the list that's presented select **UP (CMA)**
 
 You should see a new terminal open up and [Docker Compose](https://docs.docker.com/compose/) begin to start building the images. Once that is done it will switch to running the API in docker.
 
 ### Prep the database
 
-The database is automatically created but you still need to run migrations and seed it. Again using the command palette and the **Run test task** option, find and select in turn
-
-- **Run sroc-cma dev migrations**
-- **Run sroc-cma dev seeds**
+The database is automatically created but you still need to run migrations and seed it. Again using the command palette and the **Run test task** option, find and select **DB (CMA)**.
 
 The API should now be ready to use.
 
 ### Prep for testing
 
-Before we can run any tests the 'test' database needs to be created and migrations run against it. Using the command palette and the **Run test task** option, find and select
+Before we can run any tests the 'test' database needs to be created and migrations run against it. Using the command palette and the **Run test task** option, find and select **DB TEST (CMA)**.
 
-- **Prepare sroc-cma test db**
-
-This will both create the test database and run migrations against it. It is also safe to run repeatedly should you need to run new migrations.
+This will both create the test database and run migrations against it. It is also safe to run repeatedly should you need to rebuild it.
 
 ### Non-vscode users
 
@@ -77,11 +72,11 @@ If you are not a VSCode user it does not mean you cannot use Docker. Refer to [t
 
 To run lint checks use the command palette and the **Run test task** option to find and select
 
-- **Run sroc-cma lint checks**
+- **LINT (CMA)**
 
 To run unit tests find and select
 
-- **Run sroc-cma unit tests**
+- **TEST (CMA)**
 
 Check out the `scripts` in [package.json](package.json) if you intend to run things locally.
 

--- a/README.md
+++ b/README.md
@@ -48,19 +48,19 @@ As [Docker](https://www.docker.com/) is our chosen solution for deploying and ma
 
 Open the project in VSCode and then use the [Command palette](https://code.visualstudio.com/docs/getstarted/userinterface#_command-palette) to access the tasks we have provided in [tasks.json](.vscode/tasks.json)
 
-With the palette open search for **Run test task** and once highlighted select it. From the list that's presented select **UP (CMA)**
+With the palette open search for **Run test task** and once highlighted select it. From the list that's presented select **⬆️ UP (CMA)**
 
 You should see a new terminal open up and [Docker Compose](https://docs.docker.com/compose/) begin to start building the images. Once that is done it will switch to running the API in docker.
 
 ### Prep the database
 
-The database is automatically created but you still need to run migrations and seed it. Again using the command palette and the **Run test task** option, find and select **DB (CMA)**.
+The database is automatically created but you still need to run migrations and seed it. Again using the command palette and the **Run test task** option, find and select **🗄️ DB (CMA)**.
 
 The API should now be ready to use.
 
 ### Prep for testing
 
-Before we can run any tests the 'test' database needs to be created and migrations run against it. Using the command palette and the **Run test task** option, find and select **DB TEST (CMA)**.
+Before we can run any tests the 'test' database needs to be created and migrations run against it. Using the command palette and the **Run test task** option, find and select **🗄️✅ DB TEST (CMA)**.
 
 This will both create the test database and run migrations against it. It is also safe to run repeatedly should you need to rebuild it.
 
@@ -72,11 +72,11 @@ If you are not a VSCode user it does not mean you cannot use Docker. Refer to [t
 
 To run lint checks use the command palette and the **Run test task** option to find and select
 
-- **LINT (CMA)**
+- **🔎 LINT (CMA)**
 
 To run unit tests find and select
 
-- **TEST (CMA)**
+- **✅ TEST (CMA)**
 
 Check out the `scripts` in [package.json](package.json) if you intend to run things locally.
 


### PR DESCRIPTION
The recent PR [Add new docker helpers for local development](https://github.com/DEFRA/sroc-charging-module-api/pull/314) expanded the number of tasks we have in our VSCode tasks file.

On reflection, we felt that there were now commands not being used, or we were always running the same set of tasks. So, the first part of this change covers unifying some of the tasks, especially those that allow for repeated running.

The second part is being able to clearly distinguish the tasks when displayed in the list. Shorter commands that have a more direct link to what underlying command they are running we felt would help improve the understanding and use of the tasks.

<details>
<summary>Before screenshot</summary>

![Screenshot 2021-04-06 at 09 46 43](https://user-images.githubusercontent.com/1789650/113688519-4840e880-96c1-11eb-851e-263f3f78fd89.png)

</details>

<details>
<summary>After screenshot</summary>

![image](https://user-images.githubusercontent.com/1789650/113859627-05ecd980-979d-11eb-86f4-0e5c0f881640.png)

</details>