### PR TITLE
Move test sleep() method to GeneralHelper

### DIFF
--- a/test/controllers/admin/test/test_bill_runs.controller.test.js
+++ b/test/controllers/admin/test/test_bill_runs.controller.test.js
@@ -16,6 +16,7 @@ const {
   AuthorisationHelper,
   AuthorisedSystemHelper,
   DatabaseHelper,
+  GeneralHelper,
   SequenceCounterHelper
 } = require('../../../support/helpers')
 const { BillRunModel } = require('../../../../app/models')
@@ -86,7 +87,7 @@ describe('Test Bill Run Controller', () => {
       // So, the only way we could see to keep a test for this endpoint was to add in an arbitrary delay. In this case
       // we 'sleep' for 1 second (the generate process takes approx 300ms) and then continue. It seems any larger sleep
       // value causes the tests to through a timeout error.
-      await sleep(1000)
+      await GeneralHelper.sleep(1000)
 
       const billRun = await BillRunModel.query().findById(responsePayload.billRun.id)
       const invoices = await billRun.$relatedQuery('invoices')
@@ -102,8 +103,4 @@ describe('Test Bill Run Controller', () => {
       expect(transactions.filter(tran => tran.subjectToMinimumCharge).length).to.equal(3)
     })
   })
-
-  function sleep (ms) {
-    return new Promise(resolve => setTimeout(resolve, ms))
-  }
 })

--- a/test/support/helpers/general.helper.js
+++ b/test/support/helpers/general.helper.js
@@ -54,6 +54,21 @@ class GeneralHelper {
       return v.toString(16)
     })
   }
+
+  /**
+   * Use where you need to pause within a test
+   *
+   * There are times where we kick off something in the background but we then need to assert the result as part of a
+   * test. For that we have this helper that will pause the test for the number of milliseconds requested.
+   *
+   * **Note** We have noted that a delay of more than 2000ms seems to cause the test to timeout. If you see errors when
+   * using a delay greater than 2 seconds this may be the cause.
+   *
+   * @param {number} ms Time in milliseconds to pause for (1000ms == 1 second)
+   */
+  static sleep (ms) {
+    return new Promise(resolve => setTimeout(resolve, ms))
+  }
 }
 
 module.exports = GeneralHelper


### PR DESCRIPTION
A small bit of housekeeping. We recently made a change where we thought we might also need to use the `sleep()` method in another test. So, we refactored it to the `GeneralHelper` where it makes better sense to be.

Turns out we didn't need it but we still feel there is value in this minor bit of housekeeping. Hence the change.