### PR TITLE
Fix - Move delete invoice to background task

### DIFF
--- a/app/controllers/presroc/bill_runs_invoices.controller.js
+++ b/app/controllers/presroc/bill_runs_invoices.controller.js
@@ -7,7 +7,7 @@ const {
 
 class BillRunsInvoicesController {
   static async delete (req, h) {
-    await DeleteInvoiceService.go(req.params.invoiceId, req.params.billRunId)
+    DeleteInvoiceService.go(req.params.invoiceId, req.params.billRunId)
 
     return h.response().code(204)
   }


### PR DESCRIPTION
https://trello.com/c/IYJIYLSB

> This is a similar change as [Fix - Move delete bill run to background task](https://github.com/DEFRA/sroc-charging-module-api/pull/343)

It was found during testing that when we have large invoices it takes a long time for the service to respond.

We have imposed a requirement that all of the API's endpoints should respond in 1 second or less (on average) and this falls outside that if the invoice is too large. This change tweaks the delete invoice endpoint so that sends an immediate 204 response if the invoice can be deleted, and then does the actual deletion in the background.