### PR TITLE
Presenters for writing customer files

### DIFF
--- a/app/presenters/customer_file_body.presenter.js
+++ b/app/presenters/customer_file_body.presenter.js
@@ -7,13 +7,13 @@
 const BasePresenter = require('./base.presenter')
 
 /**
- * Formats data for the body of a transaction file.
+ * Formats data for the body of a customer file.
  *
- * Note that data.index and data.transactionReference are added by StreamTransformUsingPresenter and are not part of the
- * data originally read from the source transaction record.
+ * Note that data.index is added by StreamTransformUsingPresenter and is not part of the data originally read from the
+ * source transaction record.
  *
  * With reference to the existing v1 charging module transaction file presenter:
- * https://github.com/DEFRA/charging-module-api/blob/main/app/schema/pre_sroc/wrls/transaction_file_presenter.js
+ * https://github.com/DEFRA/charging-module-api/blob/main/app/schema/pre_sroc/wrls/customer_file_presenter.js
  */
 
 class CustomerFileBodyPresenter extends BasePresenter {

--- a/app/presenters/customer_file_body.presenter.js
+++ b/app/presenters/customer_file_body.presenter.js
@@ -10,9 +10,9 @@ const BasePresenter = require('./base.presenter')
  * Formats data for the body of a customer file.
  *
  * Note that data.index is added by StreamTransformUsingPresenter and is not part of the data originally read from the
- * source transaction record.
+ * source customer record.
  *
- * With reference to the existing v1 charging module transaction file presenter:
+ * With reference to the existing v1 charging module customer file presenter:
  * https://github.com/DEFRA/charging-module-api/blob/main/app/schema/pre_sroc/wrls/customer_file_presenter.js
  */
 

--- a/app/presenters/customer_file_body.presenter.js
+++ b/app/presenters/customer_file_body.presenter.js
@@ -1,0 +1,44 @@
+'use strict'
+
+/**
+ * @module CustomerFileBodyPresenter
+ */
+
+const BasePresenter = require('./base.presenter')
+
+/**
+ * Formats data for the body of a transaction file.
+ *
+ * Note that data.index and data.transactionReference are added by StreamTransformUsingPresenter and are not part of the
+ * data originally read from the source transaction record.
+ *
+ * With reference to the existing v1 charging module transaction file presenter:
+ * https://github.com/DEFRA/charging-module-api/blob/main/app/schema/pre_sroc/wrls/transaction_file_presenter.js
+ */
+
+class CustomerFileBodyPresenter extends BasePresenter {
+  _presentation (data) {
+    return {
+      col01: 'D',
+      col02: this._leftPadZeroes(data.index, 7),
+      col03: data.customerReference,
+      col04: data.customerName,
+      col05: data.addressLine1,
+      col06: this._cleanseNull(data.addressLine2),
+      col07: this._cleanseNull(data.addressLine3),
+      col08: this._cleanseNull(data.addressLine4),
+      col09: this._cleanseNull(data.addressLine5),
+      col10: this._cleanseNull(data.addressLine6),
+      col11: this._handlePostcode(data.postcode)
+    }
+  }
+
+  /**
+   * Returns the trimmed postcode, or '.' if the postcode is either null or '' after trimming
+   */
+  _handlePostcode (postcode) {
+    return postcode?.trim() ? postcode.trim() : '.'
+  }
+}
+
+module.exports = CustomerFileBodyPresenter

--- a/app/presenters/customer_file_head.presenter.js
+++ b/app/presenters/customer_file_head.presenter.js
@@ -1,0 +1,41 @@
+'use strict'
+
+/**
+ * @module CustomerFileHeadPresenter
+ */
+
+const BasePresenter = require('./base.presenter')
+
+/**
+ * Formats data for the head of a customer file.
+ *
+ * Note that data.index and data.fileReference are added by StreamTransformUsingPresenter and are not part of the data
+ * originally read from the source customer record.
+ *
+ * With reference to the existing v1 charging module customer file presenter:
+ * https://github.com/DEFRA/charging-module-api/blob/main/app/schema/pre_sroc/wrls/customer_file_presenter.js
+ */
+
+class CustomerFileHeadPresenter extends BasePresenter {
+  _presentation (data) {
+    return {
+      col01: 'H',
+      col02: this._leftPadZeroes(data.index, 7),
+      col03: 'NAL',
+      col04: data.region,
+      col05: 'C',
+      col06: this._fileNumber(data.fileReference),
+      col07: this._formatDate(Date.now())
+    }
+  }
+
+  /**
+   * When given a file reference eg. 'nalwc50003', returns the file number part '50003'. The format we return it in
+   * doesn't matter so we simply return a string without converting to an integer first.
+   */
+  _fileNumber (fileReference) {
+    return fileReference.slice(-5)
+  }
+}
+
+module.exports = CustomerFileHeadPresenter

--- a/app/presenters/customer_file_tail.presenter.js
+++ b/app/presenters/customer_file_tail.presenter.js
@@ -1,0 +1,36 @@
+'use strict'
+
+/**
+ * @module CustomerFileTailPresenter
+ */
+
+const BasePresenter = require('./base.presenter')
+
+/**
+ * Formats data for the tail of a customer file.
+ *
+ * Note that data.index is added by StreamTransformUsingPresenter and is not part of the data originally read from the
+ * source customer record.
+ *
+ * With reference to the existing v1 charging module customer file presenter:
+ * https://github.com/DEFRA/charging-module-api/blob/main/app/schema/pre_sroc/wrls/customer_file_presenter.js
+ */
+
+class CustomerFileTailPresenter extends BasePresenter {
+  _presentation (data) {
+    return {
+      col01: 'T',
+      col02: this._leftPadZeroes(data.index, 7),
+      col03: this._numberOfLinesInFile(data.index)
+    }
+  }
+
+  /**
+   * Returns the number of lines in the file, which we calculate as the current row index + 1 (since index starts at 0)
+   */
+  _numberOfLinesInFile (index) {
+    return index + 1
+  }
+}
+
+module.exports = CustomerFileTailPresenter

--- a/app/presenters/index.js
+++ b/app/presenters/index.js
@@ -7,6 +7,7 @@ const CreateBillRunPresenter = require('./create_bill_run.presenter')
 const CreateTransactionPresenter = require('./create_transaction.presenter')
 const CustomerFileBodyPresenter = require('./customer_file_body.presenter')
 const CustomerFileHeadPresenter = require('./customer_file_head.presenter')
+const CustomerFileTailPresenter = require('./customer_file_tail.presenter')
 const JsonPresenter = require('./json.presenter')
 const RulesServicePresenter = require('./rules_service.presenter')
 const TransactionFileBodyPresenter = require('./transaction_file_body.presenter')
@@ -26,6 +27,7 @@ module.exports = {
   CreateTransactionPresenter,
   CustomerFileBodyPresenter,
   CustomerFileHeadPresenter,
+  CustomerFileTailPresenter,
   JsonPresenter,
   RulesServicePresenter,
   TransactionFileBodyPresenter,

--- a/app/presenters/index.js
+++ b/app/presenters/index.js
@@ -5,6 +5,7 @@ const BillRunStatusPresenter = require('./bill_run_status.presenter')
 const CalculateChargePresenter = require('./calculate_charge.presenter')
 const CreateBillRunPresenter = require('./create_bill_run.presenter')
 const CreateTransactionPresenter = require('./create_transaction.presenter')
+const CustomerFileBodyPresenter = require('./customer_file_body.presenter')
 const JsonPresenter = require('./json.presenter')
 const RulesServicePresenter = require('./rules_service.presenter')
 const TransactionFileBodyPresenter = require('./transaction_file_body.presenter')
@@ -22,6 +23,7 @@ module.exports = {
   CalculateChargePresenter,
   CreateBillRunPresenter,
   CreateTransactionPresenter,
+  CustomerFileBodyPresenter,
   JsonPresenter,
   RulesServicePresenter,
   TransactionFileBodyPresenter,

--- a/app/presenters/index.js
+++ b/app/presenters/index.js
@@ -6,6 +6,7 @@ const CalculateChargePresenter = require('./calculate_charge.presenter')
 const CreateBillRunPresenter = require('./create_bill_run.presenter')
 const CreateTransactionPresenter = require('./create_transaction.presenter')
 const CustomerFileBodyPresenter = require('./customer_file_body.presenter')
+const CustomerFileHeadPresenter = require('./customer_file_head.presenter')
 const JsonPresenter = require('./json.presenter')
 const RulesServicePresenter = require('./rules_service.presenter')
 const TransactionFileBodyPresenter = require('./transaction_file_body.presenter')
@@ -24,6 +25,7 @@ module.exports = {
   CreateBillRunPresenter,
   CreateTransactionPresenter,
   CustomerFileBodyPresenter,
+  CustomerFileHeadPresenter,
   JsonPresenter,
   RulesServicePresenter,
   TransactionFileBodyPresenter,

--- a/test/presenters/customer_file_body.presenter.test.js
+++ b/test/presenters/customer_file_body.presenter.test.js
@@ -7,6 +7,8 @@ const Code = require('@hapi/code')
 const { describe, it } = exports.lab = Lab.script()
 const { expect } = Code
 
+const { PresenterHelper } = require('../support/helpers')
+
 // Thing under test
 const { CustomerFileBodyPresenter } = require('../../app/presenters')
 
@@ -28,12 +30,7 @@ describe('Customer File Body Presenter', () => {
     const presenter = new CustomerFileBodyPresenter(data)
     const result = presenter.go()
 
-    // To avoid writing out col01...col11 we generate an array of them
-    const expectedFields = []
-    for (let fieldNumber = 1; fieldNumber <= 11; fieldNumber++) {
-      const paddedNumber = fieldNumber.toString().padStart(2, '0')
-      expectedFields.push(`col${paddedNumber}`)
-    }
+    const expectedFields = PresenterHelper.generateNumberedCols(11)
 
     expect(result).to.only.include(expectedFields)
   })

--- a/test/presenters/customer_file_body.presenter.test.js
+++ b/test/presenters/customer_file_body.presenter.test.js
@@ -30,7 +30,7 @@ describe('Customer File Body Presenter', () => {
     const presenter = new CustomerFileBodyPresenter(data)
     const result = presenter.go()
 
-    const expectedFields = PresenterHelper.generateNumberedCols(11)
+    const expectedFields = PresenterHelper.generateNumberedColumns(11)
 
     expect(result).to.only.include(expectedFields)
   })

--- a/test/presenters/customer_file_body.presenter.test.js
+++ b/test/presenters/customer_file_body.presenter.test.js
@@ -1,0 +1,80 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Thing under test
+const { CustomerFileBodyPresenter } = require('../../app/presenters')
+
+describe('Customer File Body Presenter', () => {
+  const data = {
+    index: 1,
+    customerReference: 'CUSTOMER_REF',
+    customerName: 'CUSTOMER_NAME',
+    addressLine1: 'ADDRESS_LINE_1',
+    addressLine2: 'ADDRESS_LINE_2',
+    addressLine3: 'ADDRESS_LINE_3',
+    addressLine4: 'ADDRESS_LINE_4',
+    addressLine5: 'ADDRESS_LINE_5',
+    addressLine6: 'ADDRESS_LINE_6',
+    postcode: 'POSTCODE'
+  }
+
+  it('returns the required columns', () => {
+    const presenter = new CustomerFileBodyPresenter(data)
+    const result = presenter.go()
+
+    // To avoid writing out col01...col11 we generate an array of them
+    const expectedFields = []
+    for (let fieldNumber = 1; fieldNumber <= 11; fieldNumber++) {
+      const paddedNumber = fieldNumber.toString().padStart(2, '0')
+      expectedFields.push(`col${paddedNumber}`)
+    }
+
+    expect(result).to.only.include(expectedFields)
+  })
+
+  it('returns the correct values for each field', () => {
+    const presenter = new CustomerFileBodyPresenter(data)
+    const result = presenter.go()
+
+    expect(result.col01).to.equal('D')
+    expect(result.col02).to.equal('0000001')
+    expect(result.col03).to.equal(data.customerReference)
+    expect(result.col04).to.equal(data.customerName)
+    expect(result.col05).to.equal(data.addressLine1)
+    expect(result.col06).to.equal(data.addressLine2)
+    expect(result.col07).to.equal(data.addressLine3)
+    expect(result.col08).to.equal(data.addressLine4)
+    expect(result.col09).to.equal(data.addressLine5)
+    expect(result.col10).to.equal(data.addressLine6)
+    expect(result.col11).to.equal(data.postcode)
+  })
+
+  describe('when given an empty postcode', () => {
+    it("returns a '.' for an empty postcode", () => {
+      const presenter = new CustomerFileBodyPresenter({ ...data, postcode: '' })
+      const result = presenter.go()
+
+      expect(result.col11).to.equal('.')
+    })
+
+    it("returns a '.' for a null postcode", () => {
+      const presenter = new CustomerFileBodyPresenter({ ...data, postcode: null })
+      const result = presenter.go()
+
+      expect(result.col11).to.equal('.')
+    })
+
+    it("returns a '.' for a postcode of only spaces", () => {
+      const presenter = new CustomerFileBodyPresenter({ ...data, postcode: '   ' })
+      const result = presenter.go()
+
+      expect(result.col11).to.equal('.')
+    })
+  })
+})

--- a/test/presenters/customer_file_head.presenter.test.js
+++ b/test/presenters/customer_file_head.presenter.test.js
@@ -9,6 +9,8 @@ const { expect } = Code
 
 const { BasePresenter } = require('../../app/presenters')
 
+const { PresenterHelper } = require('../support/helpers')
+
 // Thing under test
 const { CustomerFileHeadPresenter } = require('../../app/presenters')
 
@@ -23,12 +25,7 @@ describe('Customer File Head presenter', () => {
     const testPresenter = new CustomerFileHeadPresenter(data)
     const result = testPresenter.go()
 
-    // To avoid writing out col01...col07 we generate an array of them
-    const expectedFields = []
-    for (let fieldNumber = 1; fieldNumber <= 7; fieldNumber++) {
-      const paddedNumber = fieldNumber.toString().padStart(2, '0')
-      expectedFields.push(`col${paddedNumber}`)
-    }
+    const expectedFields = PresenterHelper.generateNumberedCols(7)
 
     expect(result).to.only.include(expectedFields)
   })

--- a/test/presenters/customer_file_head.presenter.test.js
+++ b/test/presenters/customer_file_head.presenter.test.js
@@ -25,7 +25,7 @@ describe('Customer File Head presenter', () => {
     const testPresenter = new CustomerFileHeadPresenter(data)
     const result = testPresenter.go()
 
-    const expectedFields = PresenterHelper.generateNumberedCols(7)
+    const expectedFields = PresenterHelper.generateNumberedColumns(7)
 
     expect(result).to.only.include(expectedFields)
   })

--- a/test/presenters/customer_file_head.presenter.test.js
+++ b/test/presenters/customer_file_head.presenter.test.js
@@ -1,0 +1,51 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it } = exports.lab = Lab.script()
+const { expect } = Code
+
+const { BasePresenter } = require('../../app/presenters')
+
+// Thing under test
+const { CustomerFileHeadPresenter } = require('../../app/presenters')
+
+describe.only('Customer File Head presenter', () => {
+  const data = {
+    index: 0,
+    region: 'A',
+    fileReference: 'nalrc50003'
+  }
+
+  it('returns the required columns', () => {
+    const testPresenter = new CustomerFileHeadPresenter(data)
+    const result = testPresenter.go()
+
+    // To avoid writing out col01...col07 we generate an array of them
+    const expectedFields = []
+    for (let fieldNumber = 1; fieldNumber <= 7; fieldNumber++) {
+      const paddedNumber = fieldNumber.toString().padStart(2, '0')
+      expectedFields.push(`col${paddedNumber}`)
+    }
+
+    expect(result).to.only.include(expectedFields)
+  })
+
+  it('correctly presents the data', () => {
+    const testPresenter = new CustomerFileHeadPresenter(data)
+    const result = testPresenter.go()
+
+    const basePresenter = new BasePresenter()
+    const date = basePresenter._formatDate(new Date())
+
+    expect(result.col01).to.equal('H')
+    expect(result.col02).to.equal('0000000')
+    expect(result.col03).to.equal('NAL')
+    expect(result.col04).to.equal(data.region)
+    expect(result.col05).to.equal('C')
+    expect(result.col06).to.equal('50003')
+    expect(result.col07).to.equal(date)
+  })
+})

--- a/test/presenters/customer_file_head.presenter.test.js
+++ b/test/presenters/customer_file_head.presenter.test.js
@@ -12,7 +12,7 @@ const { BasePresenter } = require('../../app/presenters')
 // Thing under test
 const { CustomerFileHeadPresenter } = require('../../app/presenters')
 
-describe.only('Customer File Head presenter', () => {
+describe('Customer File Head presenter', () => {
   const data = {
     index: 0,
     region: 'A',

--- a/test/presenters/customer_file_tail.presenter.test.js
+++ b/test/presenters/customer_file_tail.presenter.test.js
@@ -21,7 +21,7 @@ describe('Customer File Tail Presenter', () => {
     const presenter = new CustomerFileTailPresenter(data)
     const result = presenter.go()
 
-    const expectedFields = PresenterHelper.generateNumberedCols(3)
+    const expectedFields = PresenterHelper.generateNumberedColumns(3)
 
     expect(result).to.only.include(expectedFields)
   })

--- a/test/presenters/customer_file_tail.presenter.test.js
+++ b/test/presenters/customer_file_tail.presenter.test.js
@@ -1,0 +1,44 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Thing under test
+const { TransactionFileTailPresenter } = require('../../app/presenters')
+
+describe('Transaction File Tail Presenter', () => {
+  const data = {
+    index: 3,
+    invoiceValue: 12345,
+    creditNoteValue: 67890
+  }
+
+  it('returns the required columns', () => {
+    const presenter = new TransactionFileTailPresenter(data)
+    const result = presenter.go()
+
+    // To avoid writing out col01...col05 we generate an array of them
+    const expectedFields = []
+    for (let fieldNumber = 1; fieldNumber <= 5; fieldNumber++) {
+      const paddedNumber = fieldNumber.toString().padStart(2, '0')
+      expectedFields.push(`col${paddedNumber}`)
+    }
+
+    expect(result).to.only.include(expectedFields)
+  })
+
+  it('returns the correct values', () => {
+    const presenter = new TransactionFileTailPresenter(data)
+    const result = presenter.go()
+
+    expect(result.col01).to.equal('T')
+    expect(result.col02).to.equal('0000003')
+    expect(result.col03).to.equal(4)
+    expect(result.col04).to.equal(data.invoiceValue)
+    expect(result.col05).to.equal(-data.creditNoteValue)
+  })
+})

--- a/test/presenters/customer_file_tail.presenter.test.js
+++ b/test/presenters/customer_file_tail.presenter.test.js
@@ -10,32 +10,28 @@ const { expect } = Code
 const { PresenterHelper } = require('../support/helpers')
 
 // Thing under test
-const { TransactionFileTailPresenter } = require('../../app/presenters')
+const { CustomerFileTailPresenter } = require('../../app/presenters')
 
-describe('Transaction File Tail Presenter', () => {
+describe('Customer File Tail Presenter', () => {
   const data = {
-    index: 3,
-    invoiceValue: 12345,
-    creditNoteValue: 67890
+    index: 3
   }
 
   it('returns the required columns', () => {
-    const presenter = new TransactionFileTailPresenter(data)
+    const presenter = new CustomerFileTailPresenter(data)
     const result = presenter.go()
 
-    const expectedFields = PresenterHelper.generateNumberedCols(5)
+    const expectedFields = PresenterHelper.generateNumberedCols(3)
 
     expect(result).to.only.include(expectedFields)
   })
 
   it('returns the correct values', () => {
-    const presenter = new TransactionFileTailPresenter(data)
+    const presenter = new CustomerFileTailPresenter(data)
     const result = presenter.go()
 
     expect(result.col01).to.equal('T')
     expect(result.col02).to.equal('0000003')
     expect(result.col03).to.equal(4)
-    expect(result.col04).to.equal(data.invoiceValue)
-    expect(result.col05).to.equal(-data.creditNoteValue)
   })
 })

--- a/test/presenters/customer_file_tail.presenter.test.js
+++ b/test/presenters/customer_file_tail.presenter.test.js
@@ -7,6 +7,8 @@ const Code = require('@hapi/code')
 const { describe, it } = exports.lab = Lab.script()
 const { expect } = Code
 
+const { PresenterHelper } = require('../support/helpers')
+
 // Thing under test
 const { TransactionFileTailPresenter } = require('../../app/presenters')
 
@@ -21,12 +23,7 @@ describe('Transaction File Tail Presenter', () => {
     const presenter = new TransactionFileTailPresenter(data)
     const result = presenter.go()
 
-    // To avoid writing out col01...col05 we generate an array of them
-    const expectedFields = []
-    for (let fieldNumber = 1; fieldNumber <= 5; fieldNumber++) {
-      const paddedNumber = fieldNumber.toString().padStart(2, '0')
-      expectedFields.push(`col${paddedNumber}`)
-    }
+    const expectedFields = PresenterHelper.generateNumberedCols(5)
 
     expect(result).to.only.include(expectedFields)
   })

--- a/test/presenters/transaction_file_body.presenter.test.js
+++ b/test/presenters/transaction_file_body.presenter.test.js
@@ -45,7 +45,7 @@ describe('Transaction File Body Presenter', () => {
     const presenter = new TransactionFileBodyPresenter(data)
     const result = presenter.go()
 
-    const expectedFields = PresenterHelper.generateNumberedCols(43)
+    const expectedFields = PresenterHelper.generateNumberedColumns(43)
 
     expect(result).to.only.include(expectedFields)
   })

--- a/test/presenters/transaction_file_body.presenter.test.js
+++ b/test/presenters/transaction_file_body.presenter.test.js
@@ -9,6 +9,8 @@ const { expect } = Code
 
 const { BasePresenter } = require('../../app/presenters')
 
+const { PresenterHelper } = require('../support/helpers')
+
 // Thing under test
 const { TransactionFileBodyPresenter } = require('../../app/presenters')
 
@@ -43,12 +45,7 @@ describe('Transaction File Body Presenter', () => {
     const presenter = new TransactionFileBodyPresenter(data)
     const result = presenter.go()
 
-    // To avoid writing out col01...col43 we generate an array of them
-    const expectedFields = []
-    for (let fieldNumber = 1; fieldNumber <= 43; fieldNumber++) {
-      const paddedNumber = fieldNumber.toString().padStart(2, '0')
-      expectedFields.push(`col${paddedNumber}`)
-    }
+    const expectedFields = PresenterHelper.generateNumberedCols(43)
 
     expect(result).to.only.include(expectedFields)
   })

--- a/test/presenters/transaction_file_head.presenter.test.js
+++ b/test/presenters/transaction_file_head.presenter.test.js
@@ -27,7 +27,7 @@ describe('Transaction File Head presenter', () => {
     const testPresenter = new TransactionFileHeadPresenter(data)
     const result = testPresenter.go()
 
-    const expectedFields = PresenterHelper.generateNumberedCols(8)
+    const expectedFields = PresenterHelper.generateNumberedColumns(8)
 
     expect(result).to.only.include(expectedFields)
   })

--- a/test/presenters/transaction_file_head.presenter.test.js
+++ b/test/presenters/transaction_file_head.presenter.test.js
@@ -9,6 +9,8 @@ const { expect } = Code
 
 const { BasePresenter } = require('../../app/presenters')
 
+const { PresenterHelper } = require('../support/helpers')
+
 // Thing under test
 const { TransactionFileHeadPresenter } = require('../../app/presenters')
 
@@ -25,12 +27,7 @@ describe('Transaction File Head presenter', () => {
     const testPresenter = new TransactionFileHeadPresenter(data)
     const result = testPresenter.go()
 
-    // To avoid writing out col01...col08 we generate an array of them
-    const expectedFields = []
-    for (let fieldNumber = 1; fieldNumber <= 8; fieldNumber++) {
-      const paddedNumber = fieldNumber.toString().padStart(2, '0')
-      expectedFields.push(`col${paddedNumber}`)
-    }
+    const expectedFields = PresenterHelper.generateNumberedCols(8)
 
     expect(result).to.only.include(expectedFields)
   })

--- a/test/presenters/transaction_file_tail.presenter.test.js
+++ b/test/presenters/transaction_file_tail.presenter.test.js
@@ -23,7 +23,7 @@ describe('Transaction File Tail Presenter', () => {
     const presenter = new TransactionFileTailPresenter(data)
     const result = presenter.go()
 
-    const expectedFields = PresenterHelper.generateNumberedCols(5)
+    const expectedFields = PresenterHelper.generateNumberedColumns(5)
 
     expect(result).to.only.include(expectedFields)
   })

--- a/test/presenters/transaction_file_tail.presenter.test.js
+++ b/test/presenters/transaction_file_tail.presenter.test.js
@@ -7,6 +7,8 @@ const Code = require('@hapi/code')
 const { describe, it } = exports.lab = Lab.script()
 const { expect } = Code
 
+const { PresenterHelper } = require('../support/helpers')
+
 // Thing under test
 const { TransactionFileTailPresenter } = require('../../app/presenters')
 
@@ -21,12 +23,7 @@ describe('Transaction File Tail Presenter', () => {
     const presenter = new TransactionFileTailPresenter(data)
     const result = presenter.go()
 
-    // To avoid writing out col01...col05 we generate an array of them
-    const expectedFields = []
-    for (let fieldNumber = 1; fieldNumber <= 5; fieldNumber++) {
-      const paddedNumber = fieldNumber.toString().padStart(2, '0')
-      expectedFields.push(`col${paddedNumber}`)
-    }
+    const expectedFields = PresenterHelper.generateNumberedCols(5)
 
     expect(result).to.only.include(expectedFields)
   })

--- a/test/support/helpers/index.js
+++ b/test/support/helpers/index.js
@@ -7,6 +7,7 @@ const DatabaseHelper = require('./database.helper')
 const GeneralHelper = require('./general.helper')
 const InvoiceHelper = require('./invoice.helper')
 const LicenceHelper = require('./licence.helper')
+const PresenterHelper = require('./presenter.helper')
 const RegimeHelper = require('./regime.helper')
 const RouteHelper = require('./route.helper')
 const RulesServiceHelper = require('./rules_service.helper')
@@ -22,6 +23,7 @@ module.exports = {
   GeneralHelper,
   InvoiceHelper,
   LicenceHelper,
+  PresenterHelper,
   RegimeHelper,
   RouteHelper,
   RulesServiceHelper,

--- a/test/support/helpers/presenter.helper.js
+++ b/test/support/helpers/presenter.helper.js
@@ -1,0 +1,26 @@
+'use strict'
+
+class PresenterHelper {
+  /**
+   * Generates an array of column fields for use when testing that a file presenter returns the correct columns.
+   *
+   * Our convention is that file presenters return data with key names col01, col02, col03 etc. When we test that the
+   * required data is returned, we generate an array of key names and check that the required data contains only those
+   * keys. This method will generate and return the array.
+   *
+   * @param {integer} cols The number of col__ fields to return, starting with col01
+   * @returns {array} The array of column fields
+   */
+  static generateNumberedCols (cols) {
+    const numberedCols = []
+
+    for (let fieldNumber = 1; fieldNumber <= cols; fieldNumber++) {
+      const paddedNumber = fieldNumber.toString().padStart(2, '0')
+      numberedCols.push(`col${paddedNumber}`)
+    }
+
+    return numberedCols
+  }
+}
+
+module.exports = PresenterHelper

--- a/test/support/helpers/presenter.helper.js
+++ b/test/support/helpers/presenter.helper.js
@@ -11,7 +11,7 @@ class PresenterHelper {
    * @param {integer} cols The number of col__ fields to return, starting with col01
    * @returns {array} The array of column fields
    */
-  static generateNumberedCols (cols) {
+  static generateNumberedColumns (cols) {
     const numberedCols = []
 
     for (let fieldNumber = 1; fieldNumber <= cols; fieldNumber++) {


### PR DESCRIPTION
https://trello.com/c/CSrOSDTP/1942-s-develop-generate-customer-files-v2

This branch creates presenters which will transform data in the customer table into the format required for customer files.

It also introduces `PresenterHelper` with a `generateNumberedColumns` method which can be used to generate the arrays of column names (eg. `['col01', 'col02', 'col03']` used in all of the file presenter tests, and refactors the existing transaction file tests to use it.