### PR TITLE
Generate customer files when sending bill runs

### DIFF
--- a/app/controllers/presroc/bill_runs.controller.js
+++ b/app/controllers/presroc/bill_runs.controller.js
@@ -8,6 +8,7 @@ const {
   GenerateBillRunService,
   GenerateBillRunValidationService,
   SendBillRunReferenceService,
+  SendCustomerFileService,
   SendTransactionFileService,
   ViewBillRunService
 } = require('../../services')
@@ -48,6 +49,7 @@ class BillRunsController {
     const sentBillRun = await SendBillRunReferenceService.go(req.app.regime, req.app.billRun)
 
     SendTransactionFileService.go(req.app.regime, sentBillRun, req.app.notifier)
+    SendCustomerFileService.go(req.app.regime, [sentBillRun.region], req.app.notifier)
 
     return h.response().code(204)
   }


### PR DESCRIPTION
https://trello.com/c/CSrOSDTP/1942-s-develop-generate-customer-files-v2

When we send a bill run, we also want to generate and send a customer file if one is required. This change adds the `SendCustomerFileService` to the 'send bill run' controller in order to achieve this.