### PR TITLE
Pass correct params to GenerateCustomerFileService

### DIFF
--- a/app/services/send_customer_file.service.js
+++ b/app/services/send_customer_file.service.js
@@ -75,8 +75,10 @@ class SendCustomerFileService {
    * Generate and send the customer file. Returns the path and filename of the generated file.
    */
   static async _generateAndSend (regime, region) {
-    const filename = await this._filename(regime, region)
-    const generatedFile = await GenerateCustomerFileService.go(regime, region, filename)
+    const fileReference = await this._fileReference(regime, region)
+    const filename = this._filename(fileReference)
+
+    const generatedFile = await GenerateCustomerFileService.go(regime.id, region, filename, fileReference)
 
     // The key is the remote path and filename in the S3 bucket, eg. 'wrls/customer/nalac50001.dat'
     const key = path.join(regime.slug, 'customer', filename)
@@ -89,8 +91,11 @@ class SendCustomerFileService {
   /**
    * Obtains a file reference for the given regime and region and returns the resulting filename
    */
-  static async _filename (regime, region) {
-    const fileReference = await NextCustomerFileReferenceService.go(regime, region)
+  static async _fileReference (regime, region) {
+    return NextCustomerFileReferenceService.go(regime, region)
+  }
+
+  static _filename (fileReference) {
     return `${fileReference}.dat`
   }
 

--- a/test/services/send_customer_file.service.test.js
+++ b/test/services/send_customer_file.service.test.js
@@ -75,7 +75,7 @@ describe('Send Customer File service', () => {
         await SendCustomerFileService.go(regime, ['A'])
 
         expect(generateStub.calledOnce).to.be.true()
-        expect(generateStub.getCall(0).args[0]).to.equal(regime)
+        expect(generateStub.getCall(0).args[0]).to.equal(regime.id)
         expect(generateStub.getCall(0).args[1]).to.equal('A')
       })
 
@@ -148,9 +148,9 @@ describe('Send Customer File service', () => {
         await SendCustomerFileService.go(regime, ['A', 'W'])
 
         expect(generateStub.calledTwice).to.be.true()
-        expect(generateStub.getCall(0).args[0]).to.equal(regime)
+        expect(generateStub.getCall(0).args[0]).to.equal(regime.id)
         expect(generateStub.getCall(0).args[1]).to.equal('A')
-        expect(generateStub.getCall(1).args[0]).to.equal(regime)
+        expect(generateStub.getCall(1).args[0]).to.equal(regime.id)
         expect(generateStub.getCall(1).args[1]).to.equal('W')
       })
 


### PR DESCRIPTION
https://trello.com/c/CSrOSDTP/1942-s-develop-generate-customer-files-v2

After merging the individual parts, we realised that `SendCustomerFileService` wasn't passing the correct parameters to `GenerateCustomerFileService` -- it was passing a regime object instead of the regime id, and it wasn't providing the file reference needed in the transaction file. This PR fixes both of these issues.