### PR TITLE
Overwrite existing customer details entry

### DIFF
--- a/app/services/create_customer_details.service.js
+++ b/app/services/create_customer_details.service.js
@@ -33,8 +33,11 @@ class CreateCustomerDetailsService {
   }
 
   static _create (translator) {
+    // Implements UPSERT by specifying that the new data should be merged in case of a conflict
     return CustomerModel.query()
       .insert({ ...translator })
+      .onConflict('customerReference')
+      .merge()
   }
 }
 

--- a/db/migrations/20210413154851_alter_customers.js
+++ b/db/migrations/20210413154851_alter_customers.js
@@ -1,0 +1,21 @@
+'use strict'
+
+const tableName = 'customers'
+
+exports.up = async function (knex) {
+  await knex
+    .schema
+    .alterTable(tableName, table => {
+      // Add unique constraint
+      table.unique(['customer_reference'])
+    })
+}
+
+exports.down = async function (knex) {
+  await knex
+    .schema
+    .alterTable(tableName, table => {
+      // Remove unique constraint
+      table.dropUnique(['customer_reference'])
+    })
+}

--- a/test/services/create_customer_details.service.test.js
+++ b/test/services/create_customer_details.service.test.js
@@ -53,6 +53,16 @@ describe('Create Customer Details service', () => {
       expect(result.addressLine6).to.equal(payload.addressLine6)
       expect(result.postcode).to.equal(payload.postcode)
     })
+
+    it('overwrites a previous change for the customer', async () => {
+      await CreateCustomerDetailsService.go(payload, regime)
+      await CreateCustomerDetailsService.go({ ...payload, postcode: 'NEW_POSTCODE' }, regime)
+
+      const result = await CustomerModel.query()
+
+      expect(result.length).to.equal(1)
+      expect(result[0].postcode).to.equal('NEW_POSTCODE')
+    })
   })
 
   describe('When an invalid payload is supplied', () => {

--- a/test/services/send_customer_file.service.test.js
+++ b/test/services/send_customer_file.service.test.js
@@ -37,7 +37,6 @@ describe('Send Customer File service', () => {
   let notifierFake
 
   const payload = {
-    customerReference: 'AB12345678',
     customerName: 'CUSTOMER_NAME',
     addressLine1: 'ADDRESS_LINE_1',
     addressLine2: 'ADDRESS_LINE_2',
@@ -53,8 +52,8 @@ describe('Send Customer File service', () => {
 
     regime = await RegimeHelper.addRegime('wrls', 'WRLS')
 
-    await CreateCustomerDetailsService.go({ ...payload, region: 'A' }, regime)
-    await CreateCustomerDetailsService.go({ ...payload, region: 'W' }, regime)
+    await CreateCustomerDetailsService.go({ ...payload, region: 'A', customerReference: 'AA12345678' }, regime)
+    await CreateCustomerDetailsService.go({ ...payload, region: 'W', customerReference: 'WA87654321' }, regime)
 
     deleteStub = Sinon.stub(DeleteFileService, 'go').returns(true)
     generateStub = Sinon.stub(GenerateCustomerFileService, 'go').returns('stubFilename')


### PR DESCRIPTION
https://trello.com/c/21HaVqbi/1934-m-include-required-content-in-customer-files-v2

AC7 states that existing detail records for a customer reference should be overwritten if a new one is added. We therefore change `CreateCustomerDetailsService` to use an upsert-style query when adding records by adding a unique constraint to the `customer_reference` field, and adding `.onConflict('customerReference').merge()` when we `insert`.
