### PR TITLE
Delete invoice error handling

### DIFF
--- a/app/controllers/presroc/bill_runs_invoices.controller.js
+++ b/app/controllers/presroc/bill_runs_invoices.controller.js
@@ -2,12 +2,17 @@
 
 const {
   DeleteInvoiceService,
+  FetchAndValidateBillRunInvoiceService,
   ViewBillRunInvoiceService
 } = require('../../services')
 
 class BillRunsInvoicesController {
   static async delete (req, h) {
-    DeleteInvoiceService.go(req.params.invoiceId, req.params.billRunId)
+    // We fetch and validate the invoice within the controller so a not found/conflict error is returned immediately
+    const invoice = await FetchAndValidateBillRunInvoiceService.go(req.params.billRunId, req.params.invoiceId)
+
+    // We start DeleteInvoiceService without await so that it runs in the background
+    DeleteInvoiceService.go(invoice, req.params.billRunId, req.app.notifier)
 
     return h.response().code(204)
   }

--- a/app/services/delete_invoice.service.js
+++ b/app/services/delete_invoice.service.js
@@ -10,7 +10,9 @@ const { raw } = require('../models/base.model')
 class DeleteInvoiceService {
   /**
    * Deletes an invoice along with its licences and transactions, and updates the figures of the bill run that the
-   * invoice belongs to. Note that the invoice will be validated to ensure it is linked to the bill run.
+   * invoice belongs to. Intended to be run as a background task by a controller, ie. called without an await. Note that
+   * the invoice will _not_ be validated to ensure it is linked to the bill run; it is expected that this will be done
+   * from the calling controller so that it can present the appropriate error to the user immediately.
    *
    * @param {module:InvoiceModel} invoice The invoice to be deleted.
    * @param {string} billRunId The id of the bill run that the invoice belongs to.

--- a/app/services/delete_invoice.service.js
+++ b/app/services/delete_invoice.service.js
@@ -7,35 +7,35 @@
 const { BillRunModel, InvoiceModel } = require('../models')
 const { raw } = require('../models/base.model')
 
-// Files in the same folder cannot be destructured from index.js so have to be required directly
-const FetchAndValidateBillRunInvoiceService = require('./fetch_and_validate_bill_run_invoice.service')
-
 class DeleteInvoiceService {
   /**
    * Deletes an invoice along with its licences and transactions, and updates the figures of the bill run that the
    * invoice belongs to. Note that the invoice will be validated to ensure it is linked to the bill run.
    *
-   * @param {string} invoiceId The id of the invoice to be deleted.
+   * @param {module:InvoiceModel} invoice The invoice to be deleted.
    * @param {string} billRunId The id of the bill run that the invoice belongs to.
    */
-  static async go (invoiceId, billRunId) {
-    const invoice = await FetchAndValidateBillRunInvoiceService.go(billRunId, invoiceId)
-    const billRunPatch = this._billRunPatch(invoice)
+  static async go (invoice, billRunId, notifier) {
+    try {
+      const billRunPatch = this._billRunPatch(invoice)
 
-    await InvoiceModel.transaction(async trx => {
-      // We only need to delete the invoice as the deletion will cascade down to the licence level, and from there down
-      // to the transaction level.
-      await InvoiceModel
-        .query(trx)
-        .deleteById(invoiceId)
+      await InvoiceModel.transaction(async trx => {
+        // We only need to delete the invoice as the deletion will cascade down to the licence level, and from there down
+        // to the transaction level.
+        await InvoiceModel
+          .query(trx)
+          .deleteById(invoice.id)
 
-      await BillRunModel
-        .query(trx)
-        .findById(billRunId)
-        .patch(billRunPatch)
+        await BillRunModel
+          .query(trx)
+          .findById(billRunId)
+          .patch(billRunPatch)
 
-      await this._setBillRunStatusIfEmpty(billRunId, trx)
-    })
+        await this._setBillRunStatusIfEmpty(billRunId, trx)
+      })
+    } catch (error) {
+      notifier.omfg('Error deleting invoice', { id: invoice.id, error })
+    }
   }
 
   /**

--- a/test/services/delete_invoice.service.test.js
+++ b/test/services/delete_invoice.service.test.js
@@ -45,6 +45,7 @@ describe('Delete Invoice service', () => {
   let payload
   let invoice
   let rulesServiceStub
+  let notifierFake
 
   beforeEach(async () => {
     await DatabaseHelper.clean()
@@ -57,6 +58,9 @@ describe('Delete Invoice service', () => {
 
     rulesServiceStub = Sinon.stub(RulesService, 'go').returns(rulesServiceResponse)
     billRun = await BillRunHelper.addBillRun(authorisedSystem.id, regime.id)
+
+    // Create a fake function to stand in place of Notifier.omfg()
+    notifierFake = { omfg: Sinon.fake() }
   })
 
   afterEach(async () => {
@@ -71,7 +75,7 @@ describe('Delete Invoice service', () => {
       })
 
       it('deletes the invoice', async () => {
-        await DeleteInvoiceService.go(invoice.id, billRun.id)
+        await DeleteInvoiceService.go(invoice, billRun.id)
 
         const result = await InvoiceModel.query().findById(invoice.id)
 
@@ -79,10 +83,11 @@ describe('Delete Invoice service', () => {
       })
 
       it('updates the bill run values', async () => {
-        // We generate the bill run to ensure that the invoice-level figures are updated
+        // We generate the bill run and retrieve the invoice again to ensure that the invoice-level figures are updated
         await GenerateBillRunService.go(billRun)
+        invoice = await InvoiceModel.query().findOne({ billRunId: billRun.id })
 
-        await DeleteInvoiceService.go(invoice.id, billRun.id)
+        await DeleteInvoiceService.go(invoice, billRun.id)
 
         const result = await BillRunModel.query().findById(billRun.id)
 
@@ -95,7 +100,7 @@ describe('Delete Invoice service', () => {
       it('deletes the invoice licences', async () => {
         const invoice = await InvoiceModel.query().findOne({ billRunId: billRun.id })
 
-        await DeleteInvoiceService.go(invoice.id, billRun.id)
+        await DeleteInvoiceService.go(invoice, billRun.id)
 
         const licences = await LicenceModel.query().select().where({ billRunId: billRun.id })
         expect(licences).to.be.empty()
@@ -104,7 +109,7 @@ describe('Delete Invoice service', () => {
       it('deletes the invoice transactions', async () => {
         const invoice = await InvoiceModel.query().findOne({ billRunId: billRun.id })
 
-        await DeleteInvoiceService.go(invoice.id, billRun.id)
+        await DeleteInvoiceService.go(invoice, billRun.id)
 
         const transactions = await TransactionModel.query().select().where({ billRunId: billRun.id })
         expect(transactions).to.be.empty()
@@ -118,7 +123,7 @@ describe('Delete Invoice service', () => {
       })
 
       it('deletes the invoice', async () => {
-        await DeleteInvoiceService.go(invoice.id, billRun.id)
+        await DeleteInvoiceService.go(invoice, billRun.id)
 
         const result = await InvoiceModel.query().findById(invoice.id)
 
@@ -126,10 +131,11 @@ describe('Delete Invoice service', () => {
       })
 
       it('updates the bill run values', async () => {
-        // We generate the bill run to ensure that the invoice-level figures are updated
+        // We generate the bill run and retrieve the invoice again to ensure that the invoice-level figures are updated
         await GenerateBillRunService.go(billRun)
+        invoice = await InvoiceModel.query().findOne({ billRunId: billRun.id })
 
-        await DeleteInvoiceService.go(invoice.id, billRun.id)
+        await DeleteInvoiceService.go(invoice, billRun.id)
 
         const result = await BillRunModel.query().findById(billRun.id)
 
@@ -142,7 +148,7 @@ describe('Delete Invoice service', () => {
       it('deletes the invoice licences', async () => {
         const invoice = await InvoiceModel.query().findOne({ billRunId: billRun.id })
 
-        await DeleteInvoiceService.go(invoice.id, billRun.id)
+        await DeleteInvoiceService.go(invoice, billRun.id)
 
         const licences = await LicenceModel.query().select().where({ billRunId: billRun.id })
         expect(licences).to.be.empty()
@@ -151,7 +157,7 @@ describe('Delete Invoice service', () => {
       it('deletes the invoice transactions', async () => {
         const invoice = await InvoiceModel.query().findOne({ billRunId: billRun.id })
 
-        await DeleteInvoiceService.go(invoice.id, billRun.id)
+        await DeleteInvoiceService.go(invoice, billRun.id)
 
         const transactions = await TransactionModel.query().select().where({ billRunId: billRun.id })
         expect(transactions).to.be.empty()
@@ -167,7 +173,7 @@ describe('Delete Invoice service', () => {
       })
 
       it('deletes the invoice', async () => {
-        await DeleteInvoiceService.go(invoice.id, billRun.id)
+        await DeleteInvoiceService.go(invoice, billRun.id)
 
         const result = await InvoiceModel.query().findById(invoice.id)
 
@@ -175,10 +181,11 @@ describe('Delete Invoice service', () => {
       })
 
       it('updates the bill run values', async () => {
-        // We generate the bill run to ensure that the invoice-level figures are updated
+        // We generate the bill run and retrieve the invoice again to ensure that the invoice-level figures are updated
         await GenerateBillRunService.go(billRun)
+        invoice = await InvoiceModel.query().findOne({ billRunId: billRun.id })
 
-        await DeleteInvoiceService.go(invoice.id, billRun.id)
+        await DeleteInvoiceService.go(invoice, billRun.id)
 
         const result = await BillRunModel.query().findById(billRun.id)
 
@@ -188,7 +195,7 @@ describe('Delete Invoice service', () => {
       it('deletes the invoice licences', async () => {
         const invoice = await InvoiceModel.query().findOne({ billRunId: billRun.id })
 
-        await DeleteInvoiceService.go(invoice.id, billRun.id)
+        await DeleteInvoiceService.go(invoice, billRun.id)
 
         const licences = await LicenceModel.query().select().where({ billRunId: billRun.id })
         expect(licences).to.be.empty()
@@ -197,7 +204,7 @@ describe('Delete Invoice service', () => {
       it('deletes the invoice transactions', async () => {
         const invoice = await InvoiceModel.query().findOne({ billRunId: billRun.id })
 
-        await DeleteInvoiceService.go(invoice.id, billRun.id)
+        await DeleteInvoiceService.go(invoice, billRun.id)
 
         const transactions = await TransactionModel.query().select().where({ billRunId: billRun.id })
         expect(transactions).to.be.empty()
@@ -216,7 +223,7 @@ describe('Delete Invoice service', () => {
       })
 
       it('deletes the invoice', async () => {
-        await DeleteInvoiceService.go(invoice.id, billRun.id)
+        await DeleteInvoiceService.go(invoice, billRun.id)
 
         const result = await InvoiceModel.query().findById(invoice.id)
 
@@ -224,10 +231,11 @@ describe('Delete Invoice service', () => {
       })
 
       it('updates the bill run values', async () => {
-        // We generate the bill run to ensure that the invoice-level figures are updated
+        // We generate the bill run and retrieve the invoice again to ensure that the invoice-level figures are updated
         await GenerateBillRunService.go(billRun)
+        invoice = await InvoiceModel.query().findOne({ billRunId: billRun.id })
 
-        await DeleteInvoiceService.go(invoice.id, billRun.id)
+        await DeleteInvoiceService.go(invoice, billRun.id)
 
         const result = await BillRunModel.query().findById(billRun.id)
 
@@ -242,7 +250,7 @@ describe('Delete Invoice service', () => {
       it('deletes the invoice licences', async () => {
         const invoice = await InvoiceModel.query().findOne({ billRunId: billRun.id })
 
-        await DeleteInvoiceService.go(invoice.id, billRun.id)
+        await DeleteInvoiceService.go(invoice, billRun.id)
 
         const licences = await LicenceModel.query().select().where({ billRunId: billRun.id })
         expect(licences).to.be.empty()
@@ -251,7 +259,7 @@ describe('Delete Invoice service', () => {
       it('deletes the invoice transactions', async () => {
         const invoice = await InvoiceModel.query().findOne({ billRunId: billRun.id })
 
-        await DeleteInvoiceService.go(invoice.id, billRun.id)
+        await DeleteInvoiceService.go(invoice, billRun.id)
 
         const transactions = await TransactionModel.query().select().where({ billRunId: billRun.id })
         expect(transactions).to.be.empty()
@@ -271,7 +279,7 @@ describe('Delete Invoice service', () => {
       })
 
       it('deletes the invoice', async () => {
-        await DeleteInvoiceService.go(invoice.id, billRun.id)
+        await DeleteInvoiceService.go(invoice, billRun.id)
 
         const result = await InvoiceModel.query().findById(invoice.id)
 
@@ -279,10 +287,11 @@ describe('Delete Invoice service', () => {
       })
 
       it('updates the bill run values', async () => {
-        // We generate the bill run to ensure that the invoice-level figures are updated
+        // We generate the bill run and retrieve the invoice again to ensure that the invoice-level figures are updated
         await GenerateBillRunService.go(billRun)
+        invoice = await InvoiceModel.query().findOne({ billRunId: billRun.id })
 
-        await DeleteInvoiceService.go(invoice.id, billRun.id)
+        await DeleteInvoiceService.go(invoice, billRun.id)
 
         const result = await BillRunModel.query().findById(billRun.id)
 
@@ -297,7 +306,7 @@ describe('Delete Invoice service', () => {
       it('deletes the invoice licences', async () => {
         const invoice = await InvoiceModel.query().findOne({ billRunId: billRun.id })
 
-        await DeleteInvoiceService.go(invoice.id, billRun.id)
+        await DeleteInvoiceService.go(invoice, billRun.id)
 
         const licences = await LicenceModel.query().select().where({ billRunId: billRun.id })
         expect(licences).to.be.empty()
@@ -306,7 +315,7 @@ describe('Delete Invoice service', () => {
       it('deletes the invoice transactions', async () => {
         const invoice = await InvoiceModel.query().findOne({ billRunId: billRun.id })
 
-        await DeleteInvoiceService.go(invoice.id, billRun.id)
+        await DeleteInvoiceService.go(invoice, billRun.id)
 
         const transactions = await TransactionModel.query().select().where({ billRunId: billRun.id })
         expect(transactions).to.be.empty()
@@ -321,7 +330,7 @@ describe('Delete Invoice service', () => {
       })
 
       it("changes the bill run status to 'initialised'", async () => {
-        await DeleteInvoiceService.go(invoice.id, billRun.id)
+        await DeleteInvoiceService.go(invoice, billRun.id)
 
         const result = await BillRunModel.query().findById(billRun.id)
 
@@ -346,7 +355,7 @@ describe('Delete Invoice service', () => {
       })
 
       it('leaves the bill run status as-is', async () => {
-        await DeleteInvoiceService.go(invoice.id, billRun.id)
+        await DeleteInvoiceService.go(invoice, billRun.id)
 
         const result = await BillRunModel.query().findById(billRun.id)
 
@@ -355,29 +364,14 @@ describe('Delete Invoice service', () => {
     })
   })
 
-  describe('When an invalid invoice is supplied', () => {
-    describe('because there is no matching invoice', () => {
-      it('throws an error', async () => {
-        const unknownInvoiceId = GeneralHelper.uuid4()
-        const unknownBillRunId = GeneralHelper.uuid4()
-        const err = await expect(DeleteInvoiceService.go(unknownInvoiceId, unknownBillRunId)).to.reject()
+  describe('When an error occurs', () => {
+    it('calls the notifier', async () => {
+      const unknownInvoiceId = GeneralHelper.uuid4()
+      const unknownBillRunId = GeneralHelper.uuid4()
+      await DeleteInvoiceService.go(unknownInvoiceId, unknownBillRunId, notifierFake)
 
-        expect(err).to.be.an.error()
-        expect(err.output.payload.message).to.equal(`Invoice ${unknownInvoiceId} is unknown.`)
-      })
-    })
-
-    describe('because there the invoice is not linked to the bill run', () => {
-      it('throws an error', async () => {
-        await CreateTransactionService.go(payload, billRun, authorisedSystem, regime)
-        invoice = await InvoiceModel.query().findOne({ billRunId: billRun.id })
-        const unknownBillRunId = GeneralHelper.uuid4()
-
-        const err = await expect(DeleteInvoiceService.go(invoice.id, unknownBillRunId)).to.reject()
-
-        expect(err).to.be.an.error()
-        expect(err.output.payload.message).to.equal(`Invoice ${invoice.id} is not linked to bill run ${unknownBillRunId}.`)
-      })
+      expect(notifierFake.omfg.callCount).to.equal(1)
+      expect(notifierFake.omfg.firstArg).to.equal('Error deleting invoice')
     })
   })
 })


### PR DESCRIPTION
After we [moved delete invoice to a background task](https://github.com/DEFRA/sroc-charging-module-api/pull/345), we found that trying to delete a non-existent invoice, or an invoice not connected to the given bill run, would bring the service down. This turned out to be caused by `FetchAndValidateBillRunInvoiceService` throwing an error in these circumstances -- moving the delete invoice task to the background meant that there was nothing to catch these errors.

In order to resolve this, we have moved `FetchAndValidateBillRunInvoiceService` into the controller, so that a `404` or `409` error will be presented to the user if it occurs. We have also amended `DeleteInvoiceService` to use the notifier to log any additional errors which may occur so that they don't bring down the service.