### PR TITLE
Delete bill run error handling

### DIFF
--- a/app/controllers/presroc/bill_runs.controller.js
+++ b/app/controllers/presroc/bill_runs.controller.js
@@ -55,7 +55,7 @@ class BillRunsController {
   }
 
   static async delete (req, h) {
-    DeleteBillRunService.go(req.app.billRun)
+    DeleteBillRunService.go(req.app.billRun, req.app.notifier)
 
     return h.response().code(204)
   }

--- a/app/services/delete_bill_run.service.js
+++ b/app/services/delete_bill_run.service.js
@@ -19,11 +19,18 @@ class DeleteBillRunService {
    * controller, the bill run's status will already have been validated to ensure the bill run is editable.
    *
    * @param {@module:BillRunModel} billRun The bill run to be deleted.
+   * @param {@module:Notifier} notifier Instance of `Notifier` class. We use it to log errors rather than throwing them
+   * as this service is intended to run in the background.
+   *
    */
-  static async go (billRun) {
-    await this._setDeletingStatus(billRun)
+  static async go (billRun, notifier) {
+    try {
+      await this._setDeletingStatus(billRun)
 
-    await this._deleteBillRun(billRun)
+      await this._deleteBillRun(billRun)
+    } catch (error) {
+      notifier.omfg('Error deleting bill run', { id: billRun.id, error })
+    }
   }
 
   static _setDeletingStatus (billRun) {

--- a/app/services/delete_invoice.service.js
+++ b/app/services/delete_invoice.service.js
@@ -16,6 +16,8 @@ class DeleteInvoiceService {
    *
    * @param {module:InvoiceModel} invoice The invoice to be deleted.
    * @param {string} billRunId The id of the bill run that the invoice belongs to.
+   * @param {@module:Notifier} notifier Instance of `Notifier` class. We use it to log errors rather than throwing them
+   * as this service is intended to run in the background.
    */
   static async go (invoice, billRunId, notifier) {
     try {

--- a/app/services/send_customer_file.service.js
+++ b/app/services/send_customer_file.service.js
@@ -33,7 +33,8 @@ class SendCustomerFileService {
    *
    * @param {module:RegimeModel} regime The regime that the customer file is to be generated for.
    * @param {array} regions An arry of regions we want to send a customer file for.
-   * @param {@module:Notifier} [notifier] Instance of `Notifier` class. Used to report any errors that occur.
+   * @param {@module:Notifier} notifier Instance of `Notifier` class. We use it to log errors rather than throwing them
+   * as this service is intended to run in the background.
    */
   static async go (regime, regions, notifier) {
     let generatedFile

--- a/app/services/send_transaction_file.service.js
+++ b/app/services/send_transaction_file.service.js
@@ -26,7 +26,8 @@ class SendTransactionFileService {
    * @param {module:RegimeModel} regime The regime that the bill run belongs to. The regime slug will form part of the
    * path we upload to.
    * @param {module:BillRunModel} billRun The bill run we want to send the transaction file for.
-   * @param {@module:Notifier} [notifier] Instance of `Notifier` class. Used to report any errors that occur
+   * @param {@module:Notifier} notifier Instance of `Notifier` class. We use it to log errors rather than throwing them
+   * as this service is intended to run in the background.
    */
   static async go (regime, billRun, notifier) {
     let generatedFile

--- a/test/services/delete_bill_run.service.test.js
+++ b/test/services/delete_bill_run.service.test.js
@@ -83,7 +83,7 @@ describe('Delete Bill Run service', () => {
     })
   })
 
-  describe.only('When an error occurs', () => {
+  describe('When an error occurs', () => {
     it('calls the notifier', async () => {
       Sinon.stub(DeleteBillRunService, '_deleteBillRun').throws()
       await DeleteBillRunService.go(billRun, notifierFake)


### PR DESCRIPTION
After [moving delete bill run to a background task](https://github.com/DEFRA/sroc-charging-module-api/pull/343), this adds error trapping using `notifier` to ensure that any unexpected errors don't bring down the service.

This isn't being done as part of a defect, as all necessary bill run validation (eg. checking the bill run exists and can be edited) is handled prior to calling the service; however while [adding error handling to delete invoice](https://github.com/DEFRA/sroc-charging-module-api/pull/356) we realised we should always be using `notifier` within services intended to run in the background.

While doing this, we noticed that a few comments for other "background" services were either missing or incorrect (eg. specifying that `notifier` is optional); these have also been amended.