### PR TITLE
Fix transaction file compensation charge defect

### DIFF
--- a/app/presenters/transaction_file_body.presenter.js
+++ b/app/presenters/transaction_file_body.presenter.js
@@ -73,18 +73,27 @@ class TransactionFileBodyPresenter extends BasePresenter {
   }
 
   /**
-   * Returns an empty string if this is a compensation charge, ie. if regimeValue17 is `true`
-   * Also returns an empty string if this is a minimum charge adjustment
+   * Several fields rely on whether or not this transaction is a compensation charge. This is held in regimeValue17 as a
+   * string so we add a helper function to return it as a boolean
    */
-  _blankIfCompensationChargeOrMinimumCharge (value, data) {
-    return data.regimeValue17 || data.minimumChargeAdjustment ? '' : value
+  _compensationCharge (data) {
+    // We don't expect to store anything other than lower case but we change case just to be safe
+    return data.regimeValue17.toLowerCase() === 'true'
   }
 
   /**
-   * Returns an empty string if this is not a compensation charge, ie. if regimeValue17 is `false`
+   * Returns an empty string if this is a compensation charge
+   * Also returns an empty string if this is a minimum charge adjustment
+   */
+  _blankIfCompensationChargeOrMinimumCharge (value, data) {
+    return this._compensationCharge(data) || data.minimumChargeAdjustment ? '' : value
+  }
+
+  /**
+   * Returns an empty string if this is not a compensation charge
    */
   _blankIfNotCompensationCharge (value, data) {
-    return data.regimeValue17 ? value : ''
+    return this._compensationCharge(data) ? value : ''
   }
 
   /**

--- a/app/services/generate_transaction_file.service.js
+++ b/app/services/generate_transaction_file.service.js
@@ -60,6 +60,7 @@ class GenerateTransactionFileService {
         'lineAttr10',
         'lineAttr13',
         'lineAttr14',
+        'regimeValue17',
         'minimumChargeAdjustment',
         'invoices.transactionReference',
         'invoices.creditLineValue',

--- a/test/presenters/transaction_file_body.presenter.test.js
+++ b/test/presenters/transaction_file_body.presenter.test.js
@@ -37,6 +37,7 @@ describe('Transaction File Body Presenter', () => {
     lineAttr10: 'TEST',
     lineAttr13: '0',
     lineAttr14: '0',
+    // Note that the generic field regimeValue17 stores this as a string, not a boolean
     regimeValue17: 'false',
     minimumChargeAdjustment: false
   }
@@ -116,7 +117,12 @@ describe('Transaction File Body Presenter', () => {
   })
 
   it('returns correct values when compensation charge and minimum charge adjustment are false', () => {
-    const presenter = new TransactionFileBodyPresenter({ ...data, regimeValue17: false, minimumChargeAdjustment: false })
+    const presenter = new TransactionFileBodyPresenter({
+      ...data,
+      regimeValue17: 'false',
+      minimumChargeAdjustment: false
+    })
+
     const result = presenter.go()
 
     expect(result.col26).to.equal(data.lineAttr1)
@@ -135,7 +141,12 @@ describe('Transaction File Body Presenter', () => {
   })
 
   it('returns correct values when compensation charge is true', () => {
-    const presenter = new TransactionFileBodyPresenter({ ...data, regimeValue17: true, minimumChargeAdjustment: false })
+    const presenter = new TransactionFileBodyPresenter({
+      ...data,
+      regimeValue17: 'true',
+      minimumChargeAdjustment: false
+    })
+
     const result = presenter.go()
 
     expect(result.col26).to.equal('')
@@ -154,7 +165,12 @@ describe('Transaction File Body Presenter', () => {
   })
 
   it('returns correct values when minimum charge adjustment is true', () => {
-    const presenter = new TransactionFileBodyPresenter({ ...data, regimeValue17: false, minimumChargeAdjustment: true })
+    const presenter = new TransactionFileBodyPresenter({
+      ...data,
+      regimeValue17: 'false',
+      minimumChargeAdjustment: true
+    })
+
     const result = presenter.go()
 
     expect(result.col26).to.equal('')
@@ -173,7 +189,12 @@ describe('Transaction File Body Presenter', () => {
   })
 
   it('returns the correct value for col30', () => {
-    const presenter = new TransactionFileBodyPresenter({ ...data, regimeValue17: false, minimumChargeAdjustment: false })
+    const presenter = new TransactionFileBodyPresenter({
+      ...data,
+      regimeValue17: 'false',
+      minimumChargeAdjustment: false
+    })
+
     const result = presenter.go()
 
     expect(result.col30).to.equal('1.23 Ml')


### PR DESCRIPTION
https://trello.com/c/RBEmt0JV/1924-include-required-content-in-transaction-files-v2

Certain fields in the transaction file are only populated depending on whether or not the transaction is a compensation charge. We found during testing that this was not being done correctly. This turned out to be because the compensation charge is stored in generic field `regimeValue17` which is stored as a string, not a boolean, and therefore was always determined to be `true` regardless of whether it was the string `'true'` or `'false'`. We fix this by adding a helper method to correctly parse this field, and amend the existing `_blankIfCompensationChargeOrMinimumCharge` and `_blankIfNotCompensationCharge` methods to use this instead of `regimeValue17`.

This led to our `GenerateTransactionFileService` tests all failing, and the revelation that the service did not actually include `regimeValue17` in its select query! This has now been resolved.