### PR TITLE
Correctly record prorata days for two-part tariffs

### DIFF
--- a/app/translators/calculate_charge.translator.js
+++ b/app/translators/calculate_charge.translator.js
@@ -177,10 +177,14 @@ class CalculateChargeTranslator extends BaseTranslator {
    *
    * For example, if billable days is 12 and authorised days is 6 it will return `012/006`.
    *
+   * The exception is if this is a two-part tariff (ie. regimeValue16 is true); in this case, it returns `000/000`.
+   *
    * @returns {String} Billable days and authorised days as a formatted string
    */
   _prorataDays () {
-    return `${this._padNumber(this.regimeValue4)}/${this._padNumber(this.regimeValue5)}`
+    return this.regimeValue16
+      ? '000/000'
+      : `${this._padNumber(this.regimeValue4)}/${this._padNumber(this.regimeValue5)}`
   }
 
   /**

--- a/test/translators/calculate_charge.translator.test.js
+++ b/test/translators/calculate_charge.translator.test.js
@@ -79,6 +79,19 @@ describe('Calculate Charge translator', () => {
 
       expect(testTranslator.lineAttr3).to.equal('008/016')
     })
+
+    it("correctly uses '000/000' for a 2-part tariff", async () => {
+      const proraratPayload = {
+        ...payload,
+        billableDays: 8,
+        authorisedDays: 16,
+        twoPartTariff: true
+      }
+
+      const testTranslator = new CalculateChargeTranslator(data(proraratPayload))
+
+      expect(testTranslator.lineAttr3).to.equal('000/000')
+    })
   })
 
   describe('calculating the financial year', () => {


### PR DESCRIPTION
During transaction file testing we found that prorata days were not being correctly formatted for two-part tariffs; the acceptance criteria state that a two-part tariff should have the string `000/000` for prorata days but this was not being done.

This fix resolves this by amending the calculate charge translator so that two-part tariffs store `000/000` for the prorata days.