### PR TITLE
Fix transaction file minimum charge defect

### DIFF
--- a/app/presenters/transaction_file_body.presenter.js
+++ b/app/presenters/transaction_file_body.presenter.js
@@ -74,11 +74,12 @@ class TransactionFileBodyPresenter extends BasePresenter {
 
   /**
    * Several fields rely on whether or not this transaction is a compensation charge. This is held in regimeValue17 as a
-   * string so we add a helper function to return it as a boolean
+   * string so we add a helper function to return it as a boolean.
    */
   _compensationCharge (data) {
-    // We don't expect to store anything other than lower case but we change case just to be safe
-    return data.regimeValue17.toLowerCase() === 'true'
+    // We don't expect to store anything other than lower case but we change case just to be safe. We use optional
+    // chaining as regimeValue17 is null for minimum charge transactions.
+    return data.regimeValue17?.toLowerCase() === 'true'
   }
 
   /**

--- a/test/presenters/transaction_file_body.presenter.test.js
+++ b/test/presenters/transaction_file_body.presenter.test.js
@@ -165,9 +165,10 @@ describe('Transaction File Body Presenter', () => {
   })
 
   it('returns correct values when minimum charge adjustment is true', () => {
+    // regimeValue17 is null for minimum charge transactions
     const presenter = new TransactionFileBodyPresenter({
       ...data,
-      regimeValue17: 'false',
+      regimeValue17: null,
       minimumChargeAdjustment: true
     })
 


### PR DESCRIPTION
Our [fix for the transaction file compensation charge defect](https://github.com/DEFRA/sroc-charging-module-api/pull/360) was found to cause issues for bill runs with minimum charge transactions. This turned out to be because `regimeValue17` is stored as `null` for minimum charges, thus causing an error when we attempt to make it lower case. Adding the optional chaining operator to our `_compensationCharge` method means we now return `false` without issue if `regimeValue17` is `null`.

This defect was undiscovered in unit test as our test incorrectly stated `regimeValue17` would be `'false'` for a minimum charge adjustment. The test has been amended accordingly.