### PR TITLE
Create customer files table

### DIFF
--- a/db/migrations/20210416132011_create_customer_files.js
+++ b/db/migrations/20210416132011_create_customer_files.js
@@ -1,0 +1,34 @@
+'use strict'
+
+const tableName = 'customer_files'
+
+exports.up = async function (knex) {
+  await knex
+    .schema
+    .createTable(tableName, table => {
+      // Primary Key
+      table.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'))
+
+      // Data
+      table.uuid('regime_id').notNullable()
+      table.string('region').notNullable()
+      table.string('file_reference').notNullable()
+
+      // Automatic timestamps
+      table.timestamps(false, true)
+    })
+
+  await knex.raw(`
+    CREATE TRIGGER update_timestamp
+    BEFORE UPDATE
+    ON ${tableName}
+    FOR EACH ROW
+    EXECUTE PROCEDURE update_timestamp();
+  `)
+}
+
+exports.down = async function (knex) {
+  return knex
+    .schema
+    .dropTableIfExists(tableName)
+}


### PR DESCRIPTION
https://trello.com/c/LwTT9wKp/1948-m-develop-generate-customer-files-audit-table-v2

This change creates the `customer_files` table. It differs slightly from the v1 table, in that we don't record the status -- we may adjust this in future but for now we work on the assumption that files are only added to the db after being successfully generated and sent (whereas v1 adds them with an `initialised` status, changing to `exported` once they are generated and sent).