### PR TITLE
Fix multiple region customer file generation

### DIFF
--- a/app/services/send_customer_file.service.js
+++ b/app/services/send_customer_file.service.js
@@ -43,8 +43,8 @@ class SendCustomerFileService {
       try {
         const fileNeeded = await this._checkIfFileNeeded(regime, region)
         if (!fileNeeded) {
-          // No file is needed for this region so break and move on to the next region
-          break
+          // No file is needed for this region so continue to the next region
+          continue
         }
 
         generatedFile = await this._generateAndSend(regime, region)


### PR DESCRIPTION
We discovered a bug in `SendCustomerFileService` which was affecting the generation of multiple files. Say for example regions `A`, `B` and `W` had customer changes; when `SendCustomerFileService` was called with the array of all regions `['A', 'B', 'E', 'N', 'S', 'T', 'W', 'Y']`, files would be created for regions `A` and `B` but not for region `W`.

We found that this was caused by the loop which iterates over each region; when a file was not needed for a region, we would `break` which it turns out was incorrect -- this would break out of the loop entirely so it would only produce files up until the first one that wasn't needed. 

To fix this, we changed `break` to `continue`, which will correctly loop back and continue with the next region.