### PR TITLE
Create exported_customers table

### DIFF
--- a/db/migrations/20210420141638_create_exported_customers.js
+++ b/db/migrations/20210420141638_create_exported_customers.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const tableName = 'exported_customers'
+
+exports.up = async function (knex) {
+  await knex
+    .schema
+    .createTable(tableName, table => {
+      // Primary Key
+      table.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'))
+
+      // Data
+      table.string('customer_reference').notNullable()
+      table.uuid('customer_file_id').references('customer_files.id').notNullable()
+
+      // Automatic timestamps
+      table.timestamps(false, true)
+    })
+
+  await knex.raw(`
+    CREATE TRIGGER update_timestamp
+    BEFORE UPDATE
+    ON ${tableName}
+    FOR EACH ROW
+    EXECUTE PROCEDURE update_timestamp();
+  `)
+}
+
+exports.down = async function (knex) {
+  return knex
+    .schema
+    .dropTableIfExists(tableName)
+}


### PR DESCRIPTION
https://trello.com/c/LwTT9wKp/1948-m-develop-generate-customer-files-audit-table-v2

Once a customer change is exported, we want to delete the customer's details as per the [acceptance criteria](https://trello.com/c/yw0K7fge/244-generate-customer-files) but retain a record that their details were updated. The `exported_customers` table created in this PR will hold this record by saving `customer_reference` alongside `customer_files.id` of the customer file that the details change was included in.