### PR TITLE
Add generate customer file task

### DIFF
--- a/app/tasks/customer_files.task.js
+++ b/app/tasks/customer_files.task.js
@@ -9,6 +9,15 @@ const { RegimeModel } = require('../models')
 const { SendCustomerFileService } = require('../services')
 
 class CustomerFilesTask {
+  /**
+   * Check and if required generate a 'customer file' for each regime in the system
+   *
+   * Intended to be called as a scheduled task from Jenkins using a package.json script and via `TaskRunner`. It gets
+   * all regimes in the service and then calls `SendCustomerFileService` for each one.
+   *
+   * @param {@module:BaseNotifier} notifier Instance of a `Notifier` class. Expected to be an instance of `TaskNotifier`
+   * but anything that implements `BaseNotifier` is supported.
+   */
   static async go (notifier) {
     notifier.omg('Starting sending customer files task')
 

--- a/app/tasks/customer_files.task.js
+++ b/app/tasks/customer_files.task.js
@@ -1,0 +1,31 @@
+'use strict'
+
+/**
+ * @module CustomerFilesTask
+ */
+
+const { StaticLookup } = require('../lib')
+const { RegimeModel } = require('../models')
+const { SendCustomerFileService } = require('../services')
+
+class CustomerFilesTask {
+  static async go (notifier) {
+    notifier.omg('Starting sending customer files task')
+
+    const regimes = await this._regimes()
+    const regions = StaticLookup.regions
+
+    for (const regime of regimes) {
+      await SendCustomerFileService.go(regime, regions, notifier)
+    }
+
+    notifier.omg('Finished sending customer files task')
+  }
+
+  static _regimes () {
+    return RegimeModel
+      .query()
+  }
+}
+
+module.exports = CustomerFilesTask

--- a/app/tasks/index.js
+++ b/app/tasks/index.js
@@ -3,6 +3,8 @@
 const CustomerFilesTask = require('./customer_files.task')
 const TaskRunner = require('./task_runner')
 
+// This determines if the module has been run directly, for example, as a script entry in `package.json` or just
+// used in a `require()` call. If run directly we execute the `TaskRunner`.
 if (require.main === module) {
   TaskRunner.go(process.argv[2])
 }

--- a/app/tasks/index.js
+++ b/app/tasks/index.js
@@ -1,0 +1,13 @@
+'use strict'
+
+const CustomerFilesTask = require('./customer_files.task')
+const TaskRunner = require('./task_runner')
+
+if (require.main === module) {
+  TaskRunner.go(process.argv[2])
+}
+
+module.exports = {
+  CustomerFilesTask,
+  TaskRunner
+}

--- a/app/tasks/task_runner.js
+++ b/app/tasks/task_runner.js
@@ -6,7 +6,33 @@
 
 const CustomerFilesTask = require('./customer_files.task')
 
+/**
+ * Use to run any one of our 'tasks'
+ *
+ * It manages instantiating the notifier they'll use for logging progress and sending errors to Errbit then exiting
+ * once the work is complete.
+ *
+ * ## Usage
+ *
+ * As new tasks are added there is a process that must be followed to implement them properly. The first 2 steps are no
+ * different to what we do when adding services, translators etc.
+ *
+ * - add your new task to `app/tasks/` as a standard JS class using the 'service' pattern we have adopted
+ * - add a reference to it in `app/tasks/index.js`
+ *
+ * The next steps are specific to tasks
+ *
+ * - add a reference to it in this file
+ * - update the switch statement in `_determineTaskClass()` to handle your new task class
+ * - add an entry to package.json, for example, `"my-new-task": "node app/tasks/index.js MyNewTask"` ensuring you
+ * include the arg which is your tasks's class name
+ */
 class TaskRunner {
+  /**
+   * Execute the task runner for the task identified by the `className`
+   *
+   * @param {String} className Name of the task (class name) to be run
+   */
   static async go (className) {
     const notifier = this._notifier()
 

--- a/app/tasks/task_runner.js
+++ b/app/tasks/task_runner.js
@@ -1,0 +1,45 @@
+'use strict'
+
+/**
+ * @module TaskRunner
+ */
+
+const CustomerFilesTask = require('./customer_files.task')
+
+class TaskRunner {
+  static async go (className) {
+    const notifier = this._notifier()
+
+    const taskClass = this._determineTaskClass(className.trim().toLowerCase())
+
+    await taskClass.go(notifier)
+    await notifier.flush()
+
+    process.exit()
+  }
+
+  static _determineTaskClass (className) {
+    switch (className) {
+      case 'customerfilestask':
+        return CustomerFilesTask
+      default:
+        throw new Error(`Unknown class name '${className}' passed to task runner`)
+    }
+  }
+
+  static _notifier () {
+    return {
+      omg: (message, data = {}) => {
+        console.log(message, data)
+      },
+      omfg: (message, data = {}) => {
+        console.error(message, data)
+      },
+      flush: async () => {
+        console.log('Flushed!')
+      }
+    }
+  }
+}
+
+module.exports = TaskRunner

--- a/app/tasks/task_runner.js
+++ b/app/tasks/task_runner.js
@@ -45,12 +45,15 @@ class TaskRunner {
   }
 
   static _determineTaskClass (className) {
-    switch (className) {
-      case 'customerfilestask':
-        return CustomerFilesTask
-      default:
-        throw new Error(`Unknown class name '${className}' passed to task runner`)
+    const taskClasses = {
+      customerfilestask: CustomerFilesTask
     }
+
+    if (!taskClasses[className]) {
+      throw new Error(`Unknown class name '${className}' passed to task runner`)
+    }
+
+    return taskClasses[className]
   }
 
   static _notifier () {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "rollbackdb": "knex migrate:rollback --all",
     "rollbackdbtest": "NODE_ENV=test knex migrate:rollback --all",
     "seeddb": "knex seed:run",
-    "unit-test": "lab --silent-skips --shuffle"
+    "unit-test": "lab --silent-skips --shuffle",
+    "customer-files-task": "node app/tasks/index.js CustomerFilesTask"
   },
   "repository": {
     "type": "git",

--- a/test/tasks/customer_files.task.test.js
+++ b/test/tasks/customer_files.task.test.js
@@ -1,0 +1,45 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Thing under test
+const { CustomerFilesTask } = require('../../app/tasks')
+
+// Things we need to stub
+const { RegimeModel } = require('../../app/models')
+const { SendCustomerFileService } = require('../../app/services')
+
+describe('Customer Files Task', () => {
+  let notifierFake
+  let serviceStub
+  const regimes = [
+    { slug: 'wrls' },
+    { slug: 'cfd' }
+  ]
+
+  beforeEach(async () => {
+    notifierFake = { omg: Sinon.fake(), omfg: Sinon.fake() }
+
+    serviceStub = Sinon.stub(SendCustomerFileService, 'go')
+    Sinon.stub(RegimeModel, 'query').returns(regimes)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe('For each regime in the system', () => {
+    it("calls the 'SendCustomerFileService'", async () => {
+      await CustomerFilesTask.go(notifierFake)
+
+      expect(serviceStub.firstCall.calledWith(regimes[0])).to.be.true()
+      expect(serviceStub.secondCall.calledWith(regimes[1])).to.be.true()
+    })
+  })
+})

--- a/test/tasks/task_runner.test.js
+++ b/test/tasks/task_runner.test.js
@@ -1,0 +1,79 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Thing under test
+const { TaskRunner } = require('../../app/tasks')
+
+// Things we need to stub
+const { CustomerFilesTask } = require('../../app/tasks')
+
+describe('Task Runner', () => {
+  let taskStub
+  let notifierFake
+
+  beforeEach(async () => {
+    // We need a recognised task for the tests but we don't actually want to execute it
+    taskStub = Sinon.stub(CustomerFilesTask, 'go')
+
+    // Our TaskRunner calls this when all the work is done, but if left unstubbed it also kills the tests!
+    Sinon.stub(process, 'exit')
+
+    // We stub what _notifier() returns to kill console logs messages messing up the test output. Once `TaskNotifier`
+    // is merged in we can stub it instead.
+    // Also, we use a stub rather than a fake for `flush()`. This allows us to then use Sinon's callsFake() function in
+    // the test that confirms it was called
+    notifierFake = { omg: Sinon.fake(), omfg: Sinon.fake(), flush: Sinon.stub() }
+    Sinon.stub(TaskRunner, '_notifier').returns(notifierFake)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe('When passed a valid classname', () => {
+    describe('in properly formatted camel case', () => {
+      it('can determine the task to run', () => {
+        TaskRunner.go('CustomerFilesTask')
+
+        expect(taskStub.called).to.be.true()
+      })
+    })
+
+    describe("in improperly formatted 'cat walked over the keyboard' case", () => {
+      it('can determine the task to run', () => {
+        TaskRunner.go('cusTomerFilestaSk')
+
+        expect(taskStub.called).to.be.true()
+      })
+    })
+
+    it('flushes the notifier to ensure all errors are sent to Errbit', () => {
+      TaskRunner.go('CustomerFilesTask')
+
+      // We have 2 options for checking `flush()` gets called. If we make the test async and add 'await' to the
+      // TaskRunner.go() call we can assert that flush() was called. But when we use the TaskRunner for real we won't do
+      // this. So, the alternate is to use Sinons's callsFake() method which allows us to make the assertion in a
+      // callback which only gets fired when flush() is called (if that never happens the test will simply timeout and
+      // error). This matches how TaskRunner is actually called which is why its the option we went for
+      notifierFake.flush.callsFake(() => {
+        expect(notifierFake.flush.called).to.be.true()
+      })
+    })
+  })
+
+  describe('When passed an invalid classname', () => {
+    it('throws an error', async () => {
+      const err = await expect(TaskRunner.go('FooTask')).to.reject()
+
+      expect(err).to.be.an.error()
+      expect(taskStub.called).to.be.false()
+    })
+  })
+})

--- a/test/tasks/task_runner.test.js
+++ b/test/tasks/task_runner.test.js
@@ -73,6 +73,7 @@ describe('Task Runner', () => {
       const err = await expect(TaskRunner.go('FooTask')).to.reject()
 
       expect(err).to.be.an.error()
+      expect(err.message).to.equal("Unknown class name 'footask' passed to task runner")
       expect(taskStub.called).to.be.false()
     })
   })


### PR DESCRIPTION
https://trello.com/c/Nu0BAjJE

Client systems can send us changes to customer details which we then send across to SOP. Customers changes are grouped by region and if a bill run with a matching region is `sent` we also generate that customer file.

But if there happens to be no bill runs for a region that week, the business still wants us to ensure the customer changes are sent to SOP. We do that by triggering the creation of the customer files on a schedule once a week. The plan is for a Jenkins job to be set up to run on a schedule and use this task we are adding to do that.

This is the first for the service; a 'service' that is called outside of a request (in this case from `package.json`). To be consistent with the ECS naming convention and what we have done in Jenkins for our migrate DB and seed DB actions, we are also 'namespacing' these services under 'tasks'.

So, this change adds the first such service task which when called will run the `SendCustomerFileService` and generate the files for all regions.