### PR TITLE
Add customer file to customer_file table

### DIFF
--- a/app/models/index.js
+++ b/app/models/index.js
@@ -3,6 +3,7 @@
 const AuthorisedSystemModel = require('./authorised_system.model')
 const BaseModel = require('./base.model')
 const BillRunModel = require('./bill_run.model')
+const CustomerFileModel = require('./customer_file.model')
 const CustomerModel = require('./customer.model')
 const InvoiceModel = require('./invoice.model')
 const LicenceModel = require('./licence.model')
@@ -14,6 +15,7 @@ module.exports = {
   AuthorisedSystemModel,
   BaseModel,
   BillRunModel,
+  CustomerFileModel,
   CustomerModel,
   InvoiceModel,
   LicenceModel,

--- a/app/services/send_customer_file.service.js
+++ b/app/services/send_customer_file.service.js
@@ -26,9 +26,11 @@ class SendCustomerFileService {
    *
    * For each given region it:
    * - Checks if a file is needed (ie. if there are any customer changes in the db for the given regime and region);
+   * - Creates an appropriate entry in the customer_files table and sets the status to `pending`;
    * - Calls GenerateCustomerFileService to generate the customer file;
    * - Calls SendFileToS3Service to send the customer file to the S3 bucket;
    * - Deletes the customer records for the regime and region from the db;
+   * - Sets the customer_files record status to `exported` and exportedDate to the current date;
    * - Deletes the file if ServerConfig.removeTemporaryFiles is set to `true`.
    *
    * @param {module:RegimeModel} regime The regime that the customer file is to be generated for.

--- a/app/services/send_customer_file.service.js
+++ b/app/services/send_customer_file.service.js
@@ -115,7 +115,7 @@ class SendCustomerFileService {
   /**
    * Generate and send the customer file. Returns the path and filename of the generated file.
    */
-  static async _generateAndSend (regime, region, fileReference, customerFile) {
+  static async _generateAndSend (regime, region, fileReference) {
     const filename = this._filename(fileReference)
 
     const generatedFile = await GenerateCustomerFileService.go(regime.id, region, filename, fileReference)

--- a/app/services/send_customer_file.service.js
+++ b/app/services/send_customer_file.service.js
@@ -102,13 +102,13 @@ class SendCustomerFileService {
   }
 
   /**
-   * Sets the status of a customer file to 'exported' and sets exportDate to the current date
+   * Sets the status of a customer file to 'exported' and sets exportedAt to the current date
    */
   static async _setExportedStatusAndDate (customerFile) {
     await customerFile.$query()
       .patch({
         status: 'exported',
-        exportDate: new Date().toISOString()
+        exportedAt: new Date()
       })
   }
 

--- a/db/migrations/20210421110628_alter_customer_files.js
+++ b/db/migrations/20210421110628_alter_customer_files.js
@@ -7,7 +7,7 @@ exports.up = async function (knex) {
     .schema
     .alterTable(tableName, table => {
       table.string('status').notNullable().defaultTo('initialised')
-      table.date('export_date')
+      table.dateTime('exported_at')
     })
 }
 
@@ -17,7 +17,7 @@ exports.down = async function (knex) {
     .alterTable(tableName, table => {
       table.dropColumns(
         'status',
-        'export_date'
+        'exported_at'
       )
     })
 }

--- a/db/migrations/20210421110628_alter_customer_files.js
+++ b/db/migrations/20210421110628_alter_customer_files.js
@@ -1,0 +1,23 @@
+'use strict'
+
+const tableName = 'customer_files'
+
+exports.up = async function (knex) {
+  await knex
+    .schema
+    .alterTable(tableName, table => {
+      table.string('status').notNullable().defaultTo('initialised')
+      table.date('export_date')
+    })
+}
+
+exports.down = async function (knex) {
+  await knex
+    .schema
+    .alterTable(tableName, table => {
+      table.dropColumns(
+        'status',
+        'export_date'
+      )
+    })
+}

--- a/test/services/send_customer_file.service.test.js
+++ b/test/services/send_customer_file.service.test.js
@@ -122,7 +122,7 @@ describe('Send Customer File service', () => {
         })
       })
 
-      describe('it creates an entry in the customer_files table', () => {
+      describe("and the 'customer_files' record it creates", () => {
         it('has the correct details', async () => {
           const customerFile = await CustomerFileModel.query().first()
 
@@ -131,7 +131,7 @@ describe('Send Customer File service', () => {
           expect(customerFile.fileReference).to.equal('nalac50001')
         })
 
-        it("sets the status to 'pending' during file generaton", async () => {
+        it("sets its status to 'pending' during file generation", async () => {
           /**
            * Iterate over each query call to get the underlying SQL query:
            *   .getCall gives us the given call
@@ -152,13 +152,13 @@ describe('Send Customer File service', () => {
           expect(queries.length).to.equal(1)
         })
 
-        it("sets the status to 'exported' after exporting", async () => {
+        it("sets its status to 'exported' after exporting", async () => {
           const customerFile = await CustomerFileModel.query().first()
 
           expect(customerFile.status).to.equal('exported')
         })
 
-        it('sets the date after exporting', async () => {
+        it('sets its date after exporting', async () => {
           const customerFile = await CustomerFileModel.query().first()
           const exportedDate = new Date(customerFile.exportedAt)
 
@@ -232,8 +232,8 @@ describe('Send Customer File service', () => {
         })
       })
 
-      describe('it creates an entry in the customer_files table', () => {
-        it('has the correct details', async () => {
+      describe("and the 'customer_files' record it creates", () => {
+        it('have the correct details', async () => {
           const customerFiles = await CustomerFileModel.query()
 
           expect(customerFiles[0].regimeId).to.equal(regime.id)
@@ -245,7 +245,7 @@ describe('Send Customer File service', () => {
           expect(customerFiles[1].fileReference).to.equal('nalwc50001')
         })
 
-        it("sets the status to 'pending' during file generaton", async () => {
+        it("have a status of 'pending' during file generation", async () => {
           /**
            * Iterate over each query call to get the underlying SQL query:
            *   .getCall gives us the given call
@@ -266,14 +266,14 @@ describe('Send Customer File service', () => {
           expect(queries.length).to.equal(2)
         })
 
-        it("sets the status to 'exported' after exporting", async () => {
+        it("have a status of 'exported' after exporting", async () => {
           const customerFiles = await CustomerFileModel.query()
 
           expect(customerFiles[0].status).to.equal('exported')
           expect(customerFiles[1].status).to.equal('exported')
         })
 
-        it('sets the date after exporting', async () => {
+        it('have the date set after exporting', async () => {
           const customerFiles = await CustomerFileModel.query()
           const exportedDates = customerFiles.map(file => new Date(file.exportedAt))
 
@@ -333,8 +333,8 @@ describe('Send Customer File service', () => {
         })
       })
 
-      describe('it creates an entry in the customer_files table', () => {
-        it('has the correct details', async () => {
+      describe("and the 'customer_files' records it creates", () => {
+        it('have the correct details', async () => {
           const customerFiles = await CustomerFileModel.query()
 
           expect(customerFiles[0].regimeId).to.equal(regime.id)
@@ -346,7 +346,7 @@ describe('Send Customer File service', () => {
           expect(customerFiles[1].fileReference).to.equal('nalwc50001')
         })
 
-        it("sets the status to 'pending' during file generaton", async () => {
+        it("have a status of 'pending' during file generation", async () => {
           /**
            * Iterate over each query call to get the underlying SQL query:
            *   .getCall gives us the given call
@@ -367,14 +367,14 @@ describe('Send Customer File service', () => {
           expect(queries.length).to.equal(2)
         })
 
-        it("sets the status to 'exported' after exporting", async () => {
+        it("have a status of 'exported' after exporting", async () => {
           const customerFiles = await CustomerFileModel.query()
 
           expect(customerFiles[0].status).to.equal('exported')
           expect(customerFiles[1].status).to.equal('exported')
         })
 
-        it('sets the date after exporting', async () => {
+        it('have the date set after exporting', async () => {
           const customerFiles = await CustomerFileModel.query()
           const exportedDates = customerFiles.map(file => new Date(file.exportedAt))
 

--- a/test/services/send_customer_file.service.test.js
+++ b/test/services/send_customer_file.service.test.js
@@ -160,11 +160,10 @@ describe('Send Customer File service', () => {
 
         it('sets the date after exporting', async () => {
           const customerFile = await CustomerFileModel.query().first()
-          const exportedDate = new Date(customerFile.exportDate)
+          const exportedDate = new Date(customerFile.exportedAt)
 
-          expect(exportedDate.getDate()).to.equal(new Date().getDate())
-          expect(exportedDate.getMonth()).to.equal(new Date().getMonth())
-          expect(exportedDate.getFullYear()).to.equal(new Date().getFullYear())
+          expect(exportedDate).to.be.a.date()
+          expect(compareDateToNow(exportedDate)).to.be.true()
         })
       })
     })
@@ -276,14 +275,12 @@ describe('Send Customer File service', () => {
 
         it('sets the date after exporting', async () => {
           const customerFiles = await CustomerFileModel.query()
-          const exportedDates = customerFiles.map(file => new Date(file.exportDate))
+          const exportedDates = customerFiles.map(file => new Date(file.exportedAt))
 
-          expect(exportedDates[0].getDate()).to.equal(new Date().getDate())
-          expect(exportedDates[0].getMonth()).to.equal(new Date().getMonth())
-          expect(exportedDates[0].getFullYear()).to.equal(new Date().getFullYear())
-          expect(exportedDates[1].getDate()).to.equal(new Date().getDate())
-          expect(exportedDates[1].getMonth()).to.equal(new Date().getMonth())
-          expect(exportedDates[1].getFullYear()).to.equal(new Date().getFullYear())
+          for (const date of exportedDates) {
+            expect(date).to.be.a.date()
+            expect(compareDateToNow(date)).to.be.true()
+          }
         })
       })
     })
@@ -379,14 +376,12 @@ describe('Send Customer File service', () => {
 
         it('sets the date after exporting', async () => {
           const customerFiles = await CustomerFileModel.query()
-          const exportedDates = customerFiles.map(file => new Date(file.exportDate))
+          const exportedDates = customerFiles.map(file => new Date(file.exportedAt))
 
-          expect(exportedDates[0].getDate()).to.equal(new Date().getDate())
-          expect(exportedDates[0].getMonth()).to.equal(new Date().getMonth())
-          expect(exportedDates[0].getFullYear()).to.equal(new Date().getFullYear())
-          expect(exportedDates[1].getDate()).to.equal(new Date().getDate())
-          expect(exportedDates[1].getMonth()).to.equal(new Date().getMonth())
-          expect(exportedDates[1].getFullYear()).to.equal(new Date().getFullYear())
+          for (const date of exportedDates) {
+            expect(date).to.be.a.date()
+            expect(compareDateToNow(date)).to.be.true()
+          }
         })
       })
     })
@@ -421,4 +416,11 @@ describe('Send Customer File service', () => {
       expect(notifierFake.omfg.firstArg).to.equal('Error sending customer file')
     })
   })
+
+  /**
+   * Compares a date/time object to the current date/time and returns true if they are within a second of each other.
+   */
+  function compareDateToNow (date) {
+    return new Date() - date.getTime() < 1000
+  }
 })


### PR DESCRIPTION
https://trello.com/c/LwTT9wKp/1948-m-develop-generate-customer-files-audit-table-v2

When generation of a customer file is initiated, we want to add a record of the file to the `customer_files` table with a default status of `initialised`, then set the status to `pending` once file generation begins. If file generation is successful then we set the status to `exported` and set `export_date` to the current date/time.

This change adds `status` and `export_date` columns to the `customer_files` table, and updates the send customer file process to populate the table accordingly.

Note that this change does not yet include additional validation to ensure that the customer file isn't already being generated; this will be added in a future PR.