### PR TITLE
Fix POST /customer-changes response code

### DIFF
--- a/app/controllers/presroc/customer_details.controller.js
+++ b/app/controllers/presroc/customer_details.controller.js
@@ -6,7 +6,7 @@ class PresrocCustomerDetailsController {
   static async create (req, h) {
     await CreateCustomerDetailsService.go(req.payload, req.app.regime)
 
-    return h.response().code(204)
+    return h.response().code(201)
   }
 }
 

--- a/test/controllers/presroc/customer_details.controller.test.js
+++ b/test/controllers/presroc/customer_details.controller.test.js
@@ -65,7 +65,7 @@ describe('Customer Details controller', () => {
         // We can pass an empty payload as we've stubbed the service
         const response = await server.inject(options(authToken, {}))
 
-        expect(response.statusCode).to.equal(204)
+        expect(response.statusCode).to.equal(201)
       })
     })
   })


### PR DESCRIPTION
We have just spotted that the response code when a customer change is posted to `/v2/wrls/customer-changes` is `204`. Our convention is to use `201` for our `POST` endpoints as we are creating new records.

This is a fault of the [Swagger docs](https://app.swaggerhub.com/apis-docs/sro/sroc-charging-module-api/draft) which also say the response will be a 204 no doubt because we copy and pasted them from the V1 docs!