### PR TITLE
Fix SendCustomerFileService error logging

### DIFF
--- a/app/services/send_customer_file.service.js
+++ b/app/services/send_customer_file.service.js
@@ -54,6 +54,8 @@ class SendCustomerFileService {
         if (this._removeTemporaryFiles()) {
           await DeleteFileService.go(generatedFile)
         }
+
+        notifier.omg('Completed sending customer file', { regime: regime.slug, region, generatedFile })
       } catch (error) {
         notifier.omfg(
           `Error sending customer file for ${regime.slug} ${region}`,

--- a/app/services/send_customer_file.service.js
+++ b/app/services/send_customer_file.service.js
@@ -55,7 +55,10 @@ class SendCustomerFileService {
           await DeleteFileService.go(generatedFile)
         }
       } catch (error) {
-        notifier.omfg('Error sending customer file', { generatedFile, error })
+        notifier.omfg(
+          `Error sending customer file for ${regime.slug} ${region}`,
+          { regime: regime.slug, region, generatedFile, error }
+        )
       }
     }
   }

--- a/test/services/send_customer_file.service.test.js
+++ b/test/services/send_customer_file.service.test.js
@@ -261,7 +261,7 @@ describe('Send Customer File service', () => {
       await SendCustomerFileService.go(regime, ['A'], notifierFake)
 
       expect(notifierFake.omfg.callCount).to.equal(1)
-      expect(notifierFake.omfg.firstArg).to.equal('Error sending customer file')
+      expect(notifierFake.omfg.firstArg).to.equal(`Error sending customer file for ${regime.slug} A`)
     })
   })
 })

--- a/test/services/send_customer_file.service.test.js
+++ b/test/services/send_customer_file.service.test.js
@@ -60,8 +60,8 @@ describe('Send Customer File service', () => {
     sendStub = Sinon.stub(SendFileToS3Service, 'go').returns(true)
     Sinon.stub(NextCustomerFileReferenceService, 'go').callsFake((_, region) => `nal${region.toLowerCase()}c50001`)
 
-    // Create a fake function to stand in place of Notifier.omfg()
-    notifierFake = { omfg: Sinon.fake() }
+    // Create fake functions to stand in place of Notifier.omg() and Notifier.omfg()
+    notifierFake = { omg: Sinon.fake(), omfg: Sinon.fake() }
   })
 
   afterEach(() => {
@@ -71,7 +71,7 @@ describe('Send Customer File service', () => {
   describe('When a single region is specified', () => {
     describe('and a customer file is required', () => {
       beforeEach(async () => {
-        await SendCustomerFileService.go(regime, ['A'])
+        await SendCustomerFileService.go(regime, ['A'], notifierFake)
       })
 
       it('generates a customer file', async () => {
@@ -122,7 +122,7 @@ describe('Send Customer File service', () => {
 
     describe("and a customer file isn't required", () => {
       beforeEach(async () => {
-        await SendCustomerFileService.go(regime, ['X'])
+        await SendCustomerFileService.go(regime, ['X'], notifierFake)
       })
 
       it("doesn't try to generate a file", async () => {
@@ -138,7 +138,7 @@ describe('Send Customer File service', () => {
   describe('When multiple regions are specified', () => {
     describe('and a customer file is required for each region', () => {
       beforeEach(async () => {
-        await SendCustomerFileService.go(regime, ['A', 'W'])
+        await SendCustomerFileService.go(regime, ['A', 'W'], notifierFake)
       })
 
       it('generates a customer file', async () => {
@@ -187,7 +187,7 @@ describe('Send Customer File service', () => {
 
     describe('and a customer file is only required for some regions', () => {
       beforeEach(async () => {
-        await SendCustomerFileService.go(regime, ['A', 'B', 'W'])
+        await SendCustomerFileService.go(regime, ['A', 'B', 'W'], notifierFake)
       })
 
       it('generates all required customer files', async () => {
@@ -236,7 +236,7 @@ describe('Send Customer File service', () => {
 
     describe("and a customer file isn't required for any region", () => {
       beforeEach(async () => {
-        await SendCustomerFileService.go(regime, ['X', 'Y'])
+        await SendCustomerFileService.go(regime, ['X', 'Y'], notifierFake)
       })
 
       it("doesn't try to generate a file", async () => {


### PR DESCRIPTION
https://trello.com/c/Nu0BAjJE

Whilst looking to [Add generate customer file task](https://github.com/DEFRA/sroc-charging-module-api/pull/370) we came across some odd behaviour.

We are working on a new `TaskNotifier` intended for use outside of a Hapi request. To confirm it was working as expected we introduced an error into the `SendCustomerFileService` as it processed each regime. So, we should have seen 4 errors reported to Errbit but we only saw 1.

After much (_much_ 😩) digging we tracked down the problem. Airbrake runs each 'notification' through a series of filters before deciding whether to forward it on. We were falling foul of a check which looks to see if the same error has been reported in the last 1000ms. In our case it had.

```javascript
    let s = JSON.stringify(notice.errors);
    if (s === lastNoticeJSON) {
      return null;
    }
```

_https://github.com/airbrake/airbrake-js/blob/master/packages/browser/src/filter/debounce.ts for the filter and https://github.com/airbrake/airbrake-js/blob/a1663636301e256c61480306ce92f512f8075bed/packages/browser/src/base_notifier.ts#L153-L160 for where it's checked in the `notify()` call._

It ignores the additional data we add which in our case makes each error unique. So, we have fallen foul of our attempts to ensure errors are _not_ distinct to allow for easier grouping in Errbit 🤦.

In most places that convention is still fine. It's just in this case there is a possibility that errors are generated for each region, or across the 4 regimes in a process that takes less than 1000 in total.

So, this change tweaks our messages to make them distinct for each iteration.