### PR TITLE
Fix - add client ID back into conflict response

### DIFF
--- a/app/services/db_errors.service.js
+++ b/app/services/db_errors.service.js
@@ -50,19 +50,22 @@ class DbErrorsService {
   }
 
   static _uniqueViolationError (error, data) {
-    let message
+    let boomError
 
     if (error.constraint === 'transactions_regime_id_client_id_unique') {
-      const regimeId = data.params.regimeId
-      message = `A transaction with Client ID '${data.payload.clientId}' for Regime '${regimeId}' already exists.`
+      boomError = new Boom.Boom(
+        `A transaction with Client ID '${data.payload.clientId}' for Regime '${data.params.regimeId}' already exists.`,
+        { statusCode: 409 }
+      )
+      boomError.output.payload.clientId = data.payload.clientId
     } else {
-      message = `${error.name} - ${error.nativeError.detail}`
+      boomError = new Boom.Boom(
+        `${error.name} - ${error.nativeError.detail}`,
+        { statusCode: 409 }
+      )
     }
 
-    return new Boom.Boom(
-      message,
-      { statusCode: 409 }
-    )
+    return boomError
   }
 
   static _dbError (error) {

--- a/test/services/db_errors.service.test.js
+++ b/test/services/db_errors.service.test.js
@@ -50,7 +50,7 @@ describe('Db Errors service', () => {
       })
 
       describe('specifically a duplicate client Id for the same regime', () => {
-        it("returns a '409' Boom error with a tailored message", () => {
+        it("returns a '409' Boom error with a tailored response", () => {
           const args = {
             client: 'postgresql',
             constraint: 'transactions_regime_id_client_id_unique',
@@ -74,6 +74,7 @@ describe('Db Errors service', () => {
           expect(result.output.payload.message).to.equal(
             "A transaction with Client ID 'DOUBLEIMPACT' for Regime 'wrls' already exists."
           )
+          expect(result.output.payload.clientId).to.equal('DOUBLEIMPACT')
         })
       })
     })


### PR DESCRIPTION
Client systems when adding transactions can include a `clientId` property. This can be whatever they like, as long as it's unique for transactions in that regime. It's intended to be used for the client system to include _their_ transaction ID so they can ensure they don't accidentally duplicate a charge.

This was something we added into [V1 of the API](https://github.com/charging-module-api) to give client systems more confidence when re-trying failed transaction entries. In V1 it was completely custom and relied on us querying the DB first for a matching transaction. If found we then sent our own custom response.

```json
{
  "id": "5ee921b3-3ab2-45ea-98b4-7d82ece0267a",
  "clientId": "1234567890"
}
```

In V2 we no longer query for a matching transaction first. Instead, we rely on a DB constraint that will error when we attempt to save the record if there is a duplicate `client_id` for the same regime. This is one of the ways we have made adding a transaction faster than V1, even though we're doing more (i.e. creating and updating invoice and licence records).

The error message we return does include the problem client ID. But because we are now relying on Hapi boom to catch and 'boomify' the error, it is contained in the error message which isn't as easy to parse by a client system.

```json
{
  "statusCode": 409,
  "error": "Conflict",
  "message": "A transaction with Client ID '1234567890' for Regime 'wrls' already exists."
}
```

This change is an attempt to fix the response to bring it more in line with V1. We are limited though.

First, because we are relying on the DB firing an error instead of querying the DB ourselves it means we lose the ID of the CM transaction with the matching client ID. Without slowing down all `POST` transactions, or adding lots more logic into this error trapping process there is just no way to get it.

Second, we are relying on Boom to provide the error, and it limits just how much we can modify the response. To quote

> **How do I include extra information in my responses? output.payload is missing data, what gives?**
> There is a reason the values passed back in the response payloads are pretty locked down. It's mostly for security and to not leak any important information back to the client. This means you will need to put in a little more effort to include extra information about your custom error.

So this change alters the behaviour of the `DbErrorsService` to allow us to add the clientId to the create transaction 409 response.

```json
{
  "statusCode": 409,
  "error": "Conflict",
  "message": "A transaction with Client ID '1234567890' for Regime 'wrls' already exists.",
  "clientId": "1234567890"
}
```