### PR TITLE
Add customer files test endpoint

### DIFF
--- a/app/controllers/admin/test/test_customer_files.controller.js
+++ b/app/controllers/admin/test/test_customer_files.controller.js
@@ -1,0 +1,13 @@
+'use strict'
+
+const { ListCustomerFilesService } = require('../../../services')
+
+class TestCustomerFilesController {
+  static async index (req, h) {
+    const result = await ListCustomerFilesService.go(req.app.regime)
+
+    return h.response(result).code(200)
+  }
+}
+
+module.exports = TestCustomerFilesController

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -8,6 +8,7 @@ const AirbrakeController = require('./admin/health/airbrake.controller')
 const CustomersController = require('./admin/customers.controller')
 const DatabaseController = require('./admin/health/database.controller')
 const TestBillRunsController = require('./admin/test/test_bill_runs.controller')
+const TestCustomerFilesController = require('./admin/test/test_customer_files.controller')
 const TestTransactionsController = require('./admin/test/test_transactions.controller')
 const NotSupportedController = require('./not_supported.controller')
 const PresrocBillRunsController = require('./presroc/bill_runs.controller')
@@ -24,6 +25,7 @@ module.exports = {
   CustomersController,
   DatabaseController,
   TestBillRunsController,
+  TestCustomerFilesController,
   TestTransactionsController,
   PresrocBillRunsController,
   PresrocCalculateChargeController,

--- a/app/routes/test.routes.js
+++ b/app/routes/test.routes.js
@@ -2,6 +2,7 @@
 
 const {
   TestBillRunsController,
+  TestCustomerFilesController,
   TestTransactionsController
 } = require('../controllers')
 
@@ -23,6 +24,17 @@ const routes = [
     handler: TestTransactionsController.show,
     options: {
       description: "Used by the delivery team to check all a transaction's data.",
+      auth: {
+        scope: ['admin']
+      }
+    }
+  },
+  {
+    method: 'GET',
+    path: '/admin/test/{regimeId}/customer-files',
+    handler: TestCustomerFilesController.index,
+    options: {
+      description: 'Used by the delivery team to list all customer files for a regime.',
       auth: {
         scope: ['admin']
       }

--- a/app/services/index.js
+++ b/app/services/index.js
@@ -25,6 +25,7 @@ const GenerateBillRunValidationService = require('./generate_bill_run_validation
 const GenerateCustomerFileService = require('./generate_customer_file.service')
 const GenerateTransactionFileService = require('./generate_transaction_file.service')
 const ListAuthorisedSystemsService = require('./list_authorised_systems.service')
+const ListCustomerFilesService = require('./list_customer_files.service')
 const ListRegimesService = require('./list_regimes.service')
 const MoveCustomersToExportedTableService = require('./move_customers_to_exported_table.service')
 const NextBillRunNumberService = require('./next_bill_run_number.service')
@@ -76,6 +77,7 @@ module.exports = {
   GenerateCustomerFileService,
   GenerateTransactionFileService,
   ListAuthorisedSystemsService,
+  ListCustomerFilesService,
   ListRegimesService,
   ObjectCleaningService,
   RequestBillRunService,

--- a/app/services/list_customer_files.service.js
+++ b/app/services/list_customer_files.service.js
@@ -1,0 +1,38 @@
+'use strict'
+
+/**
+ * @module ListCustomerFilesService
+ */
+
+const { CustomerFileModel } = require('../models')
+const { JsonPresenter } = require('../presenters')
+
+class ListCustomerFilesService {
+  /**
+   * Returns a JSON array of customer files
+   *
+   * @param {module:RegimeModel} regime Instance of `RegimeModel` representing the regime we are listing customer files
+   * for
+   *
+   * @returns {module:CustomerFileModel[]} an array of `CustomerFileModel` based on customer files currently in the database
+   */
+  static async go (regime) {
+    const customerFiles = await this._customerFiles(regime.id)
+
+    return this._response(customerFiles)
+  }
+
+  static _customerFiles (regimeId) {
+    return CustomerFileModel
+      .query()
+      .where('regimeId', regimeId)
+  }
+
+  static _response (customerFiles) {
+    const presenter = new JsonPresenter(customerFiles)
+
+    return presenter.go()
+  }
+}
+
+module.exports = ListCustomerFilesService

--- a/test/controllers/admin/test/test_customer_files.controller.test.js
+++ b/test/controllers/admin/test/test_customer_files.controller.test.js
@@ -1,0 +1,92 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, before, beforeEach, after } = exports.lab = Lab.script()
+const { expect } = Code
+
+// For running our service
+const { deployment } = require('../../../../server')
+
+// Test helpers
+const {
+  AuthorisationHelper,
+  AuthorisedSystemHelper,
+  DatabaseHelper,
+  GeneralHelper
+} = require('../../../support/helpers')
+
+// Things we need to stub
+const JsonWebToken = require('jsonwebtoken')
+const { ListCustomerFilesService } = require('../../../../app/services')
+
+describe('Test customer files controller', () => {
+  let server
+  let authToken
+  let regime
+
+  before(async () => {
+    server = await deployment()
+    authToken = AuthorisationHelper.adminToken()
+
+    Sinon
+      .stub(JsonWebToken, 'verify')
+      .returns(AuthorisationHelper.decodeToken(authToken))
+  })
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+
+    const authSystem = await AuthorisedSystemHelper.addAdminSystem()
+    const regimes = await authSystem.$relatedQuery('regimes')
+    regime = regimes.filter(r => r.slug === 'wrls')[0]
+  })
+
+  after(async () => {
+    Sinon.restore()
+  })
+
+  describe('Listing customer files: GET /admin/test/customer-files', () => {
+    const options = (regime, token) => {
+      return {
+        method: 'GET',
+        url: `/admin/test/${regime.slug}/customer-files`,
+        headers: { authorization: `Bearer ${token}` }
+      }
+    }
+
+    describe('When there are customer files', () => {
+      beforeEach(async () => {
+        Sinon.stub(ListCustomerFilesService, 'go').returns([
+          {
+            id: GeneralHelper.uuid4(),
+            regimeId: regime.id,
+            region: 'A',
+            fileReference: 'nalac50001',
+            status: 'exported'
+          },
+          {
+            id: GeneralHelper.uuid4(),
+            regimeId: regime.id,
+            region: 'A',
+            fileReference: 'nalac50002',
+            status: 'pending'
+          }
+        ])
+      })
+
+      it('returns a list of customer files', async () => {
+        const response = await server.inject(options(regime, authToken))
+
+        const payload = JSON.parse(response.payload)
+
+        expect(response.statusCode).to.equal(200)
+        expect(payload.length).to.equal(2)
+        expect(payload[1].fileReference).to.equal('nalac50002')
+      })
+    })
+  })
+})

--- a/test/services/list_customer_files.service.test.js
+++ b/test/services/list_customer_files.service.test.js
@@ -1,0 +1,70 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const { DatabaseHelper, CustomerHelper, RegimeHelper } = require('../support/helpers')
+
+// Thing under test
+const { ListCustomerFilesService } = require('../../app/services')
+
+describe('List Customer Files service', () => {
+  let regime
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+
+    regime = await RegimeHelper.addRegime('ice', 'Ice')
+  })
+
+  describe('When there are no customer files', () => {
+    describe('for the requested regime', () => {
+      beforeEach(async () => {
+        await CustomerHelper.addCustomerFile()
+      })
+
+      it('returns an empty array', async () => {
+        const result = await ListCustomerFilesService.go(regime)
+
+        expect(result).to.equal([])
+      })
+    })
+
+    it('returns an empty array', async () => {
+      const result = await ListCustomerFilesService.go(regime)
+
+      expect(result).to.equal([])
+    })
+  })
+
+  describe('When there are customer files', () => {
+    describe('for the requested regime', () => {
+      beforeEach(async () => {
+        await CustomerHelper.addCustomerFile(regime, 'A', 'nalac50001')
+        await CustomerHelper.addCustomerFile(regime, 'A', 'nalac50002')
+
+        const otherRegime = await RegimeHelper.addRegime('wind', 'Wind')
+        await CustomerHelper.addCustomerFile(otherRegime, 'A', 'balac50001')
+      })
+
+      it('returns them', async () => {
+        const result = await ListCustomerFilesService.go(regime)
+
+        expect(result.length).to.equal(2)
+        expect(result[1].fileReference).to.equal('nalac50002')
+      })
+
+      it('does not returns records for other regimes', async () => {
+        const result = await ListCustomerFilesService.go(regime)
+        const filteredResults = result.filter(file => file.fileReference === 'balac50001')
+
+        expect(filteredResults).to.be.empty()
+      })
+    })
+  })
+})

--- a/test/services/list_customer_files.service.test.js
+++ b/test/services/list_customer_files.service.test.js
@@ -35,10 +35,12 @@ describe('List Customer Files service', () => {
       })
     })
 
-    it('returns an empty array', async () => {
-      const result = await ListCustomerFilesService.go(regime)
+    describe('for any regimes', () => {
+      it('returns an empty array', async () => {
+        const result = await ListCustomerFilesService.go(regime)
 
-      expect(result).to.equal([])
+        expect(result).to.equal([])
+      })
     })
   })
 

--- a/test/support/helpers/customer.helper.js
+++ b/test/support/helpers/customer.helper.js
@@ -1,0 +1,50 @@
+'use strict'
+
+const { CustomerFileModel } = require('../../../app/models')
+const GeneralHelper = require('./general.helper')
+
+/**
+ * Use to help with creating customer records, for example, 'CustomerFiles'
+ */
+class CustomerFileHelper {
+  /**
+   * Create a `customer_file` record
+   *
+   * @param {module:RegimeModel} [regime] Instance of `RegimeModel` to assign  the customer file to. If nulll it will
+   * generate a random UUID and use that instead
+   * @param {string} [region] Region to use. Defaults to 'A'
+   * @param {string} [fileReference] File reference to use. Defaults to 'nalac50001'
+   * @param {string} [status] Status to use. Defaults to 'exported'. If set to `exported` it will also default
+   * `exported_at` to `Date.now()`
+   *
+   * @returns {module:CustomerFileModel} The newly created instance of `CustomerFileModel`
+   */
+  static addCustomerFile (regime = null, region = 'A', fileReference = 'nalac50001', status = 'exported') {
+    return CustomerFileModel.query()
+      .insert({
+        regimeId: this._regimeId(regime),
+        region,
+        fileReference,
+        exportedAt: this._exportedAt(status)
+      })
+      .returning('*')
+  }
+
+  static _regimeId (regime) {
+    if (!regime) {
+      return GeneralHelper.uuid4()
+    }
+
+    return regime.id
+  }
+
+  static _exportedAt (status) {
+    if (status === 'exported') {
+      return new Date().toISOString()
+    }
+
+    return null
+  }
+}
+
+module.exports = CustomerFileHelper

--- a/test/support/helpers/customer.helper.js
+++ b/test/support/helpers/customer.helper.js
@@ -31,11 +31,7 @@ class CustomerFileHelper {
   }
 
   static _regimeId (regime) {
-    if (!regime) {
-      return GeneralHelper.uuid4()
-    }
-
-    return regime.id
+    return regime?.id ?? GeneralHelper.uuid4()
   }
 
   static _exportedAt (status) {

--- a/test/support/helpers/customer.helper.js
+++ b/test/support/helpers/customer.helper.js
@@ -10,7 +10,7 @@ class CustomerFileHelper {
   /**
    * Create a `customer_file` record
    *
-   * @param {module:RegimeModel} [regime] Instance of `RegimeModel` to assign  the customer file to. If nulll it will
+   * @param {module:RegimeModel} [regime] Instance of `RegimeModel` to assign the customer file to. If null it will
    * generate a random UUID and use that instead
    * @param {string} [region] Region to use. Defaults to 'A'
    * @param {string} [fileReference] File reference to use. Defaults to 'nalac50001'

--- a/test/support/helpers/customer.helper.js
+++ b/test/support/helpers/customer.helper.js
@@ -37,5 +37,6 @@ class CustomerFileHelper {
   static _exportedAt (status) {
     return status === 'exported' ? new Date().toISOString() : null
   }
+}
 
 module.exports = CustomerFileHelper

--- a/test/support/helpers/customer.helper.js
+++ b/test/support/helpers/customer.helper.js
@@ -35,12 +35,7 @@ class CustomerFileHelper {
   }
 
   static _exportedAt (status) {
-    if (status === 'exported') {
-      return new Date().toISOString()
-    }
-
-    return null
+    return status === 'exported' ? new Date().toISOString() : null
   }
-}
 
 module.exports = CustomerFileHelper

--- a/test/support/helpers/index.js
+++ b/test/support/helpers/index.js
@@ -3,6 +3,7 @@
 const AuthorisationHelper = require('./authorisation.helper')
 const AuthorisedSystemHelper = require('./authorised_system.helper')
 const BillRunHelper = require('./bill_run.helper')
+const CustomerHelper = require('./customer.helper')
 const DatabaseHelper = require('./database.helper')
 const GeneralHelper = require('./general.helper')
 const InvoiceHelper = require('./invoice.helper')
@@ -19,6 +20,7 @@ module.exports = {
   AuthorisationHelper,
   AuthorisedSystemHelper,
   BillRunHelper,
+  CustomerHelper,
   DatabaseHelper,
   GeneralHelper,
   InvoiceHelper,


### PR DESCRIPTION
https://trello.com/c/h5nxl1FS

In [V1 of the API](https://github.com/DEFRA/charging-module-api) an endpoint had been provided that allowed the QA team to see the customer file audit records.

They'd like the same endpoint in V2 so this change adds it.

There will be some changes though

- like the `GET /admin` regimes and authorised systems endpoints, and the `GET /admin/test/transactions` endpoint we intend to just return the data raw
- like those endpoints, there will be no filtering (certainly in this initial version)
- like those endpoints we'll include any child records automatically