### PR TITLE
Move Customers To Exported Table service

### DIFF
--- a/app/models/exported_customer.model.js
+++ b/app/models/exported_customer.model.js
@@ -1,13 +1,13 @@
 'use strict'
 
 /**
- * @module CustomerModel
+ * @module ExportedCustomerModel
  */
 
 const { Model } = require('objection')
 const BaseModel = require('./base.model')
 
-class CustomerModel extends BaseModel {
+class ExportedCustomerModel extends BaseModel {
   static get tableName () {
     return 'exported_customers'
   }
@@ -26,4 +26,4 @@ class CustomerModel extends BaseModel {
   }
 }
 
-module.exports = CustomerModel
+module.exports = ExportedCustomerModel

--- a/app/models/exported_customer.model.js
+++ b/app/models/exported_customer.model.js
@@ -1,0 +1,29 @@
+'use strict'
+
+/**
+ * @module CustomerModel
+ */
+
+const { Model } = require('objection')
+const BaseModel = require('./base.model')
+
+class CustomerModel extends BaseModel {
+  static get tableName () {
+    return 'exported_customers'
+  }
+
+  static get relationMappings () {
+    return {
+      customerFile: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: 'customer_file.model',
+        join: {
+          from: 'exported_customers.customerFileId',
+          to: 'customerFiles.id'
+        }
+      }
+    }
+  }
+}
+
+module.exports = CustomerModel

--- a/app/models/index.js
+++ b/app/models/index.js
@@ -5,6 +5,7 @@ const BaseModel = require('./base.model')
 const BillRunModel = require('./bill_run.model')
 const CustomerFileModel = require('./customer_file.model')
 const CustomerModel = require('./customer.model')
+const ExportedCustomerModel = require('./exported_customer.model')
 const InvoiceModel = require('./invoice.model')
 const LicenceModel = require('./licence.model')
 const RegimeModel = require('./regime.model')
@@ -17,6 +18,7 @@ module.exports = {
   BillRunModel,
   CustomerFileModel,
   CustomerModel,
+  ExportedCustomerModel,
   InvoiceModel,
   LicenceModel,
   RegimeModel,

--- a/app/services/index.js
+++ b/app/services/index.js
@@ -26,6 +26,7 @@ const GenerateCustomerFileService = require('./generate_customer_file.service')
 const GenerateTransactionFileService = require('./generate_transaction_file.service')
 const ListAuthorisedSystemsService = require('./list_authorised_systems.service')
 const ListRegimesService = require('./list_regimes.service')
+const MoveCustomersToExportedTableService = require('./move_customers_to_exported_table.service')
 const NextBillRunNumberService = require('./next_bill_run_number.service')
 const NextCustomerFileReferenceService = require('./next_customer_file_reference.service')
 const NextTransactionFileReferenceService = require('./next_transaction_file_reference.service')
@@ -79,6 +80,7 @@ module.exports = {
   ObjectCleaningService,
   RequestBillRunService,
   RulesService,
+  MoveCustomersToExportedTableService,
   NextBillRunNumberService,
   NextCustomerFileReferenceService,
   NextTransactionFileReferenceService,

--- a/app/services/move_customers_to_exported_table.service.js
+++ b/app/services/move_customers_to_exported_table.service.js
@@ -1,0 +1,53 @@
+'use strict'
+
+/**
+ * @module MoveCustomersToExportedTableService
+ */
+
+const { CustomerModel, ExportedCustomerModel } = require('../models')
+
+class MoveCustomersToExportedTableService {
+  /**
+   * Adds customers to the `exported_customers` table and deletes them from the `customers` table.
+   *
+   * @param {*} regime The regime of the customers to be moved.
+   * @param {*} region The region of the customers to be moved.
+   * @param {*} customerFileId The id of the file to be recorded against each customer in `exported_customers`.
+   */
+  static async go (regime, region, customerFileId) {
+    await CustomerModel.transaction(async trx => {
+      const customerQuery = this._selectCustomers(regime, region, trx)
+
+      await this._populateExportedTable(customerQuery, customerFileId, trx)
+      await this._clearCustomerTable(customerQuery)
+    })
+  }
+
+  static _selectCustomers (regime, region, trx) {
+    return CustomerModel.query(trx)
+      .where('regimeId', regime.id)
+      .where('region', region)
+      .select('id', 'customerReference')
+  }
+
+  /**
+   * Executes the query, iterates over the results and adds each customer to the `exported_customer` table
+   */
+  static async _populateExportedTable (customerQuery, customerFileId, trx) {
+    const customers = await customerQuery
+    for (const customer of customers) {
+      const { customerReference } = customer
+      await ExportedCustomerModel.query(trx)
+        .insert({
+          customerReference,
+          customerFileId
+        })
+    }
+  }
+
+  static async _clearCustomerTable (customerQuery) {
+    await customerQuery.delete()
+  }
+}
+
+module.exports = MoveCustomersToExportedTableService

--- a/test/services/move_customers_to_exported_table.service.test.js
+++ b/test/services/move_customers_to_exported_table.service.test.js
@@ -1,0 +1,84 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const { DatabaseHelper, RegimeHelper } = require('../support/helpers')
+const { CustomerModel, CustomerFileModel, ExportedCustomerModel } = require('../../app/models')
+const { CreateCustomerDetailsService } = require('../../app/services')
+
+// Thing under test
+const { MoveCustomersToExportedTableService } = require('../../app/services')
+
+describe('Move Customers To Exported Table service', () => {
+  let regime
+  let customerFile
+
+  const payload = {
+    region: 'A',
+    customerReference: 'AB12345678',
+    customerName: 'CUSTOMER_NAME',
+    addressLine1: 'ADDRESS_LINE_1',
+    addressLine2: 'ADDRESS_LINE_2',
+    addressLine3: 'ADDRESS_LINE_3',
+    addressLine4: 'ADDRESS_LINE_4',
+    addressLine5: 'ADDRESS_LINE_5',
+    addressLine6: 'ADDRESS_LINE_6',
+    postcode: 'POSTCODE'
+  }
+
+  const fileReference = 'nalwc50003'
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+    regime = await RegimeHelper.addRegime('wrls', 'WRLS')
+    CreateCustomerDetailsService.go(payload, regime)
+
+    customerFile = await CustomerFileModel.query().insert({
+      regimeId: regime.id,
+      region: payload.region,
+      fileReference
+    })
+  })
+
+  describe('When called', () => {
+    it('populates the exported_customers table', async () => {
+      await MoveCustomersToExportedTableService.go(regime, payload.region, customerFile.id)
+
+      const result = await ExportedCustomerModel.query().first()
+
+      expect(result.customerReference).to.equal(payload.customerReference)
+      expect(result.customerFileId).to.equal(customerFile.id)
+    })
+
+    it('clears the customers table', async () => {
+      await MoveCustomersToExportedTableService.go(regime, payload.region, customerFile.id)
+
+      const result = await CustomerModel.query()
+
+      expect(result).to.be.empty()
+    })
+
+    it('only handles customers of the specified regime and region', async () => {
+      const wrongRegime = await RegimeHelper.addRegime('wrng', 'WRNG')
+      CreateCustomerDetailsService.go({ ...payload, customerReference: 'A_WRNG' }, wrongRegime)
+      CreateCustomerDetailsService.go({ ...payload, customerReference: 'W_WRLS', region: 'W' }, regime)
+
+      await MoveCustomersToExportedTableService.go(regime, payload.region, customerFile.id)
+
+      const customers = await CustomerModel.query()
+      expect(customers.length).to.equal(2)
+      expect(customers[0].customerReference).to.equal('A_WRNG')
+      expect(customers[1].customerReference).to.equal('W_WRLS')
+
+      const exportedCustomers = await ExportedCustomerModel.query()
+      expect(exportedCustomers.length).to.equal(1)
+      expect(exportedCustomers[0].customerReference).to.equal(payload.customerReference)
+    })
+  })
+})


### PR DESCRIPTION
https://trello.com/c/LwTT9wKp/1948-m-develop-generate-customer-files-audit-table-v2

This service moves customers for a given regime and region from the `customers` table to the `exported_customers` table:

- It creates an entry in the `exported_customers` table for each customer, adding the `customer_reference` (the only detail we need to record) alongside the id of the customer file they were exported in;
- It deletes the corresponding entries from the `customers` file.