### PR TITLE
Update TaskRunner to use TaskNotifier

### DIFF
--- a/app/tasks/task_runner.js
+++ b/app/tasks/task_runner.js
@@ -4,6 +4,7 @@
  * @module TaskRunner
  */
 
+const { TaskNotifier } = require('../lib')
 const CustomerFilesTask = require('./customer_files.task')
 
 /**
@@ -57,17 +58,7 @@ class TaskRunner {
   }
 
   static _notifier () {
-    return {
-      omg: (message, data = {}) => {
-        console.log(message, data)
-      },
-      omfg: (message, data = {}) => {
-        console.error(message, data)
-      },
-      flush: async () => {
-        console.log('Flushed!')
-      }
-    }
+    return new TaskNotifier()
   }
 }
 


### PR DESCRIPTION
When we added the [customer file task](https://github.com/DEFRA/sroc-charging-module-api/pull/370) we included a temporary implementation for a 'notifier because we knew [Add TaskNotifier and refactor existing Notifier](https://github.com/DEFRA/sroc-charging-module-api/pull/379) was waiting in the wings.

The `TaskNotifier` has now been merged so this change updates the `TaskRunner` to use it.