### PR TITLE
Add test Show customer file endpoint

### DIFF
--- a/app/controllers/admin/test/test_customer_files.controller.js
+++ b/app/controllers/admin/test/test_customer_files.controller.js
@@ -1,10 +1,16 @@
 'use strict'
 
-const { ListCustomerFilesService } = require('../../../services')
+const { ListCustomerFilesService, ShowCustomerFileService } = require('../../../services')
 
 class TestCustomerFilesController {
   static async index (req, h) {
     const result = await ListCustomerFilesService.go(req.app.regime)
+
+    return h.response(result).code(200)
+  }
+
+  static async show (req, h) {
+    const result = await ShowCustomerFileService.go(req.params.id)
 
     return h.response(result).code(200)
   }

--- a/app/models/customer_file.model.js
+++ b/app/models/customer_file.model.js
@@ -22,6 +22,14 @@ class CustomerFileModel extends BaseModel {
           to: 'customers.customerFileId'
         }
       },
+      exportedCustomers: {
+        relation: Model.HasManyRelation,
+        modelClass: 'exported_customer.model',
+        join: {
+          from: 'customerFiles.id',
+          to: 'exportedCustomers.customerFileId'
+        }
+      },
       regime: {
         relation: Model.BelongsToOneRelation,
         modelClass: 'regime.model',

--- a/app/models/customer_file.model.js
+++ b/app/models/customer_file.model.js
@@ -9,7 +9,7 @@ const BaseModel = require('./base.model')
 
 class CustomerFileModel extends BaseModel {
   static get tableName () {
-    return 'customer_files'
+    return 'customerFiles'
   }
 
   static get relationMappings () {

--- a/app/models/exported_customer.model.js
+++ b/app/models/exported_customer.model.js
@@ -9,7 +9,7 @@ const BaseModel = require('./base.model')
 
 class ExportedCustomerModel extends BaseModel {
   static get tableName () {
-    return 'exported_customers'
+    return 'exportedCustomers'
   }
 
   static get relationMappings () {

--- a/app/models/sequence_counter.model.js
+++ b/app/models/sequence_counter.model.js
@@ -9,7 +9,7 @@ const BaseModel = require('./base.model')
 
 class SequenceCounterModel extends BaseModel {
   static get tableName () {
-    return 'sequence_counters'
+    return 'sequenceCounters'
   }
 
   static get relationMappings () {

--- a/app/routes/test.routes.js
+++ b/app/routes/test.routes.js
@@ -39,6 +39,17 @@ const routes = [
         scope: ['admin']
       }
     }
+  },
+  {
+    method: 'GET',
+    path: '/admin/test/customer-files/{id}',
+    handler: TestCustomerFilesController.show,
+    options: {
+      description: 'Used by the delivery team to show a customer file and its exported customers.',
+      auth: {
+        scope: ['admin']
+      }
+    }
   }
 ]
 

--- a/app/services/index.js
+++ b/app/services/index.js
@@ -40,6 +40,7 @@ const SendCustomerFileService = require('./send_customer_file.service')
 const SendFileToS3Service = require('./send_file_to_s3.service')
 const SendTransactionFileService = require('./send_transaction_file.service')
 const ShowAuthorisedSystemService = require('./show_authorised_system.service')
+const ShowCustomerFileService = require('./show_customer_file.service')
 const ShowRegimeService = require('./show_regime.service')
 const ShowTransactionService = require('./show_transaction.service')
 const StreamReadableDataService = require('./streams/stream_readable_data.service')
@@ -92,6 +93,7 @@ module.exports = {
   SendFileToS3Service,
   SendTransactionFileService,
   ShowAuthorisedSystemService,
+  ShowCustomerFileService,
   ShowRegimeService,
   ShowTransactionService,
   StreamReadableDataService,

--- a/app/services/show_customer_file.service.js
+++ b/app/services/show_customer_file.service.js
@@ -1,0 +1,44 @@
+'use strict'
+
+/**
+ * @module ShowCustomerFileService
+ */
+
+const Boom = require('@hapi/boom')
+
+const { CustomerFileModel } = require('../models')
+const { JsonPresenter } = require('../presenters')
+
+/**
+ * Returns the customer file with matching Id
+ *
+ * If no matching customer file is found it will throw a `Boom.notFound()` error (404)
+ *
+ * @param {string} id Id of the customer file to find
+ * @returns {module:CustomerFileModel} a `CustomerFileModel` if found else it will throw a Boom 404 error
+ */
+class ShowCustomerFileService {
+  static async go (id) {
+    const customerFile = await this._customerFile(id)
+
+    if (!customerFile) {
+      throw Boom.notFound(`No customer file found with id ${id}`)
+    }
+
+    return this._response(customerFile)
+  }
+
+  static _customerFile (id) {
+    return CustomerFileModel.query()
+      .findById(id)
+      .withGraphFetched('exportedCustomers')
+  }
+
+  static _response (customerFile) {
+    const presenter = new JsonPresenter(customerFile)
+
+    return presenter.go()
+  }
+}
+
+module.exports = ShowCustomerFileService

--- a/test/services/show_customer_file.service.test.js
+++ b/test/services/show_customer_file.service.test.js
@@ -56,7 +56,7 @@ describe('Show Customer File service', () => {
   })
 
   describe('When an invalid UUID is used', () => {
-    it('returns throws an error', async () => {
+    it('throws an error', async () => {
       const err = await expect(ShowCustomerFileService.go('123456789')).to.reject(DataError)
 
       expect(err).to.be.an.error()

--- a/test/services/show_customer_file.service.test.js
+++ b/test/services/show_customer_file.service.test.js
@@ -47,7 +47,7 @@ describe('Show Customer File service', () => {
   })
 
   describe('When there is no matching customer file', () => {
-    it('returns throws an error', async () => {
+    it('throws an error', async () => {
       const id = GeneralHelper.uuid4()
       const err = await expect(ShowCustomerFileService.go(id)).to.reject(Error, `No customer file found with id ${id}`)
 

--- a/test/services/show_customer_file.service.test.js
+++ b/test/services/show_customer_file.service.test.js
@@ -30,7 +30,7 @@ describe('Show Customer File service', () => {
 
       const result = await ShowCustomerFileService.go(customerFile.id)
 
-      expect(result instanceof CustomerFileModel).to.equal(true)
+      expect(result).to.be.an.instanceOf(CustomerFileModel)
       expect(result.id).to.equal(customerFile.id)
     })
 

--- a/test/services/show_customer_file.service.test.js
+++ b/test/services/show_customer_file.service.test.js
@@ -1,0 +1,65 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const {
+  DatabaseHelper,
+  CustomerHelper,
+  GeneralHelper
+} = require('../support/helpers')
+const { CustomerFileModel } = require('../../app/models')
+const { DataError } = require('objection')
+
+// Thing under test
+const { ShowCustomerFileService } = require('../../app/services')
+
+describe('Show Customer File service', () => {
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+  })
+
+  describe('When there is a matching customer file', () => {
+    it('returns the details for it', async () => {
+      const customerFile = await CustomerHelper.addCustomerFile()
+
+      const result = await ShowCustomerFileService.go(customerFile.id)
+
+      expect(result instanceof CustomerFileModel).to.equal(true)
+      expect(result.id).to.equal(customerFile.id)
+    })
+
+    it('returns a result that includes a list of related exported customers', async () => {
+      const customerFile = await CustomerHelper.addCustomerFile()
+      await CustomerHelper.addExportedCustomer(customerFile, 'BB02BEEB')
+      await CustomerHelper.addExportedCustomer(customerFile, 'CC02BEEB')
+
+      const result = await ShowCustomerFileService.go(customerFile.id)
+
+      expect(result.exportedCustomers.length).to.equal(2)
+      expect(result.exportedCustomers[0].customerReference).to.equal('BB02BEEB')
+    })
+  })
+
+  describe('When there is no matching customer file', () => {
+    it('returns throws an error', async () => {
+      const id = GeneralHelper.uuid4()
+      const err = await expect(ShowCustomerFileService.go(id)).to.reject(Error, `No customer file found with id ${id}`)
+
+      expect(err).to.be.an.error()
+    })
+  })
+
+  describe('When an invalid UUID is used', () => {
+    it('returns throws an error', async () => {
+      const err = await expect(ShowCustomerFileService.go('123456789')).to.reject(DataError)
+
+      expect(err).to.be.an.error()
+    })
+  })
+})

--- a/test/support/helpers/customer.helper.js
+++ b/test/support/helpers/customer.helper.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { CustomerFileModel } = require('../../../app/models')
+const { CustomerFileModel, ExportedCustomerModel } = require('../../../app/models')
 const GeneralHelper = require('./general.helper')
 
 /**
@@ -30,12 +30,34 @@ class CustomerFileHelper {
       .returning('*')
   }
 
+  /**
+   * Create a `exported_customer` record
+   *
+   * @param {module:CustomerFileModel} [customerFile] Instance of `CustomerFileModel` to assign the exported customer
+   * to. If null it will generate a random UUID and use that instead
+   * @param {string} [customerReference] customer reference to use. Defaults to 'AA02BEEB'
+   *
+   * @returns {module:ExportedCustomerModel} The newly created instance of `ExportedCustomerModel`
+   */
+  static addExportedCustomer (customerFile = null, customerReference = 'AA02BEEB') {
+    return ExportedCustomerModel.query()
+      .insert({
+        customerFileId: this._customerFileId(customerFile),
+        customerReference
+      })
+      .returning('*')
+  }
+
   static _regimeId (regime) {
     return regime?.id ?? GeneralHelper.uuid4()
   }
 
   static _exportedAt (status) {
     return status === 'exported' ? new Date().toISOString() : null
+  }
+
+  static _customerFileId (customerFile) {
+    return customerFile?.id ?? GeneralHelper.uuid4()
   }
 }
 


### PR DESCRIPTION
[Add customer files test endpoint](https://github.com/DEFRA/sroc-charging-module-api/pull/381) enables listing all customer files for a regime. But each customer file is linked to a set of `exported_customers` and there is currently no way to view them.

This change adds an endpoint that allows our test team to see the detail linked to a `customer file`.

** Note, we have essentially used the same blueprint of List and Show as used for `regime` and `authorised_systems`.