### PR TITLE
Fix previous changes in customer file export

### DIFF
--- a/app/services/generate_customer_file.service.js
+++ b/app/services/generate_customer_file.service.js
@@ -14,16 +14,13 @@ const {
 
 class GenerateCustomerFileService {
   /**
-   * Generates and writes a customer file for a region to a given filename in the temp folder.
+   * Generates and writes a customer file to a given filename in the temp folder.
    *
-   * @param {string} regimeId Id of the regime to generate the customer file for.
-   * @param {string} region The region to generate the customer file for.
-   * @param {string} filename The name of the file to be generated.
-   * @param {string} fileReference The file reference to be used in the head of the file.
+   * @param {module:CustomerFileModel} customerFile Instance of `CustomerFileModel` which a file will be generated for.
    * @returns {string} The path and filename of the generated file.
    */
-  static async go (regimeId, region, filename, fileReference) {
-    const query = this._query(regimeId, region)
+  static async go ({ id, region, fileReference }) {
+    const query = this._query(id)
 
     // Only data passed in as additionalData is available to the header
     const additionalData = { region, fileReference }
@@ -33,12 +30,12 @@ class GenerateCustomerFileService {
       CustomerFileHeadPresenter,
       CustomerFileBodyPresenter,
       CustomerFileTailPresenter,
-      filename,
+      this._filename(fileReference),
       additionalData
     )
   }
 
-  static _query (regimeId, region) {
+  static _query (customerFileId) {
     return CustomerModel.query()
       .select(
         'region',
@@ -52,9 +49,12 @@ class GenerateCustomerFileService {
         'addressLine6',
         'postcode'
       )
-      .where('regimeId', regimeId)
-      .where('region', region)
+      .where('customerFileId', customerFileId)
       .orderBy('customerReference')
+  }
+
+  static _filename (fileReference) {
+    return `${fileReference}.dat`
   }
 }
 

--- a/test/services/send_customer_file.service.test.js
+++ b/test/services/send_customer_file.service.test.js
@@ -59,7 +59,7 @@ describe('Send Customer File service', () => {
     await CreateCustomerDetailsService.go({ ...payload, region: 'W', customerReference: 'WA87654321' }, regime)
 
     deleteStub = Sinon.stub(DeleteFileService, 'go').returns(true)
-    generateStub = Sinon.stub(GenerateCustomerFileService, 'go').returns('stubFilename')
+    generateStub = Sinon.stub(GenerateCustomerFileService, 'go').callsFake(file => `${file.fileReference}.dat`)
     sendStub = Sinon.stub(SendFileToS3Service, 'go').returns(true)
     moveStub = Sinon.stub(MoveCustomersToExportedTableService, 'go').returns(true)
     Sinon.stub(NextCustomerFileReferenceService, 'go').callsFake((_, region) => `nal${region.toLowerCase()}c50001`)
@@ -81,14 +81,17 @@ describe('Send Customer File service', () => {
       })
 
       it('generates a customer file', async () => {
+        const [customerFile] = generateStub.getCall(0).args
+
         expect(generateStub.calledOnce).to.be.true()
-        expect(generateStub.getCall(0).args[0]).to.equal(regime.id)
-        expect(generateStub.getCall(0).args[1]).to.equal('A')
+        expect(customerFile).to.be.an.instanceOf(CustomerFileModel)
+        expect(customerFile.regimeId).to.equal(regime.id)
+        expect(customerFile.region).to.equal('A')
       })
 
       it('sends the customer file', async () => {
         expect(sendStub.calledOnce).to.be.true()
-        expect(sendStub.getCall(0).firstArg).to.equal('stubFilename')
+        expect(sendStub.getCall(0).firstArg).to.equal('nalac50001.dat')
         expect(sendStub.getCall(0).args[1]).to.equal(`${regime.slug}/customer/nalac50001.dat`)
       })
 
@@ -191,17 +194,19 @@ describe('Send Customer File service', () => {
 
       it('generates a customer file', async () => {
         expect(generateStub.calledTwice).to.be.true()
-        expect(generateStub.getCall(0).args[0]).to.equal(regime.id)
-        expect(generateStub.getCall(0).args[1]).to.equal('A')
-        expect(generateStub.getCall(1).args[0]).to.equal(regime.id)
-        expect(generateStub.getCall(1).args[1]).to.equal('W')
+        expect(generateStub.getCall(0).args[0]).to.be.an.instanceOf(CustomerFileModel)
+        expect(generateStub.getCall(0).args[0].regimeId).to.equal(regime.id)
+        expect(generateStub.getCall(0).args[0].region).to.equal('A')
+        expect(generateStub.getCall(1).args[0]).to.be.an.instanceOf(CustomerFileModel)
+        expect(generateStub.getCall(1).args[0].regimeId).to.equal(regime.id)
+        expect(generateStub.getCall(1).args[0].region).to.equal('W')
       })
 
       it('sends the customer file', async () => {
         expect(sendStub.calledTwice).to.be.true()
-        expect(sendStub.getCall(0).args[0]).to.equal('stubFilename')
+        expect(sendStub.getCall(0).args[0]).to.equal('nalac50001.dat')
         expect(sendStub.getCall(0).args[1]).to.equal(`${regime.slug}/customer/nalac50001.dat`)
-        expect(sendStub.getCall(1).args[0]).to.equal('stubFilename')
+        expect(sendStub.getCall(1).args[0]).to.equal('nalwc50001.dat')
         expect(sendStub.getCall(1).args[1]).to.equal(`${regime.slug}/customer/nalwc50001.dat`)
       })
 
@@ -299,17 +304,19 @@ describe('Send Customer File service', () => {
 
       it('generates all required customer files', async () => {
         expect(generateStub.calledTwice).to.be.true()
-        expect(generateStub.getCall(0).args[0]).to.equal(regime.id)
-        expect(generateStub.getCall(0).args[1]).to.equal('A')
-        expect(generateStub.getCall(1).args[0]).to.equal(regime.id)
-        expect(generateStub.getCall(1).args[1]).to.equal('W')
+        expect(generateStub.getCall(0).args[0]).to.be.an.instanceOf(CustomerFileModel)
+        expect(generateStub.getCall(0).args[0].regimeId).to.equal(regime.id)
+        expect(generateStub.getCall(0).args[0].region).to.equal('A')
+        expect(generateStub.getCall(1).args[0]).to.be.an.instanceOf(CustomerFileModel)
+        expect(generateStub.getCall(1).args[0].regimeId).to.equal(regime.id)
+        expect(generateStub.getCall(1).args[0].region).to.equal('W')
       })
 
       it('sends all required customer files', async () => {
         expect(sendStub.calledTwice).to.be.true()
-        expect(sendStub.getCall(0).args[0]).to.equal('stubFilename')
+        expect(sendStub.getCall(0).args[0]).to.equal('nalac50001.dat')
         expect(sendStub.getCall(0).args[1]).to.equal(`${regime.slug}/customer/nalac50001.dat`)
-        expect(sendStub.getCall(1).args[0]).to.equal('stubFilename')
+        expect(sendStub.getCall(1).args[0]).to.equal('nalwc50001.dat')
         expect(sendStub.getCall(1).args[1]).to.equal(`${regime.slug}/customer/nalwc50001.dat`)
       })
 


### PR DESCRIPTION
During testing we found that if a customer file was successfully generated but sending failed (eg. an invalid bucket is specified), the customer records in that file would be incorrectly included in the next customer file. This change prevents this happening:

- Once a customer file record is created, we patch the customer changes for that regime and region so that `customer_file_id` equals the id of the created record, ensuring we do not overwrite the file id if it already exists for a customer change;
- When we generate the file, we only select customer changes that have the correct `customer_file_id`.

This is implemented by refactoring `GenerateCustomerFileService` so that we pass the instance of `CustomerFileModel` to it, which it uses to get the id (plus other things needed for the file, such as region). We also refactor `SendCustomerFileService` to match.