### PR TITLE
Fix failing MoveCustomersToExportedTableService tests

### DIFF
--- a/test/services/move_customers_to_exported_table.service.test.js
+++ b/test/services/move_customers_to_exported_table.service.test.js
@@ -37,7 +37,7 @@ describe('Move Customers To Exported Table service', () => {
   beforeEach(async () => {
     await DatabaseHelper.clean()
     regime = await RegimeHelper.addRegime('wrls', 'WRLS')
-    CreateCustomerDetailsService.go(payload, regime)
+    await CreateCustomerDetailsService.go(payload, regime)
 
     customerFile = await CustomerFileModel.query().insert({
       regimeId: regime.id,


### PR DESCRIPTION
We found that the tests for `MoveCustomersToExportedTableService` would very occasionally fail. On closer examination, it looked like there was a missing `await` in the test setup which was probably causing a situation where customer details weren't in place ready for test, which would subsequently fail. This change hopes to fix this!