### PR TITLE
Create plugin to add invoice to request when needed

### DIFF
--- a/app/plugins/index.js
+++ b/app/plugins/index.js
@@ -11,6 +11,7 @@ const HapiPinoPlugin = require('./hapi_pino.plugin')
 const InvalidCharactersPlugin = require('./invalid_characters.plugin')
 const MissingPayloadPlugin = require('./missing_payload.plugin')
 const PayloadCleanerPlugin = require('./payload_cleaner.plugin')
+const RequestInvoicePlugin = require('./request_invoice.plugin')
 const RequestNotifierPlugin = require('./request_notifier.plugin')
 const RouterPlugin = require('./router.plugin')
 const StopPlugin = require('./stop.plugin')
@@ -43,6 +44,7 @@ module.exports = {
   MissingPayloadPlugin,
   PayloadCleanerPlugin,
   RequestNotifierPlugin,
+  RequestInvoicePlugin,
   RouterPlugin,
   StopPlugin,
   VersionInfoPlugin

--- a/app/plugins/request_invoice.plugin.js
+++ b/app/plugins/request_invoice.plugin.js
@@ -1,0 +1,31 @@
+'use strict'
+
+/**
+ * Determines if the request is related to an invoice and does the work of first finding it, then validating if the
+ * request is valid, ie. that the invoice exists.
+ *
+ * This sits as a partner plugin with RequestBillRun, so that by the time we get to a controller we have already
+ * retrieved and validated any bill run and invoice included in the url.
+ *
+ * In this case most of the work is done by the {@module RequestInvoiceService}. If invoice is found and valid for the
+ * request the plugin adds the {@module InvoiceModel} instance to `request.app` as per the
+ * {@link https://hapi.dev/api/?v=20.1.0#-requestapp|Hapi documentation} to make it available to all controllers.
+ *
+ * @module RequestInvoicePlugin
+ */
+
+const { RequestInvoiceService } = require('../services')
+
+const RequestInvoicePlugin = {
+  name: 'request_invoice',
+  register: (server, _options) => {
+    server.ext('onPreHandler', async (request, h) => {
+      const { invoiceId } = request.params
+      request.app.invoice = await RequestInvoiceService.go(request.path, invoiceId)
+
+      return h.continue
+    })
+  }
+}
+
+module.exports = RequestInvoicePlugin

--- a/app/services/index.js
+++ b/app/services/index.js
@@ -34,6 +34,7 @@ const NextTransactionFileReferenceService = require('./next_transaction_file_ref
 const NextTransactionReferenceService = require('./next_transaction_reference.service')
 const ObjectCleaningService = require('./plugins/object_cleaning.service')
 const RequestBillRunService = require('./plugins/request_bill_run.service')
+const RequestInvoiceService = require('./plugins/request_invoice.service')
 const RulesService = require('./rules.service')
 const SendBillRunReferenceService = require('./send_bill_run_reference.service')
 const SendCustomerFileService = require('./send_customer_file.service')
@@ -82,6 +83,7 @@ module.exports = {
   ListRegimesService,
   ObjectCleaningService,
   RequestBillRunService,
+  RequestInvoiceService,
   RulesService,
   MoveCustomersToExportedTableService,
   NextBillRunNumberService,

--- a/app/services/plugins/request_invoice.service.js
+++ b/app/services/plugins/request_invoice.service.js
@@ -1,0 +1,58 @@
+'use strict'
+
+/**
+ * @module RequestInvoiceService
+ */
+
+const Boom = require('@hapi/boom')
+
+const { InvoiceModel } = require('../../models')
+
+class RequestInvoiceService {
+  /**
+   * Find a invoice and determine if it's valid for the request.
+   *
+   * We have a number of services that
+   *
+   * - first need to find a matching invoice
+   * - perform some initial validation
+   * - perform validation specific to the service
+   *
+   * As the number of services grew, so to did the duplication of the first two actions across them. This service and
+   * the {@module InvoicePlugin} were created to remove the duplication and simplify the project.
+   *
+   * It checks that the request relates to an invoice that exists. If this check fails a {@module Boom} error is thrown.
+   *
+   * @param {string} path The full request path. Used to determine if it's invoice related
+   * @param {string} invoiceId The id of the requested invoice
+   *
+   * @returns {Object} If the request is invoice related and it's valid it returns an instance of
+   * {@module InvoiceModel}. Else it returns `null`
+   */
+  static async go (path, invoiceId) {
+    if (!this._invoiceRelated(path)) {
+      return null
+    }
+
+    const invoice = await this._invoice(invoiceId)
+    this._validateInvoice(invoice, invoiceId)
+
+    return invoice
+  }
+
+  static _invoiceRelated (path) {
+    return /\/invoices\//i.test(path)
+  }
+
+  static _invoice (invoiceId) {
+    return InvoiceModel.query().findById(invoiceId)
+  }
+
+  static _validateInvoice (invoice, invoiceId) {
+    if (!invoice) {
+      throw Boom.notFound(`Invoice ${invoiceId} is unknown.`)
+    }
+  }
+}
+
+module.exports = RequestInvoiceService

--- a/server.js
+++ b/server.js
@@ -15,6 +15,7 @@ const {
   InvalidCharactersPlugin,
   MissingPayloadPlugin,
   PayloadCleanerPlugin,
+  RequestInvoicePlugin,
   RequestNotifierPlugin,
   RouterPlugin,
   StopPlugin,
@@ -44,6 +45,9 @@ exports.deployment = async start => {
   await server.register(DbErrorsPlugin)
   await server.register(VersionInfoPlugin)
   await server.register(BillRunPlugin)
+  // We register the invoice plugin after the bill run plugin as the bill run plugin performs validation that is assumed
+  // to be done by the time we get to the invoice plugin
+  await server.register(RequestInvoicePlugin)
 
   // Register non-production plugins
   if (ServerConfig.environment === 'development') {

--- a/test/controllers/presroc/bill_runs_invoices.controller.test.js
+++ b/test/controllers/presroc/bill_runs_invoices.controller.test.js
@@ -19,7 +19,8 @@ const {
   DatabaseHelper,
   GeneralHelper,
   RegimeHelper,
-  TransactionHelper
+  TransactionHelper,
+  InvoiceHelper
 } = require('../../support/helpers')
 
 const Boom = require('@hapi/boom')
@@ -36,6 +37,7 @@ describe('Presroc Invoices controller', () => {
   let regime
   let authorisedSystem
   let billRun
+  let invoice
 
   before(async () => {
     server = await deployment()
@@ -52,6 +54,7 @@ describe('Presroc Invoices controller', () => {
     regime = await RegimeHelper.addRegime('wrls', 'WRLS')
     authorisedSystem = await AuthorisedSystemHelper.addSystem(clientID, 'system1', [regime])
     billRun = await BillRunHelper.addBillRun(authorisedSystem.id, regime.id)
+    invoice = await InvoiceHelper.addInvoice(billRun.id, 'CUSTOMER', '2020')
   })
 
   after(async () => {
@@ -82,7 +85,7 @@ describe('Presroc Invoices controller', () => {
       })
 
       it('returns a 204 response', async () => {
-        const response = await server.inject(options(authToken, billRun.id, 'INVOICE'))
+        const response = await server.inject(options(authToken, billRun.id, invoice.id))
 
         expect(response.statusCode).to.equal(204)
       })
@@ -101,7 +104,7 @@ describe('Presroc Invoices controller', () => {
         })
 
         it('returns error status 404', async () => {
-          const response = await server.inject(options(authToken, billRun.id, 'INVOICE'))
+          const response = await server.inject(options(authToken, billRun.id, invoice.id))
 
           expect(response.statusCode).to.equal(404)
         })
@@ -119,7 +122,7 @@ describe('Presroc Invoices controller', () => {
         })
 
         it('returns error status 409', async () => {
-          const response = await server.inject(options(authToken, billRun.id, 'INVOICE'))
+          const response = await server.inject(options(authToken, billRun.id, invoice.id))
 
           expect(response.statusCode).to.equal(409)
         })
@@ -194,7 +197,7 @@ describe('Presroc Invoices controller', () => {
     }
 
     it('returns success status 204', async () => {
-      const response = await server.inject(options(authToken, billRun.id))
+      const response = await server.inject(options(authToken, billRun.id, invoice.id))
 
       expect(response.statusCode).to.equal(204)
     })

--- a/test/features/find_validate_invoices.test.js
+++ b/test/features/find_validate_invoices.test.js
@@ -1,0 +1,103 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, before, beforeEach, afterEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// For running our service
+const { deployment } = require('../../server')
+
+// Test helpers
+const {
+  AuthorisationHelper,
+  AuthorisedSystemHelper,
+  BillRunHelper,
+  DatabaseHelper,
+  GeneralHelper,
+  InvoiceHelper,
+  RegimeHelper,
+  RouteHelper,
+  SequenceCounterHelper
+} = require('../support/helpers')
+
+// Things we need to stub
+const JsonWebToken = require('jsonwebtoken')
+
+describe('Finding and validating invoices in requests', () => {
+  let server
+  let invoice
+  let authToken
+  const nonAdminClientId = '1234546789'
+
+  before(async () => {
+    await DatabaseHelper.clean()
+
+    const regime = await RegimeHelper.addRegime('wrls', 'Water')
+
+    await AuthorisedSystemHelper.addSystem(nonAdminClientId, 'system', [regime])
+
+    await SequenceCounterHelper.addSequenceCounter(regime.id, 'A')
+    const billRun = await BillRunHelper.addBillRun(GeneralHelper.uuid4(), regime.id)
+    invoice = await InvoiceHelper.addInvoice(billRun.id, 'CUSTOMER', '2021')
+
+    server = await deployment()
+
+    RouteHelper.addRequestAppCheckRoute(server, 'invoice')
+  })
+
+  afterEach(async () => {
+    Sinon.restore()
+  })
+
+  describe('When the route is for an invoice', () => {
+    beforeEach(async () => {
+      authToken = AuthorisationHelper.nonAdminToken(nonAdminClientId)
+
+      Sinon
+        .stub(JsonWebToken, 'verify')
+        .returns(AuthorisationHelper.decodeToken(authToken))
+    })
+
+    describe('and the request is valid', () => {
+      const options = id => {
+        return {
+          method: 'GET',
+          url: `/test/wrls/invoices/${id}`,
+          headers: { authorization: `Bearer ${authToken}` }
+        }
+      }
+
+      it('adds the matching invoice to the request', async () => {
+        const response = await server.inject(options(invoice.id))
+        const responsePayload = JSON.parse(response.payload)
+
+        expect(response.statusCode).to.equal(200)
+        expect(responsePayload.id).to.equal(invoice.id)
+      })
+    })
+
+    describe('but the request is invalid', () => {
+      const options = id => {
+        return {
+          method: 'GET',
+          url: `/test/wrls/invoices/${id}`,
+          headers: { authorization: `Bearer ${authToken}` }
+        }
+      }
+
+      it('rejects the request with the appropriate error message', async () => {
+        const unknownInvoiceId = GeneralHelper.uuid4()
+
+        const response = await server.inject(options(unknownInvoiceId))
+        const responsePayload = JSON.parse(response.payload)
+
+        expect(response.statusCode).to.equal(404)
+        expect(responsePayload.message).to.equal(`Invoice ${unknownInvoiceId} is unknown.`)
+      })
+    })
+  })
+})

--- a/test/services/plugins/request_invoice.service.test.js
+++ b/test/services/plugins/request_invoice.service.test.js
@@ -1,0 +1,68 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const { BillRunHelper, DatabaseHelper, GeneralHelper, RegimeHelper, InvoiceHelper } = require('../../support/helpers')
+
+// Thing under test
+const { RequestInvoiceService } = require('../../../app/services')
+
+describe('Request invoice service', () => {
+  let regime
+  let invoice
+  let billRun
+
+  const invoicePath = id => {
+    return `/test/wrls/bill-runs/_/invoices/${id}`
+  }
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+  })
+
+  describe("When the request is 'invoice' related", () => {
+    beforeEach(async () => {
+      regime = await RegimeHelper.addRegime('wrls', 'WRLS')
+      billRun = await BillRunHelper.addBillRun(GeneralHelper.uuid4(), regime.id)
+      invoice = await InvoiceHelper.addInvoice(billRun.id, 'CUSTOMER', '2021')
+    })
+
+    describe('and is for a valid invoice', () => {
+      it('returns the invoice', async () => {
+        const result = await RequestInvoiceService.go(invoicePath(invoice.id), invoice.id)
+
+        expect(result.id).to.equal(invoice.id)
+      })
+    })
+
+    describe('but is for an invalid invoice', () => {
+      describe('because no matching invoice exists', () => {
+        it('returns null', async () => {
+          const unknownInvoiceId = GeneralHelper.uuid4()
+          const err = await expect(
+            RequestInvoiceService.go(invoicePath(unknownInvoiceId), unknownInvoiceId)
+          ).to.reject()
+
+          expect(err).to.be.an.error()
+          expect(err.output.payload.message).to.equal(`Invoice ${unknownInvoiceId} is unknown.`)
+        })
+      })
+    })
+  })
+
+  describe("When the request isn't invoice related", () => {
+    describe("because it's nothing to do with invoices", () => {
+      it('returns null', async () => {
+        const result = await RequestInvoiceService.go('/bill-runs/blah', GeneralHelper.uuid4())
+
+        expect(result).to.be.null()
+      })
+    })
+  })
+})

--- a/test/support/helpers/route.helper.js
+++ b/test/support/helpers/route.helper.js
@@ -142,6 +142,26 @@ class RouteHelper {
     })
   }
 
+  static addRequestAppCheckRoute (server, type) {
+    const paths = {
+      billRun: '/test/{regimeId}/bill-runs/{billRunId}',
+      invoice: '/test/{regimeId}/invoices/{invoiceId}'
+    }
+
+    server.route({
+      method: 'GET',
+      path: paths[type],
+      handler: (request, _h) => {
+        return { id: request.app[type].id }
+      },
+      options: {
+        auth: {
+          scope: ['system']
+        }
+      }
+    })
+  }
+
   /**
    * Adds a route to a Hapi server instance which is used to test the 'Notifier' plugin
    *


### PR DESCRIPTION
This change introduces `RequestInvoicePlugin` (similar to the existing bill run plugin) which will check requests to see if they contain `/invoices/`, retrieving the invoice if it exists or throwing a `404` error if it doesn't.