### PR TITLE
Move plugin test files to plugins folder

### DIFF
--- a/test/services/plugins/db_errors.service.test.js
+++ b/test/services/plugins/db_errors.service.test.js
@@ -11,7 +11,7 @@ const { expect } = Code
 const { DBError, UniqueViolationError } = require('db-errors')
 
 // Thing under test
-const { DbErrorsService } = require('../../app/services')
+const { DbErrorsService } = require('../../../app/services')
 
 describe('Db Errors service', () => {
   describe('If the value passed in is a DB error', () => {

--- a/test/services/plugins/object_cleaning.service.test.js
+++ b/test/services/plugins/object_cleaning.service.test.js
@@ -10,7 +10,7 @@ const { expect } = Code
 // Test helpers
 
 // Thing under test
-const { ObjectCleaningService } = require('../../app/services')
+const { ObjectCleaningService } = require('../../../app/services')
 
 describe('Object cleaning service', () => {
   describe('When an object contains values with extra whitespace', () => {

--- a/test/services/plugins/request_bill_run.service.test.js
+++ b/test/services/plugins/request_bill_run.service.test.js
@@ -8,10 +8,10 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const { BillRunHelper, DatabaseHelper, GeneralHelper, RegimeHelper } = require('../support/helpers')
+const { BillRunHelper, DatabaseHelper, GeneralHelper, RegimeHelper } = require('../../support/helpers')
 
 // Thing under test
-const { RequestBillRunService } = require('../../app/services')
+const { RequestBillRunService } = require('../../../app/services')
 
 describe('Request bill run service', () => {
   let regime


### PR DESCRIPTION
We have started to move our services into folders that reflect their purpose. [A recent change](https://github.com/DEFRA/sroc-charging-module-api/pull/389) moved plugins into their own `plugins` folder; this PR moves their tests into a similar folder.