### PR TITLE
Correct await async usage in RequestBillRunService

### DIFF
--- a/app/services/plugins/request_bill_run.service.js
+++ b/app/services/plugins/request_bill_run.service.js
@@ -53,8 +53,8 @@ class RequestBillRunService {
     return /\/bill-runs\//i.test(path)
   }
 
-  static async _billRun (billRunId) {
-    return await BillRunModel.query().findById(billRunId)
+  static _billRun (billRunId) {
+    return BillRunModel.query().findById(billRunId)
   }
 
   static _validateBillRun (billRun, billRunId, regime, method) {


### PR DESCRIPTION
Spotted whilst working on ['Create plugin to add invoice to request when needed'](https://github.com/DEFRA/sroc-charging-module-api/pull/393) that we were not using await/async in an optimal way.

This housekeeping change corrects the issue.