### PR TITLE
Create InvoiceRebillingCreateTransactionService

### DIFF
--- a/app/services/index.js
+++ b/app/services/index.js
@@ -24,6 +24,7 @@ const GenerateBillRunService = require('./generate_bill_run.service')
 const GenerateBillRunValidationService = require('./generate_bill_run_validation.service')
 const GenerateCustomerFileService = require('./generate_customer_file.service')
 const GenerateTransactionFileService = require('./generate_transaction_file.service')
+const InvoiceRebillingCreateTransactionService = require('./invoice_rebilling_create_transaction.service')
 const InvoiceRebillingInitialiseService = require('./invoice_rebilling_initialise.service')
 const InvoiceRebillingValidationService = require('./invoice_rebilling_validation.service')
 const ListAuthorisedSystemsService = require('./list_authorised_systems.service')
@@ -80,6 +81,7 @@ module.exports = {
   GenerateBillRunValidationService,
   GenerateCustomerFileService,
   GenerateTransactionFileService,
+  InvoiceRebillingCreateTransactionService,
   InvoiceRebillingInitialiseService,
   InvoiceRebillingValidationService,
   ListAuthorisedSystemsService,

--- a/app/services/invoice_rebilling_create_transaction.service.js
+++ b/app/services/invoice_rebilling_create_transaction.service.js
@@ -1,0 +1,54 @@
+'use strict'
+
+/**
+ * @module InvoiceRebillingCreateTransactionService
+ */
+
+const { BillRunModel, InvoiceModel, LicenceModel, TransactionModel } = require('../models')
+
+class InvoiceRebillingCreateTransactionService {
+  /**
+   * Creates a copy of a transaction for rebilling purposes. Accepts a transaction to duplicate along with the licence
+   * to create it on. We can optionally invert the transaction type, so a debit transaction would become a credit and
+   * vice-versa.
+   *
+   * @param {module:TransactionModel} transaction The transaction to be duplicated.
+   * @param {module:LicenceModel} licence The licence the transaction should be created on.
+   * @param {Boolean} [invert] Whether the transaction type should be inverted.
+   * @returns {module:TransactionModel} The newly-created transaction.
+   */
+  static async go (transaction, licence, invert = false) {
+    const preparedTransaction = await this._prepareTransaction(transaction, licence, invert)
+    return this._create(preparedTransaction)
+  }
+
+  /**
+   * Creates a new transaction ready to be persisted in the db. We set the
+   */
+  static async _prepareTransaction (transaction, licence, invert) {
+    return TransactionModel.fromJson({
+      ...transaction,
+      id: undefined,
+      billRunId: licence.billRunId,
+      invoiceId: licence.invoiceId,
+      licenceId: licence.id,
+      chargeCredit: invert ? !transaction.chargeCredit : transaction.chargeCredit
+    })
+  }
+
+  static async _create (transaction) {
+    return TransactionModel.transaction(async trx => {
+      await BillRunModel.patchTally(transaction, trx)
+      await InvoiceModel.updateTally(transaction, trx)
+      await LicenceModel.updateTally(transaction, trx)
+
+      const newTransaction = await transaction.$query(trx)
+        .insert(transaction)
+        .returning('id')
+
+      return newTransaction
+    })
+  }
+}
+
+module.exports = InvoiceRebillingCreateTransactionService

--- a/app/services/invoice_rebilling_create_transaction.service.js
+++ b/app/services/invoice_rebilling_create_transaction.service.js
@@ -23,7 +23,11 @@ class InvoiceRebillingCreateTransactionService {
   }
 
   /**
-   * Creates a new transaction ready to be persisted in the db. We set the
+   * Returns a new transaction object ready to be persisted in the db, based on the provided transaction with a few
+   * changes:
+   * - We set the id as undefined to avoid conflicting with the existing transaction;
+   * - We set the bill run, invoice and licence ids based on the provided licence;
+   * - We invert the credit boolean if required.
    */
   static async _prepareTransaction (transaction, licence, invert) {
     return TransactionModel.fromJson({
@@ -36,6 +40,9 @@ class InvoiceRebillingCreateTransactionService {
     })
   }
 
+  /**
+   * Creates a record in the db for the provided transaction and returns it
+   */
   static async _create (transaction) {
     return TransactionModel.transaction(async trx => {
       await BillRunModel.patchTally(transaction, trx)
@@ -44,7 +51,6 @@ class InvoiceRebillingCreateTransactionService {
 
       const newTransaction = await transaction.$query(trx)
         .insert(transaction)
-        .returning('id')
 
       return newTransaction
     })

--- a/test/services/invoice_rebilling_create_transaction.service.test.js
+++ b/test/services/invoice_rebilling_create_transaction.service.test.js
@@ -1,0 +1,112 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const {
+  AuthorisedSystemHelper,
+  BillRunHelper,
+  DatabaseHelper,
+  RegimeHelper,
+  TransactionHelper,
+  InvoiceHelper,
+  LicenceHelper
+} = require('../support/helpers')
+
+// Thing under test
+const { InvoiceRebillingCreateTransactionService } = require('../../app/services')
+
+describe('Invoice Rebilling Create Transaction service', () => {
+  let originalBillRun
+  let rebillBillRun
+  let authorisedSystem
+  let regime
+  let transaction
+  let result
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+    regime = await RegimeHelper.addRegime('wrls', 'WRLS')
+    authorisedSystem = await AuthorisedSystemHelper.addSystem('1234546789', 'system1', [regime])
+    originalBillRun = await BillRunHelper.addBillRun(authorisedSystem.id, regime.id)
+    rebillBillRun = await BillRunHelper.addBillRun(authorisedSystem.id, regime.id)
+  })
+
+  describe('when the transaction type is not to be inverted', () => {
+    let licence
+
+    beforeEach(async () => {
+      const invoice = await InvoiceHelper.addInvoice(rebillBillRun.id, 'TH230000222', 2021)
+      licence = await LicenceHelper.addLicence(rebillBillRun.id, 'TH230000222', invoice.id)
+      transaction = await TransactionHelper.addTransaction(originalBillRun.id, { chargeFinancialYear: 2021 })
+
+      result = await InvoiceRebillingCreateTransactionService.go(transaction, licence)
+    })
+
+    it('creates a transaction', async () => {
+      expect(result.id).to.exist()
+    })
+
+    it('creates the transaction on the correct bill run, invoice and licence', async () => {
+      expect(result.billRunId).to.equal(licence.billRunId)
+      expect(result.invoiceId).to.equal(licence.invoiceId)
+      expect(result.licenceId).to.equal(licence.id)
+    })
+
+    it('creates the transaction with the correct values', async () => {
+      // Create a list of all keys in the transaction object and filter out the ones we don't want to check
+      const transactionKeys = Object.keys(transaction)
+      const keysToSkip = ['id', 'billRunId', 'createdAt', 'updatedAt', 'createdBy', 'invoiceId', 'licenceId']
+      const keysToCheck = transactionKeys.filter(key => !keysToSkip.includes(key))
+
+      // Iterate over the remaining keys and check that the result's value matches the original transaction's value
+      for (const key in keysToCheck) {
+        expect(result[key]).to.equal(transaction[key])
+      }
+    })
+  })
+
+  describe('when the transaction type is to be inverted', () => {
+    let licence
+
+    beforeEach(async () => {
+      const invoice = await InvoiceHelper.addInvoice(rebillBillRun.id, 'TH230000222', 2021)
+      licence = await LicenceHelper.addLicence(rebillBillRun.id, 'TH230000222', invoice.id)
+    })
+
+    describe('when a debit is passed to the service', () => {
+      beforeEach(async () => {
+        transaction = await TransactionHelper.addTransaction(originalBillRun.id, {
+          chargeFinancialYear: 2021,
+          chargeCredit: false
+        })
+
+        result = await InvoiceRebillingCreateTransactionService.go(transaction, licence, true)
+      })
+
+      it('creates a credit', async () => {
+        expect(result.chargeCredit).to.be.true()
+      })
+    })
+
+    describe('when a credit is passed to the service', () => {
+      beforeEach(async () => {
+        transaction = await TransactionHelper.addTransaction(originalBillRun.id, {
+          chargeFinancialYear: 2021,
+          chargeCredit: true
+        })
+
+        result = await InvoiceRebillingCreateTransactionService.go(transaction, licence, true)
+      })
+
+      it('creates a credit', async () => {
+        expect(result.chargeCredit).to.be.false()
+      })
+    })
+  })
+})

--- a/test/services/invoice_rebilling_create_transaction.service.test.js
+++ b/test/services/invoice_rebilling_create_transaction.service.test.js
@@ -127,7 +127,7 @@ describe('Invoice Rebilling Create Transaction service', () => {
         result = await InvoiceRebillingCreateTransactionService.go(transaction, licence, true)
       })
 
-      it('creates a credit', async () => {
+      it('creates a debit', async () => {
         expect(result.chargeCredit).to.be.false()
       })
     })


### PR DESCRIPTION
https://trello.com/c/qkWbpJlf/1962-m-create-re-billing-transactions

The next stage of rebilling is to create the `InvoiceRebillingCreateTransactionService` that can be passed a transaction and a licence, and it will create a duplicate transaction on the specified licence. It can optionally invert the transaction type, ie. a debit will become a credit and vice-versa. We also update the tallies at the bill run, invoice and licence level to ensure the figures are accurate.