### PR TITLE
Create Invoice Rebilling Service

### DIFF
--- a/app/models/invoice.model.js
+++ b/app/models/invoice.model.js
@@ -116,6 +116,8 @@ class InvoiceModel extends BaseUpsertModel {
   /**
    * Returns an object that contains the minimum (base) properties and values needed when inserting a new invoice
    *
+   * If rebilledType is passed through in the transaction then we use it; otherwise, we set it to 'O'
+   *
    * See `BaseUpsertModel._baseOnInsertObject()` for more details
    *
    * @param {module:TransactionTranslator} transaction translator representing the transaction that will seed the new
@@ -127,7 +129,8 @@ class InvoiceModel extends BaseUpsertModel {
     return {
       billRunId: transaction.billRunId,
       customerReference: transaction.customerReference,
-      financialYear: transaction.chargeFinancialYear
+      financialYear: transaction.chargeFinancialYear,
+      rebilledType: transaction.rebilledType ?? 'O'
     }
   }
 

--- a/app/services/index.js
+++ b/app/services/index.js
@@ -27,6 +27,7 @@ const GenerateTransactionFileService = require('./generate_transaction_file.serv
 const InvoiceRebillingCreateLicenceService = require('./invoice_rebilling_create_licence.service')
 const InvoiceRebillingCreateTransactionService = require('./invoice_rebilling_create_transaction.service')
 const InvoiceRebillingInitialiseService = require('./invoice_rebilling_initialise.service')
+const InvoiceRebillingService = require('./invoice_rebilling.service')
 const InvoiceRebillingValidationService = require('./invoice_rebilling_validation.service')
 const ListAuthorisedSystemsService = require('./list_authorised_systems.service')
 const ListCustomerFilesService = require('./list_customer_files.service')
@@ -85,6 +86,7 @@ module.exports = {
   InvoiceRebillingCreateLicenceService,
   InvoiceRebillingCreateTransactionService,
   InvoiceRebillingInitialiseService,
+  InvoiceRebillingService,
   InvoiceRebillingValidationService,
   ListAuthorisedSystemsService,
   ListCustomerFilesService,

--- a/app/services/invoice_rebilling.service.js
+++ b/app/services/invoice_rebilling.service.js
@@ -11,7 +11,17 @@ const { LicenceModel, TransactionModel } = require('../models')
 
 class InvoiceRebillingService {
   /**
+   * Service to rebill a given invoice onto the supplied cancel invoice and rebill invoice.
    *
+   * For each licence in the invoice, it will create a corresponding licence on cancelInvoice and rebillInvoice and
+   * populate them with the transactions on the licence (flipping them from credit to debit and vice-versa as
+   * appropriate).
+   *
+   * Note that bill run, invoice and licence tallies will be updated as part of the process.
+   *
+   * @param {module:InvoiceModel} invoice Instance of `InvoiceModel` for the invoice to be rebilled.
+   * @param {module:InvoiceModel} cancelInvoice Instance of `InvoiceModel` for the cancelling invoice.
+   * @param {module:InvoiceModel} rebillInvoice Instance of `InvoiceModel` for the rebilling invoice.
    */
   static async go (invoice, cancelInvoice, rebillInvoice) {
     const licences = await this._licences(invoice)

--- a/app/services/invoice_rebilling.service.js
+++ b/app/services/invoice_rebilling.service.js
@@ -1,0 +1,47 @@
+'use strict'
+
+/**
+ * @module InvoiceRebillingService
+ */
+
+const InvoiceRebillingCreateLicenceService = require('./invoice_rebilling_create_licence.service')
+const InvoiceRebillingCreateTransactionService = require('./invoice_rebilling_create_transaction.service')
+
+const { LicenceModel, TransactionModel } = require('../models')
+
+class InvoiceRebillingService {
+  /**
+   *
+   */
+  static async go (invoice, cancelInvoice, rebillInvoice) {
+    const licences = await this._licences(invoice)
+
+    for (const licence of licences) {
+      const cancelLicence = await InvoiceRebillingCreateLicenceService.go(cancelInvoice, licence.licenceNumber)
+      const rebillLicence = await InvoiceRebillingCreateLicenceService.go(rebillInvoice, licence.licenceNumber)
+      await this._populateRebillingLicences(licence, cancelLicence, rebillLicence)
+    }
+  }
+
+  static async _populateRebillingLicences (licence, cancelLicence, rebillLicence) {
+    const transactions = await this._transactions(licence)
+
+    for (const transaction of transactions) {
+      await InvoiceRebillingCreateTransactionService.go(transaction, rebillLicence)
+      await InvoiceRebillingCreateTransactionService.go(transaction, cancelLicence, true)
+    }
+  }
+
+  static _licences (invoice) {
+    return LicenceModel.query()
+      .where('invoiceId', invoice.id)
+      .select(['id', 'licenceNumber'])
+  }
+
+  static _transactions (licence) {
+    return TransactionModel.query()
+      .where('licenceId', licence.id)
+  }
+}
+
+module.exports = InvoiceRebillingService

--- a/test/services/invoice_rebilling.service.test.js
+++ b/test/services/invoice_rebilling.service.test.js
@@ -1,0 +1,146 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const {
+  AuthorisedSystemHelper,
+  BillRunHelper,
+  DatabaseHelper,
+  InvoiceHelper,
+  RegimeHelper,
+  TransactionHelper
+} = require('../support/helpers')
+
+const { LicenceModel, TransactionModel } = require('../../app/models')
+
+// Thing under test
+const { InvoiceRebillingService } = require('../../app/services')
+
+describe.only('Invoice Rebilling service', () => {
+  let currentBillRun
+  let newBillRun
+  let authorisedSystem
+  let regime
+  let cancelInvoice
+  let rebillInvoice
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+
+    regime = await RegimeHelper.addRegime('wrls', 'WRLS')
+    authorisedSystem = await AuthorisedSystemHelper.addSystem('1234546789', 'system1', [regime])
+  })
+
+  describe('When the service is called', () => {
+    beforeEach(async () => {
+      currentBillRun = await BillRunHelper.addBillRun(authorisedSystem.id, regime.id, 'A', 'billed')
+      newBillRun = await BillRunHelper.addBillRun(authorisedSystem.id, regime.id)
+
+      const invoice = await InvoiceHelper.addInvoice(currentBillRun.id, 'CUSTOMER_REFERENCE', 2020)
+      await createPopulatedLicence(invoice, 'LICENCE001')
+      await createPopulatedLicence(invoice, 'LICENCE002')
+      await createPopulatedLicence(invoice, 'LICENCE003')
+
+      cancelInvoice = await addRebillInvoice(newBillRun.id, 'CUSTOMER_REFERENCE', 2020, invoice.id, 'C')
+      rebillInvoice = await addRebillInvoice(newBillRun.id, 'CUSTOMER_REFERENCE', 2020, invoice.id, 'R')
+
+      await InvoiceRebillingService.go(invoice, cancelInvoice, rebillInvoice)
+    })
+
+    describe('cancel licences', () => {
+      let licences
+
+      beforeEach(async () => {
+        licences = await LicenceModel.query().where('invoiceId', cancelInvoice.id)
+      })
+
+      it('are created for each licence of the invoice', async () => {
+        const licenceNumbers = licences.map(licence => licence.licenceNumber)
+
+        expect(licenceNumbers.length).to.equal(3)
+        expect(licenceNumbers).to.only.contain(['LICENCE001', 'LICENCE002', 'LICENCE003'])
+      })
+
+      it('are populated with the original transactions reversed', async () => {
+        for (const licence of licences) {
+          const transactions = await TransactionModel.query().where('licenceId', licence.id)
+          const lineDescriptions = transactions.map(transaction => transaction.lineDescription)
+          const chargeCredits = transactions.map(transaction => transaction.chargeCredit)
+
+          expect(transactions.length).to.equal(3)
+          expect(chargeCredits).to.only.contain(true)
+          expect(lineDescriptions).to.only.contain(['TRANSACTION001', 'TRANSACTION002', 'TRANSACTION003'])
+        }
+      })
+    })
+
+    describe('rebill licences', () => {
+      let licences
+
+      beforeEach(async () => {
+        licences = await LicenceModel.query().where('invoiceId', rebillInvoice.id)
+      })
+
+      it('are created for each licence of the invoice', async () => {
+        const licenceNumbers = licences.map(licence => licence.licenceNumber)
+
+        expect(licenceNumbers.length).to.equal(3)
+        expect(licenceNumbers).to.only.contain(['LICENCE001', 'LICENCE002', 'LICENCE003'])
+      })
+
+      it('are populated with the original transactions', async () => {
+        for (const licence of licences) {
+          const transactions = await TransactionModel.query().where('licenceId', licence.id)
+          const lineDescriptions = transactions.map(transaction => transaction.lineDescription)
+          const chargeCredits = transactions.map(transaction => transaction.chargeCredit)
+
+          expect(transactions.length).to.equal(3)
+          expect(chargeCredits).to.only.contain(false)
+          expect(lineDescriptions).to.only.contain(['TRANSACTION001', 'TRANSACTION002', 'TRANSACTION003'])
+        }
+      })
+    })
+  })
+
+  async function createPopulatedLicence (invoice, licenceNumber) {
+    const licence = await LicenceModel.query()
+      .insert({
+        invoiceId: invoice.id,
+        billRunId: invoice.billRunId,
+        licenceNumber
+      })
+
+    await addTransactionToLicence(invoice, licence, licenceNumber, 'TRANSACTION001')
+    await addTransactionToLicence(invoice, licence, licenceNumber, 'TRANSACTION002')
+    await addTransactionToLicence(invoice, licence, licenceNumber, 'TRANSACTION003')
+
+    return licence
+  }
+
+  async function addTransactionToLicence (invoice, licence, licenceNumber, lineDescription) {
+    await TransactionHelper.addTransaction(currentBillRun.id, {
+      invoiceId: invoice.id,
+      licenceId: licence.id,
+      chargeFinancialYear: 2020,
+      customerReference: 'CUSTOMER_REFERENCE',
+      lineAttr1: licenceNumber,
+      lineDescription
+    })
+  }
+
+  async function addRebillInvoice (billRunId, customerReference, financialYear, rebilledInvoiceId, rebilledType) {
+    return InvoiceHelper.addInvoice(
+      billRunId,
+      customerReference,
+      financialYear,
+      0, 0, 0, 0, 0, 0, 0, 0,
+      rebilledInvoiceId,
+      rebilledType)
+  }
+})

--- a/test/services/invoice_rebilling.service.test.js
+++ b/test/services/invoice_rebilling.service.test.js
@@ -87,7 +87,7 @@ describe('Invoice Rebilling service', () => {
         licences = await LicenceModel.query().where('invoiceId', rebillInvoice.id)
       })
 
-      it('are created for each licence of the invoice', async () => {
+      it('are created for each licence of the original invoice', async () => {
         const licenceNumbers = licences.map(licence => licence.licenceNumber)
 
         expect(licenceNumbers.length).to.equal(3)

--- a/test/services/invoice_rebilling.service.test.js
+++ b/test/services/invoice_rebilling.service.test.js
@@ -60,7 +60,7 @@ describe('Invoice Rebilling service', () => {
         licences = await LicenceModel.query().where('invoiceId', cancelInvoice.id)
       })
 
-      it('are created for each licence of the invoice', async () => {
+      it('are created for each licence of the original invoice', async () => {
         const licenceNumbers = licences.map(licence => licence.licenceNumber)
 
         expect(licenceNumbers.length).to.equal(3)

--- a/test/services/invoice_rebilling.service.test.js
+++ b/test/services/invoice_rebilling.service.test.js
@@ -22,7 +22,7 @@ const { LicenceModel, TransactionModel } = require('../../app/models')
 // Thing under test
 const { InvoiceRebillingService } = require('../../app/services')
 
-describe.only('Invoice Rebilling service', () => {
+describe('Invoice Rebilling service', () => {
   let currentBillRun
   let newBillRun
   let authorisedSystem

--- a/test/services/invoice_rebilling_create_transaction.service.test.js
+++ b/test/services/invoice_rebilling_create_transaction.service.test.js
@@ -43,7 +43,7 @@ describe('Invoice Rebilling Create Transaction service', () => {
     let licence
 
     beforeEach(async () => {
-      const invoice = await InvoiceHelper.addInvoice(rebillBillRun.id, 'TH230000222', 2021)
+      const invoice = await addRebillInvoice(rebillBillRun.id, 'TH230000222', 2021, null, 'R')
       licence = await LicenceHelper.addLicence(rebillBillRun.id, 'TONY/TF9222/37', invoice.id)
       transaction = await TransactionHelper.addTransaction(originalBillRun.id, { chargeFinancialYear: 2021 })
 
@@ -98,7 +98,7 @@ describe('Invoice Rebilling Create Transaction service', () => {
     let licence
 
     beforeEach(async () => {
-      const invoice = await InvoiceHelper.addInvoice(rebillBillRun.id, 'TH230000222', 2021)
+      const invoice = await addRebillInvoice(rebillBillRun.id, 'TH230000222', 2021, null, 'C')
       licence = await LicenceHelper.addLicence(rebillBillRun.id, 'TONY/TF9222/37', invoice.id)
     })
 
@@ -132,4 +132,14 @@ describe('Invoice Rebilling Create Transaction service', () => {
       })
     })
   })
+
+  async function addRebillInvoice (billRunId, customerReference, financialYear, rebilledInvoiceId, rebilledType) {
+    return InvoiceHelper.addInvoice(
+      billRunId,
+      customerReference,
+      financialYear,
+      0, 0, 0, 0, 0, 0, 0, 0,
+      rebilledInvoiceId,
+      rebilledType)
+  }
 })

--- a/test/support/helpers/invoice.helper.js
+++ b/test/support/helpers/invoice.helper.js
@@ -19,6 +19,9 @@ class InvoiceHelper {
    *  invoice.
    * @param {integer} [subjectToMinimumChargeDebitValue] Total value of minimum charge debit transactions in the
    *  invoice.
+   * @param {string} [rebilledInvoiceId] Id of the invoice this will rebill.
+   * @param {string} [rebilledType] The rebill invoice type: 'C' for cancel invoice, 'R' for rebill invoice (the db
+   * defaults to 'O' for ordinary invoice)
    *
    * @returns {module:InvoiceModel} The newly created instance of `InvoiceModel`.
    */
@@ -33,7 +36,9 @@ class InvoiceHelper {
     zeroLineCount = 0,
     subjectToMinimumChargeCount = 0,
     subjectToMinimumChargeCreditValue = 0,
-    subjectToMinimumChargeDebitValue = 0
+    subjectToMinimumChargeDebitValue = 0,
+    rebilledInvoiceId = undefined,
+    rebilledType = undefined
   ) {
     const flags = this._flags(
       creditLineCount,
@@ -58,6 +63,8 @@ class InvoiceHelper {
         subjectToMinimumChargeCount,
         subjectToMinimumChargeCreditValue,
         subjectToMinimumChargeDebitValue,
+        rebilledInvoiceId,
+        rebilledType,
         ...flags
       })
       .returning('*')


### PR DESCRIPTION
https://trello.com/c/qkWbpJlf/1962-m-create-re-billing-transactions

This change introduces the `InvoiceRebillingService` which accepts an invoice and will copy its licences and transactions to the supplied cancel invoice (with transaction types swapped so that credits become debits and vice-versa) and rebill invoice.

During development we found that `InvoiceModel` needed to be amended to accommodate `rebilledType` -- this change is included in this PR.