### PR TITLE
Add rebilling validation for cancel invoices

### DIFF
--- a/app/services/invoice_rebilling_validation.service.js
+++ b/app/services/invoice_rebilling_validation.service.js
@@ -13,7 +13,8 @@ class InvoiceRebillingValidationService {
   * Validates that an invoice exists and that it is suitable for rebilling:
   * - The invoice does not already belong to the bill run it is being rebilled to;
   * - The status of its current bill run is 'billed';
-  * - The region of the bill run it is being rebilled to matches the region of its current bill run.
+  * - The region of the bill run it is being rebilled to matches the region of its current bill run;
+  * - It is not a rebill cancel invoice.
   *
   * Note that we do not validate the status of the bill run we will rebill to as this will have already been handled by
   * our bill run plugin (since we pass the new bill run in the url).
@@ -29,6 +30,7 @@ class InvoiceRebillingValidationService {
     this._validateNotOnNewBillRun(currentBillRun, newBillRun, invoice.id)
     this._validateCurrentBillRunStatus(currentBillRun)
     this._validateRegion(currentBillRun, newBillRun, invoice.id)
+    this._validateNotCancelInvoice(invoice)
 
     return true
   }
@@ -53,6 +55,14 @@ class InvoiceRebillingValidationService {
     if (currentBillRun.region !== newBillRun.region) {
       throw Boom.conflict(
           `Invoice ${invoiceId} is for region ${currentBillRun.region} but bill run ${newBillRun.id} is for region ${newBillRun.region}.`
+      )
+    }
+  }
+
+  static _validateNotCancelInvoice (invoice) {
+    if (invoice.rebilledType === 'C') {
+      throw Boom.conflict(
+          `Invoice ${invoice.id} is a rebill cancel invoice and cannot be rebilled.`
       )
     }
   }

--- a/test/services/invoice_rebilling_validation.service.test.js
+++ b/test/services/invoice_rebilling_validation.service.test.js
@@ -46,6 +46,18 @@ describe('Invoice Rebilling Validation service', () => {
 
         expect(result).to.be.true()
       })
+
+      describe('which is a rebill invoice', () => {
+        it('returns `true`', async () => {
+          const invoice = await InvoiceHelper.addInvoice(
+            currentBillRun.id, 'CUSTOMER REFERENCE', 2020, 0, 0, 0, 0, 0, 0, 0, 0, null, 'R'
+          )
+
+          const result = await InvoiceRebillingValidationService.go(newBillRun, invoice)
+
+          expect(result).to.be.true()
+        })
+      })
     })
 
     describe('and an invalid invoice ID', () => {
@@ -76,6 +88,23 @@ describe('Invoice Rebilling Validation service', () => {
           expect(err).to.be.an.error()
           expect(err.output.payload.message).to.equal(
             `Bill run ${invalidCurrentBillRun.id} does not have a status of 'billed'.`
+          )
+        })
+      })
+
+      describe('because it is a rebill cancel invoice', () => {
+        it('throws an error', async () => {
+          const invoice = await InvoiceHelper.addInvoice(
+            currentBillRun.id, 'CUSTOMER REFERENCE', 2020, 0, 0, 0, 0, 0, 0, 0, 0, null, 'C'
+          )
+
+          const err = await expect(
+            InvoiceRebillingValidationService.go(newBillRun, invoice)
+          ).to.reject()
+
+          expect(err).to.be.an.error()
+          expect(err.output.payload.message).to.equal(
+            `Invoice ${invoice.id} is a rebill cancel invoice and cannot be rebilled.`
           )
         })
       })


### PR DESCRIPTION
When an invoice is rebilled, two rebill invoices are created: the cancel invoice, which cancels out the original invoice, and the rebill invoice, which bills the customer. We have had confirmation that rebill invoices can be rebilled but cancel invoices cannot; this change adds additional validation for this.