### PR TITLE
Add auth scope to invoice rebill endpoint

### DIFF
--- a/app/routes/bill_run_invoice.routes.js
+++ b/app/routes/bill_run_invoice.routes.js
@@ -16,7 +16,13 @@ const routes = [
   {
     method: 'PATCH',
     path: '/v2/{regimeId}/bill-runs/{billRunId}/invoices/{invoiceId}/rebill',
-    handler: PresrocBillRunsInvoicesController.rebill
+    handler: PresrocBillRunsInvoicesController.rebill,
+    options: {
+      description: 'Feature not yet complete.',
+      auth: {
+        scope: ['admin']
+      }
+    }
   }
 ]
 

--- a/test/support/helpers/authorised_system.helper.js
+++ b/test/support/helpers/authorised_system.helper.js
@@ -21,12 +21,15 @@ class AuthorisedSystemHelper {
    * @param {string} [clientId] If not set will default to the configured admin client ID.
    * @param {string} [name='active'] Name to be set for the new user
    * @param {string} [status='active'] Status to be set for the new user
+   * @param {module:RegimeModel} [regime] If not set will automatically create a regime to use
    *
    * @returns {module:AuthorisedSystemModel} The result of the db insertion for your reference
    */
-  static async addAdminSystem (clientId, name = 'admin', status = 'active') {
+  static async addAdminSystem (clientId, name = 'admin', status = 'active', regime = null) {
     const systemId = clientId || AuthenticationConfig.adminClientId
-    const regime = await RegimeHelper.addRegime('wrls', 'water')
+    if (!regime) {
+      regime = await RegimeHelper.addRegime('wrls', 'water')
+    }
 
     return this._insertSystem(systemId, name, true, status, [regime])
   }


### PR DESCRIPTION
https://trello.com/c/sMC4Ns4D

We have recently added the `PATCH /v2/{regimeId}/bill-runs/{billRunId}/invoices/{invoiceId}/rebill` endpoint as part of implementing a new feature that allows for an invoice to be rebilled (cancelled out by one new invoice and regenerated in another).

This work won't be complete before we go live with the rest of our other functionality but the endpoint would currently be available. Though we wouldn't expect our client systems to attempt to use it, just to be sure we are ensuring access to it is only possible by the admin user.

So, this change adds the admin auth scope to the route's options plus any tweaks needed to make this work.