### PR TITLE
Rebilling error handling

### DIFF
--- a/app/services/invoice_rebilling.service.js
+++ b/app/services/invoice_rebilling.service.js
@@ -27,19 +27,21 @@ class InvoiceRebillingService {
   static async go (invoice, cancelInvoice, rebillInvoice, authorisedSystem) {
     const licences = await this._licences(invoice)
 
-    for (const licence of licences) {
-      const cancelLicence = await InvoiceRebillingCreateLicenceService.go(cancelInvoice, licence.licenceNumber)
-      const rebillLicence = await InvoiceRebillingCreateLicenceService.go(rebillInvoice, licence.licenceNumber)
-      await this._populateRebillingLicences(licence, cancelLicence, rebillLicence, authorisedSystem)
-    }
+    await LicenceModel.transaction(async trx => {
+      for (const licence of licences) {
+        const cancelLicence = await InvoiceRebillingCreateLicenceService.go(cancelInvoice, licence.licenceNumber, trx)
+        const rebillLicence = await InvoiceRebillingCreateLicenceService.go(rebillInvoice, licence.licenceNumber, trx)
+        await this._populateRebillingLicences(licence, cancelLicence, rebillLicence, authorisedSystem, trx)
+      }
+    })
   }
 
-  static async _populateRebillingLicences (licence, cancelLicence, rebillLicence, authorisedSystem) {
-    const transactions = await this._transactions(licence)
+  static async _populateRebillingLicences (licence, cancelLicence, rebillLicence, authorisedSystem, trx) {
+    const transactions = await this._transactions(licence, trx)
 
     for (const transaction of transactions) {
-      await InvoiceRebillingCreateTransactionService.go(transaction, rebillLicence, authorisedSystem)
-      await InvoiceRebillingCreateTransactionService.go(transaction, cancelLicence, authorisedSystem, true)
+      await InvoiceRebillingCreateTransactionService.go(transaction, rebillLicence, authorisedSystem, trx)
+      await InvoiceRebillingCreateTransactionService.go(transaction, cancelLicence, authorisedSystem, trx, true)
     }
   }
 
@@ -49,8 +51,8 @@ class InvoiceRebillingService {
       .select(['id', 'licenceNumber'])
   }
 
-  static _transactions (licence) {
-    return TransactionModel.query()
+  static _transactions (licence, trx) {
+    return TransactionModel.query(trx)
       .where('licenceId', licence.id)
   }
 }

--- a/app/services/invoice_rebilling_create_licence.service.js
+++ b/app/services/invoice_rebilling_create_licence.service.js
@@ -12,10 +12,11 @@ class InvoiceRebillingCreateLicenceService {
    *
    * @param {module:InvoiceModel} invoice The invoice that the licence is to be created on.
    * @param {string} licenceNumber The licence number that the licence should be created with.
+   * @param {Object} [trx] Optional DB transaction this is being performed as part of.
    * @returns {module:LicenceModel} An instance of `LicenceModel` for the newly-created and persisted licence.
    */
-  static async go (invoice, licenceNumber) {
-    return LicenceModel.query()
+  static async go (invoice, licenceNumber, trx = null) {
+    return LicenceModel.query(trx)
       .insert({
         invoiceId: invoice.id,
         billRunId: invoice.billRunId,

--- a/test/services/invoice_rebilling_create_transaction.service.test.js
+++ b/test/services/invoice_rebilling_create_transaction.service.test.js
@@ -127,7 +127,9 @@ describe('Invoice Rebilling Create Transaction service', () => {
           chargeCredit: false
         })
 
-        result = await InvoiceRebillingCreateTransactionService.go(transaction, licence, rebillAuthorisedSystem, true)
+        result = await InvoiceRebillingCreateTransactionService.go(
+          transaction, licence, rebillAuthorisedSystem, null, true
+        )
       })
 
       it('creates a credit', async () => {
@@ -142,7 +144,9 @@ describe('Invoice Rebilling Create Transaction service', () => {
           chargeCredit: true
         })
 
-        result = await InvoiceRebillingCreateTransactionService.go(transaction, licence, rebillAuthorisedSystem, true)
+        result = await InvoiceRebillingCreateTransactionService.go(
+          transaction, licence, rebillAuthorisedSystem, null, true
+        )
       })
 
       it('creates a debit', async () => {


### PR DESCRIPTION
We look to implement error handling in rebilling in two ways:
* We wrap everything in a single db transaction so if any part of it fails, we are returned to a "clean" state.
* We ensure that errors that occur as part of the `InvoiceRebillingService` background task are caught and logged using are notifier.