### PR TITLE
Add update (PATCH) authorised systems endpoint

### DIFF
--- a/app/controllers/admin/authorised_systems.controller.js
+++ b/app/controllers/admin/authorised_systems.controller.js
@@ -3,7 +3,8 @@
 const {
   CreateAuthorisedSystemService,
   ListAuthorisedSystemsService,
-  ShowAuthorisedSystemService
+  ShowAuthorisedSystemService,
+  UpdateAuthorisedSystemService
 } = require('../../services')
 
 class AuthorisedSystemsController {
@@ -26,6 +27,8 @@ class AuthorisedSystemsController {
   }
 
   static async update (req, h) {
+    await UpdateAuthorisedSystemService.go(req.params.id, req.payload)
+
     return h.response().code(204)
   }
 }

--- a/app/controllers/admin/authorised_systems.controller.js
+++ b/app/controllers/admin/authorised_systems.controller.js
@@ -24,6 +24,10 @@ class AuthorisedSystemsController {
 
     return h.response(result).code(201)
   }
+
+  static async update (req, h) {
+    return h.response().code(204)
+  }
 }
 
 module.exports = AuthorisedSystemsController

--- a/app/routes/authorised_system.routes.js
+++ b/app/routes/authorised_system.routes.js
@@ -32,6 +32,16 @@ const routes = [
         scope: ['admin']
       }
     }
+  },
+  {
+    method: 'PATCH',
+    path: '/admin/authorised-systems/{id}',
+    handler: AuthorisedSystemsController.update,
+    options: {
+      auth: {
+        scope: ['admin']
+      }
+    }
   }
 ]
 

--- a/app/services/index.js
+++ b/app/services/index.js
@@ -55,6 +55,7 @@ const StreamTransformCSVService = require('./streams/stream_transform_csv.servic
 const StreamTransformUsingPresenterService = require('./streams/stream_transform_using_presenter.service')
 const StreamWritableFileService = require('./streams/stream_writable_file.service')
 const TransformRecordsToFileService = require('./transform_records_to_file.service')
+const UpdateAuthorisedSystemService = require('./update_authorised_system.service')
 const ViewBillRunService = require('./view_bill_run.service')
 const ViewBillRunInvoiceService = require('./view_bill_run_invoice.service')
 
@@ -114,6 +115,7 @@ module.exports = {
   StreamTransformUsingPresenterService,
   StreamWritableFileService,
   TransformRecordsToFileService,
+  UpdateAuthorisedSystemService,
   ViewBillRunService,
   ViewBillRunInvoiceService
 }

--- a/app/services/update_authorised_system.service.js
+++ b/app/services/update_authorised_system.service.js
@@ -16,12 +16,28 @@ class UpdateAuthorisedSystemService {
 
     this._validateAuthorisedSystem(id, authorisedSystem)
     await this._validatePayload(payload)
+
+    const patch = this._patch(payload)
+    await this._update(authorisedSystem, patch)
   }
 
   static _authorisedSystem (id) {
     return AuthorisedSystemModel.query()
       .findById(id)
       .withGraphFetched('regimes')
+  }
+
+  static _patch (payload) {
+    const patch = {}
+    if (payload.status) {
+      patch.status = payload.status
+    }
+
+    return patch
+  }
+
+  static async _update (authorisedSystem, patch) {
+    await authorisedSystem.$query().patch(patch)
   }
 
   static _validateAuthorisedSystem (id, authorisedSystem) {

--- a/app/services/update_authorised_system.service.js
+++ b/app/services/update_authorised_system.service.js
@@ -114,7 +114,7 @@ class UpdateAuthorisedSystemService {
 
   static _validatePayloadStatus (payload) {
     if (payload.status && !['active', 'inactive'].includes(payload.status)) {
-      throw Boom.badData(`${payload.status} is not valid a status. Can only be active or inactive.`)
+      throw Boom.badData(`${payload.status} is not a valid status. Can only be active or inactive.`)
     }
   }
 

--- a/app/services/update_authorised_system.service.js
+++ b/app/services/update_authorised_system.service.js
@@ -14,7 +14,8 @@ class UpdateAuthorisedSystemService {
   static async go (id, payload) {
     const authorisedSystem = await this._authorisedSystem(id)
 
-    this._validate(id, payload, authorisedSystem)
+    this._validate(id, authorisedSystem)
+    this._validatePayload(payload)
   }
 
   static _authorisedSystem (id) {
@@ -23,18 +24,26 @@ class UpdateAuthorisedSystemService {
       .withGraphFetched('regimes')
   }
 
-  static _validate (id, payload, authorisedSystem) {
+  static _validate (id, authorisedSystem) {
     if (!authorisedSystem) {
       throw Boom.notFound(`No authorised system found with id ${id}`)
     }
     if (authorisedSystem.clientId === AuthenticationConfig.adminClientId) {
       throw Boom.conflict('You cannot update the main admin.')
     }
+  }
+
+  static _validatePayload (payload) {
     // Unlike `POST` requests PATCH requests are not checked for a payload because we specifically use them in
     // situations where no payload is expected, for example, approving a bill run. In this instance we do expect a
     // payload which is why we have the check.
     if (!payload) {
       throw Boom.badData('The payload was empty.')
+    }
+    if (payload.status) {
+      if (!['active', 'inactive'].includes(payload.status)) {
+        throw Boom.badData(`${payload.status} is not valid a status. Can only be active or inactive.`)
+      }
     }
   }
 }

--- a/app/services/update_authorised_system.service.js
+++ b/app/services/update_authorised_system.service.js
@@ -14,7 +14,7 @@ class UpdateAuthorisedSystemService {
   static async go (id, payload) {
     const authorisedSystem = await this._authorisedSystem(id)
 
-    this._validate(id, authorisedSystem)
+    this._validate(id, payload, authorisedSystem)
   }
 
   static _authorisedSystem (id) {
@@ -23,12 +23,18 @@ class UpdateAuthorisedSystemService {
       .withGraphFetched('regimes')
   }
 
-  static _validate (id, authorisedSystem) {
+  static _validate (id, payload, authorisedSystem) {
     if (!authorisedSystem) {
       throw Boom.notFound(`No authorised system found with id ${id}`)
     }
     if (authorisedSystem.clientId === AuthenticationConfig.adminClientId) {
       throw Boom.conflict('You cannot update the main admin.')
+    }
+    // Unlike `POST` requests PATCH requests are not checked for a payload because we specifically use them in
+    // situations where no payload is expected, for example, approving a bill run. In this instance we do expect a
+    // payload which is why we have the check.
+    if (!payload) {
+      throw Boom.badData('The payload was empty.')
     }
   }
 }

--- a/app/services/update_authorised_system.service.js
+++ b/app/services/update_authorised_system.service.js
@@ -35,9 +35,8 @@ class UpdateAuthorisedSystemService {
    * }
    * ```
    *
-   * On regimes, the update
-   * will replace the existing ones with whatever is specified. So, if for example the authorised system was linked to
-   * 'cfd' and you also wanted to add 'wrls', your payload would need to be
+   * On regimes, the update will replace the existing ones with whatever is specified. So, if for example the authorised
+   * system was linked to 'cfd' and you also wanted to add 'wrls', your payload would need to be
    *
    * ```
    * {

--- a/app/services/update_authorised_system.service.js
+++ b/app/services/update_authorised_system.service.js
@@ -8,19 +8,28 @@ const Boom = require('@hapi/boom')
 
 const { AuthorisedSystemModel } = require('../models')
 
+const { AuthenticationConfig } = require('../../config')
+
 class UpdateAuthorisedSystemService {
   static async go (id, payload) {
     const authorisedSystem = await this._authorisedSystem(id)
 
-    if (!authorisedSystem) {
-      throw Boom.notFound(`No authorised system found with id ${id}`)
-    }
+    this._validate(id, authorisedSystem)
   }
 
   static _authorisedSystem (id) {
     return AuthorisedSystemModel.query()
       .findById(id)
       .withGraphFetched('regimes')
+  }
+
+  static _validate (id, authorisedSystem) {
+    if (!authorisedSystem) {
+      throw Boom.notFound(`No authorised system found with id ${id}`)
+    }
+    if (authorisedSystem.clientId === AuthenticationConfig.adminClientId) {
+      throw Boom.conflict('You cannot update the main admin.')
+    }
   }
 }
 

--- a/app/services/update_authorised_system.service.js
+++ b/app/services/update_authorised_system.service.js
@@ -60,6 +60,7 @@ class UpdateAuthorisedSystemService {
       throw Boom.badData('The payload was empty.')
     }
     this._validatePayloadStatus(payload)
+    this._validatePayloadName(payload)
     await this._validatePayloadRegimes(payload)
   }
 
@@ -67,6 +68,14 @@ class UpdateAuthorisedSystemService {
     if (payload.status) {
       if (!['active', 'inactive'].includes(payload.status)) {
         throw Boom.badData(`${payload.status} is not valid a status. Can only be active or inactive.`)
+      }
+    }
+  }
+
+  static _validatePayloadName (payload) {
+    if (payload.name) {
+      if (payload.name.trim().toLowerCase() === 'admin') {
+        throw Boom.badData(`You cannot use the name ${payload.name}. There can be only one!`)
       }
     }
   }

--- a/app/services/update_authorised_system.service.js
+++ b/app/services/update_authorised_system.service.js
@@ -33,7 +33,7 @@ class UpdateAuthorisedSystemService {
       patch.status = payload.status
     }
     if (payload.name) {
-      patch.name = payload.name.trim()
+      patch.name = payload.name
     }
 
     return patch
@@ -74,7 +74,7 @@ class UpdateAuthorisedSystemService {
 
   static _validatePayloadName (payload) {
     if (payload.name) {
-      if (payload.name.trim().toLowerCase() === 'admin') {
+      if (payload.name.toLowerCase() === 'admin') {
         throw Boom.badData(`You cannot use the name ${payload.name}. There can be only one!`)
       }
     }

--- a/app/services/update_authorised_system.service.js
+++ b/app/services/update_authorised_system.service.js
@@ -114,18 +114,14 @@ class UpdateAuthorisedSystemService {
   }
 
   static _validatePayloadStatus (payload) {
-    if (payload.status) {
-      if (!['active', 'inactive'].includes(payload.status)) {
-        throw Boom.badData(`${payload.status} is not valid a status. Can only be active or inactive.`)
-      }
+    if (payload.status && !['active', 'inactive'].includes(payload.status)) {
+      throw Boom.badData(`${payload.status} is not valid a status. Can only be active or inactive.`)
     }
   }
 
   static _validatePayloadName (payload) {
-    if (payload.name) {
-      if (payload.name.toLowerCase() === 'admin') {
-        throw Boom.badData(`You cannot use the name ${payload.name}. There can be only one!`)
-      }
+    if (payload.name && payload.name.toLowerCase() === 'admin') {
+      throw Boom.badData(`You cannot use the name ${payload.name}. There can be only one!`)
     }
   }
 

--- a/app/services/update_authorised_system.service.js
+++ b/app/services/update_authorised_system.service.js
@@ -11,6 +11,43 @@ const { AuthorisedSystemModel, RegimeModel } = require('../models')
 const { AuthenticationConfig } = require('../../config')
 
 class UpdateAuthorisedSystemService {
+  /**
+   * Update the details of an authorised system record
+   *
+   * Intended to be used with the `AuthorisedSystemsController.update()` action it allows us to update certain details
+   * of an authorised system record.
+   *
+   * The request is first validated in a number of ways
+   *
+   * - the authorised system to be updated exists
+   * - the request is not attempting to update the main 'admin' record
+   * - if specified the new status is a recognised one
+   * - if specified the new name is not 'admin' (there can be only one!)
+   * - if specified the regimes listed are all recognised
+   *
+   * As the list infers, the update can be for one thing or all of them as long as its valid.
+   *
+   * ```
+   * {
+   *   "status": "inactive",
+   *   "name": "Old WRLS Account",
+   *   "regimes": ["cfd", "wrls"]
+   * }
+   * ```
+   *
+   * On regimes, the update
+   * will replace the existing ones with whatever is specified. So, if for example the authorised system was linked to
+   * 'cfd' and you also wanted to add 'wrls', your payload would need to be
+   *
+   * ```
+   * {
+   *   regimes: ['cfd', 'wrls']
+   * }
+   * ```
+   *
+   * @param {string} id Id of the authorised system to be updated
+   * @param {Object} payload Details of the changes to be made to the autorised system
+   */
   static async go (id, payload) {
     const authorisedSystem = await this._authorisedSystem(id)
 

--- a/app/services/update_authorised_system.service.js
+++ b/app/services/update_authorised_system.service.js
@@ -32,6 +32,9 @@ class UpdateAuthorisedSystemService {
     if (payload.status) {
       patch.status = payload.status
     }
+    if (payload.name) {
+      patch.name = payload.name.trim()
+    }
 
     return patch
   }

--- a/app/services/update_authorised_system.service.js
+++ b/app/services/update_authorised_system.service.js
@@ -1,0 +1,27 @@
+'use strict'
+
+/**
+ * @module UpdateAuthorisedSystemService
+ */
+
+const Boom = require('@hapi/boom')
+
+const { AuthorisedSystemModel } = require('../models')
+
+class UpdateAuthorisedSystemService {
+  static async go (id, payload) {
+    const authorisedSystem = await this._authorisedSystem(id)
+
+    if (!authorisedSystem) {
+      throw Boom.notFound(`No authorised system found with id ${id}`)
+    }
+  }
+
+  static _authorisedSystem (id) {
+    return AuthorisedSystemModel.query()
+      .findById(id)
+      .withGraphFetched('regimes')
+  }
+}
+
+module.exports = UpdateAuthorisedSystemService

--- a/test/controllers/admin/authorised_systems.controller.test.js
+++ b/test/controllers/admin/authorised_systems.controller.test.js
@@ -157,4 +157,38 @@ describe('Authorised systems controller', () => {
       expect(response.statusCode).to.equal(422)
     })
   })
+
+  describe('Updating an authorised system: PATCH /admin/authorised-systems/{id}', () => {
+    const options = (id, token) => {
+      return {
+        method: 'PATCH',
+        url: `/admin/authorised-systems/${id}`,
+        headers: { authorization: `Bearer ${token}` }
+      }
+    }
+
+    describe('When the request is valid', () => {
+      it('returns success status 204', async () => {
+        const authorisedSystem = await AuthorisedSystemHelper.addSystem('1234546789', 'system1')
+
+        const response = await server.inject(options(authorisedSystem.id, authToken))
+
+        expect(response.statusCode).to.equal(204)
+      })
+    })
+
+    describe('When the request is valid', () => {
+      describe('because the authorised system does not exist', () => {
+        it("returns a 404 'not found' response", async () => {
+          const id = GeneralHelper.uuid4()
+          const response = await server.inject(options(id, authToken))
+
+          const payload = JSON.parse(response.payload)
+
+          expect(response.statusCode).to.equal(404)
+          expect(payload.message).to.equal(`No authorised system found with id ${id}`)
+        })
+      })
+    })
+  })
 })

--- a/test/controllers/admin/authorised_systems.controller.test.js
+++ b/test/controllers/admin/authorised_systems.controller.test.js
@@ -159,19 +159,21 @@ describe('Authorised systems controller', () => {
   })
 
   describe('Updating an authorised system: PATCH /admin/authorised-systems/{id}', () => {
-    const options = (id, token) => {
+    const options = (id, token, payload) => {
       return {
         method: 'PATCH',
         url: `/admin/authorised-systems/${id}`,
-        headers: { authorization: `Bearer ${token}` }
+        headers: { authorization: `Bearer ${token}` },
+        payload: payload
       }
     }
 
     describe('When the request is valid', () => {
       it('returns success status 204', async () => {
+        const payload = { status: 'inactive' }
         const authorisedSystem = await AuthorisedSystemHelper.addSystem('1234546789', 'system1')
 
-        const response = await server.inject(options(authorisedSystem.id, authToken))
+        const response = await server.inject(options(authorisedSystem.id, authToken, payload))
 
         expect(response.statusCode).to.equal(204)
       })

--- a/test/services/update_authorised_system.service.test.js
+++ b/test/services/update_authorised_system.service.test.js
@@ -8,7 +8,7 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const { AuthorisedSystemHelper, DatabaseHelper, GeneralHelper } = require('../support/helpers')
+const { AuthorisedSystemHelper, DatabaseHelper, GeneralHelper, RegimeHelper } = require('../support/helpers')
 const { DataError } = require('objection')
 
 // Thing under test
@@ -16,11 +16,27 @@ const { UpdateAuthorisedSystemService } = require('../../app/services')
 
 describe('Update Authorised System service', () => {
   let adminAuthSystem
+  let updateAuthSystem
+  let regime
 
   beforeEach(async () => {
     await DatabaseHelper.clean()
 
-    adminAuthSystem = await AuthorisedSystemHelper.addAdminSystem()
+    regime = await RegimeHelper.addRegime('ice', 'Ice')
+
+    adminAuthSystem = await AuthorisedSystemHelper.addAdminSystem(null, 'admin', 'active', regime)
+    updateAuthSystem = await AuthorisedSystemHelper.addSystem('1234546789', 'UpdateMe', [regime])
+  })
+
+  describe('When a valid authorised system ID is supplied', () => {
+    describe('but the payload is empty', () => {
+      it('throws an error', async () => {
+        const id = updateAuthSystem.id
+        const err = await expect(UpdateAuthorisedSystemService.go(id)).to.reject(Error, 'The payload was empty.')
+
+        expect(err).to.be.an.error()
+      })
+    })
   })
 
   describe('When an invalid authorised system ID is supplied', () => {

--- a/test/services/update_authorised_system.service.test.js
+++ b/test/services/update_authorised_system.service.test.js
@@ -1,0 +1,38 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const { DatabaseHelper, GeneralHelper } = require('../support/helpers')
+const { DataError } = require('objection')
+
+// Thing under test
+const { UpdateAuthorisedSystemService } = require('../../app/services')
+
+describe('Update Authorised System service', () => {
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+  })
+
+  describe('When there is no matching authorised system', () => {
+    it('throws an error', async () => {
+      const id = GeneralHelper.uuid4()
+      const err = await expect(UpdateAuthorisedSystemService.go(id)).to.reject(Error, `No authorised system found with id ${id}`)
+
+      expect(err).to.be.an.error()
+    })
+  })
+
+  describe('When an invalid UUID is used', () => {
+    it('returns throws an error', async () => {
+      const err = await expect(UpdateAuthorisedSystemService.go('123456789')).to.reject(DataError)
+
+      expect(err).to.be.an.error()
+    })
+  })
+})

--- a/test/services/update_authorised_system.service.test.js
+++ b/test/services/update_authorised_system.service.test.js
@@ -55,6 +55,27 @@ describe('Update Authorised System service', () => {
       })
     })
 
+    describe('and the payload contains a regime change', () => {
+      let newRegime
+
+      beforeEach(async () => {
+        newRegime = await RegimeHelper.addRegime('fire', 'Fire')
+      })
+
+      it('applies the update', async () => {
+        const payload = { regimes: [newRegime.slug] }
+        const id = updateAuthSystem.id
+
+        await UpdateAuthorisedSystemService.go(id, payload)
+
+        const refreshedAuthSystem = await updateAuthSystem.$query().withGraphFetched('regimes')
+
+        expect(refreshedAuthSystem.regimes.length).to.equal(1)
+        expect(refreshedAuthSystem.regimes[0].slug).to.equal(newRegime.slug)
+        expect(refreshedAuthSystem.regimes[0].id).to.equal(newRegime.id)
+      })
+    })
+
     describe('but the payload is empty', () => {
       it('throws an error', async () => {
         const id = updateAuthSystem.id

--- a/test/services/update_authorised_system.service.test.js
+++ b/test/services/update_authorised_system.service.test.js
@@ -78,6 +78,18 @@ describe('Update Authorised System service', () => {
       })
     })
 
+    describe('but the payload contains an invalid name', () => {
+      it('throws an error', async () => {
+        const payload = { name: 'admin' }
+        const id = updateAuthSystem.id
+        const err = await expect(UpdateAuthorisedSystemService.go(id, payload))
+          .to
+          .reject(Error, `You cannot use the name ${payload.name}. There can be only one!`)
+
+        expect(err).to.be.an.error()
+      })
+    })
+
     describe('but the payload contains an unknown regime', () => {
       it('throws an error', async () => {
         const payload = { status: 'active', regimes: ['ice', 'fire'] }

--- a/test/services/update_authorised_system.service.test.js
+++ b/test/services/update_authorised_system.service.test.js
@@ -29,6 +29,19 @@ describe('Update Authorised System service', () => {
   })
 
   describe('When a valid authorised system ID is supplied', () => {
+    describe('and the payload contains a status change', () => {
+      it('applies the update', async () => {
+        const payload = { status: 'inactive' }
+        const id = updateAuthSystem.id
+
+        await UpdateAuthorisedSystemService.go(id, payload)
+
+        const refreshedAuthSystem = await updateAuthSystem.$query()
+
+        expect(refreshedAuthSystem.status).to.equal('inactive')
+      })
+    })
+
     describe('but the payload is empty', () => {
       it('throws an error', async () => {
         const id = updateAuthSystem.id

--- a/test/services/update_authorised_system.service.test.js
+++ b/test/services/update_authorised_system.service.test.js
@@ -93,7 +93,7 @@ describe('Update Authorised System service', () => {
         const id = updateAuthSystem.id
         const err = await expect(UpdateAuthorisedSystemService.go(id, payload))
           .to
-          .reject(Error, `${payload.status} is not valid a status. Can only be active or inactive.`)
+          .reject(Error, `${payload.status} is not a valid status. Can only be active or inactive.`)
 
         expect(err).to.be.an.error()
       })

--- a/test/services/update_authorised_system.service.test.js
+++ b/test/services/update_authorised_system.service.test.js
@@ -51,6 +51,18 @@ describe('Update Authorised System service', () => {
         expect(err).to.be.an.error()
       })
     })
+
+    describe('but the payload contains an unknown regime', () => {
+      it('throws an error', async () => {
+        const payload = { status: 'active', regimes: ['ice', 'fire'] }
+        const id = updateAuthSystem.id
+        const err = await expect(UpdateAuthorisedSystemService.go(id, payload))
+          .to
+          .reject(Error, 'One or more of the regimes is unrecognised.')
+
+        expect(err).to.be.an.error()
+      })
+    })
   })
 
   describe('When an invalid authorised system ID is supplied', () => {

--- a/test/services/update_authorised_system.service.test.js
+++ b/test/services/update_authorised_system.service.test.js
@@ -42,6 +42,19 @@ describe('Update Authorised System service', () => {
       })
     })
 
+    describe('and the payload contains a name change', () => {
+      it('applies the update', async () => {
+        const payload = { name: 'fiddle' }
+        const id = updateAuthSystem.id
+
+        await UpdateAuthorisedSystemService.go(id, payload)
+
+        const refreshedAuthSystem = await updateAuthSystem.$query()
+
+        expect(refreshedAuthSystem.name).to.equal('fiddle')
+      })
+    })
+
     describe('but the payload is empty', () => {
       it('throws an error', async () => {
         const id = updateAuthSystem.id

--- a/test/services/update_authorised_system.service.test.js
+++ b/test/services/update_authorised_system.service.test.js
@@ -32,7 +32,21 @@ describe('Update Authorised System service', () => {
     describe('but the payload is empty', () => {
       it('throws an error', async () => {
         const id = updateAuthSystem.id
-        const err = await expect(UpdateAuthorisedSystemService.go(id)).to.reject(Error, 'The payload was empty.')
+        const err = await expect(UpdateAuthorisedSystemService.go(id))
+          .to
+          .reject(Error, 'The payload was empty.')
+
+        expect(err).to.be.an.error()
+      })
+    })
+
+    describe('but the payload contains an invalid status', () => {
+      it('throws an error', async () => {
+        const payload = { status: 'Happy' }
+        const id = updateAuthSystem.id
+        const err = await expect(UpdateAuthorisedSystemService.go(id, payload))
+          .to
+          .reject(Error, `${payload.status} is not valid a status. Can only be active or inactive.`)
 
         expect(err).to.be.an.error()
       })
@@ -43,7 +57,9 @@ describe('Update Authorised System service', () => {
     describe('because there is no matching authorised system', () => {
       it('throws an error', async () => {
         const id = GeneralHelper.uuid4()
-        const err = await expect(UpdateAuthorisedSystemService.go(id)).to.reject(Error, `No authorised system found with id ${id}`)
+        const err = await expect(UpdateAuthorisedSystemService.go(id))
+          .to
+          .reject(Error, `No authorised system found with id ${id}`)
 
         expect(err).to.be.an.error()
       })
@@ -52,7 +68,9 @@ describe('Update Authorised System service', () => {
     describe("because it's the admin authorised system", () => {
       it('throws an error', async () => {
         const id = adminAuthSystem.id
-        const err = await expect(UpdateAuthorisedSystemService.go(id)).to.reject(Error, 'You cannot update the main admin.')
+        const err = await expect(UpdateAuthorisedSystemService.go(id))
+          .to
+          .reject(Error, 'You cannot update the main admin.')
 
         expect(err).to.be.an.error()
       })
@@ -60,7 +78,9 @@ describe('Update Authorised System service', () => {
 
     describe('because the UUID is invalid', () => {
       it('returns throws an error', async () => {
-        const err = await expect(UpdateAuthorisedSystemService.go('123456789')).to.reject(DataError)
+        const err = await expect(UpdateAuthorisedSystemService.go('123456789'))
+          .to
+          .reject(DataError)
 
         expect(err).to.be.an.error()
       })


### PR DESCRIPTION
In [V1 of the API](https://github.com/charging-module-api) there was an endpoint that allowed the admin user to change the details of an 'authorised system' (our name for user accounts!)

We've always had the intention of bringing it into V2, it was just very low on the list of priorities. Now it's been identified as a need by our test team to allow them to automate the testing of authentication and authorisation.

So, this change adds a new update authorised system endpoint which will allow us to

- amend the status of an authorised system
- amend the name of an authorised system
- amend what regimes an authorised system has access to