### PR TITLE
Prevent duplicate billing

### DIFF
--- a/test/services/invoice_rebilling_validation.service.test.js
+++ b/test/services/invoice_rebilling_validation.service.test.js
@@ -92,6 +92,29 @@ describe('Invoice Rebilling Validation service', () => {
         })
       })
 
+      describe('because it is already being rebilled', () => {
+        it('throws an error', async () => {
+          const invoice = await InvoiceHelper.addInvoice(
+            currentBillRun.id, 'CUSTOMER REFERENCE', 2020, 0, 0, 0, 0, 0, 0, 0, 0, null, 'O'
+          )
+          await InvoiceHelper.addInvoice(
+            currentBillRun.id, 'CUSTOMER REFERENCE', 2020, 0, 0, 0, 0, 0, 0, 0, 0, invoice.id, 'R'
+          )
+          await InvoiceHelper.addInvoice(
+            currentBillRun.id, 'CUSTOMER REFERENCE', 2020, 0, 0, 0, 0, 0, 0, 0, 0, invoice.id, 'C'
+          )
+
+          const err = await expect(
+            InvoiceRebillingValidationService.go(newBillRun, invoice)
+          ).to.reject()
+
+          expect(err).to.be.an.error()
+          expect(err.output.payload.message).to.equal(
+            `Invoice ${invoice.id} has already been rebilled.`
+          )
+        })
+      })
+
       describe('because it is a rebill cancel invoice', () => {
         it('throws an error', async () => {
           const invoice = await InvoiceHelper.addInvoice(


### PR DESCRIPTION
https://trello.com/c/e2Z8puRX/1976-prevent-duplicate-re-billing-of-a-single-invoice

In order to prevent additional rebilling, we need to add validation to check whether it is currently being rebilled. We do this by checking to see if any invoices exist which have the invoice's id in the `rebilled_invoice_id` field.

This also satisfies the criteria that an invoice that has been rebilled can be rebilled again if the previous rebilling has been cancelled; in this scenario, both the cancel invoice and the rebill invoice will have been deleted meaning there won't be any invoices with the id in the `rebilled_invoice_id` field.