### PR TITLE
Add support to seed test authorised system

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,7 @@ AIRBRAKE_KEY=longvaluefullofnumbersandlettersinlowercase
 ENVIRONMENT=dev
 ADMIN_CLIENT_ID=cognitoclientidforadminuser
 SYSTEM_CLIENT_ID=cognitoclientidforsystemuser
+TEST_CLIENT_ID=cognitoclientidfortestuser
 IGNORE_JWT_EXPIRATION=false
 
 # Database config

--- a/config/authentication.config.js
+++ b/config/authentication.config.js
@@ -6,6 +6,7 @@ const config = {
   environment: process.env.ENVIRONMENT,
   adminClientId: process.env.ADMIN_CLIENT_ID,
   systemClientId: process.env.SYSTEM_CLIENT_ID,
+  testClientId: process.env.TEST_CLIENT_ID,
   // Credit to https://stackoverflow.com/a/323546/6117745 for how to handle
   // converting the env var to a boolean
   ignoreJwtExpiration: (String(process.env.IGNORE_JWT_EXPIRATION) === 'true') || false

--- a/db/seeds/02_authorised_systems.js
+++ b/db/seeds/02_authorised_systems.js
@@ -30,20 +30,27 @@ exports.seed = async function (knex) {
       regime_id: regime.id
     })
   }
-
+  const otherClients = []
   if (config.systemClientId) {
+    otherClients.push({ clientId: config.systemClientId, name: 'system' })
+  }
+  if (config.testClientId) {
+    otherClients.push({ clientId: config.testClientId, name: 'test' })
+  }
+
+  for (const client of otherClients) {
     result = await knex('authorised_systems')
       .returning('id')
       .insert({
-        client_id: config.systemClientId,
-        name: 'system',
+        client_id: client.clientId,
+        name: client.name,
         admin: false,
         status: 'active'
       })
-    const systemUserId = result[0]
+    const userId = result[0]
     const wrlsRegime = regimes.filter(regime => regime.slug === 'wrls')[0]
     await knex('authorised_systems_regimes').insert({
-      authorised_system_id: systemUserId,
+      authorised_system_id: userId,
       regime_id: wrlsRegime.id
     })
   }


### PR DESCRIPTION
Currently, we support seeding the 'admin' and a 'system' authorised system (user).

What has actually been happening is we have been seeding the 'admin', but using WRLS's credentials as the 'system' user. We're getting close to going live with the service so we need to move away from using WRLS's credentials and use our own system account.

Whilst looking into what accounts we have we noted there is one earmarked for the TCM, though it is no longer our intent to link the 2 systems. This observation came at the same time our test team asked if there was an account they could make changes to as part of their automated testing.

So, this change is all about adding support to seed a 'test' authorised system. But it's also signalling our intent to use our own credentials rather than our clients going forward.