### PR TITLE
Add rebilling info to ViewInvoicePresenter

### DIFF
--- a/app/presenters/view_invoice.presenter.js
+++ b/app/presenters/view_invoice.presenter.js
@@ -25,6 +25,8 @@ class ViewInvoicePresenter extends BasePresenter {
         creditLineValue: data.creditLineValue,
         debitLineValue: data.debitLineValue,
         netTotal: data.netTotal,
+        rebilledType: data.rebilledType,
+        rebilledInvoiceId: data.rebilledInvoiceId,
         licences: data.licences.map(licence => {
           const presenter = new ViewLicencePresenter(licence)
           return presenter.go()

--- a/test/presenters/view_invoice.presenter.test.js
+++ b/test/presenters/view_invoice.presenter.test.js
@@ -29,6 +29,8 @@ describe('View Invoice Presenter', () => {
     minimumChargeInvoice: false,
     transactionReference: null,
     netTotal: 2093,
+    rebilledType: 'R',
+    rebilledInvoiceId: GeneralHelper.uuid4(),
     licences: [
       {
         id: GeneralHelper.uuid4(),
@@ -75,7 +77,9 @@ describe('View Invoice Presenter', () => {
       'transactionReference',
       'creditLineValue',
       'debitLineValue',
-      'netTotal'
+      'netTotal',
+      'rebilledType',
+      'rebilledInvoiceId'
     ])
   })
 


### PR DESCRIPTION
https://trello.com/c/3Uugplg1/1970-s-include-re-billing-data-in-view-invoice-response

We add `rebilledType` and `rebilledInvoiceId` to `ViewInvoicePresenter` so that rebilling info is present when viewing an invoice.