### PR TITLE
Add rebilling fields to View Bill Run query

### DIFF
--- a/app/services/view_bill_run.service.js
+++ b/app/services/view_bill_run.service.js
@@ -61,7 +61,9 @@ class ViewBillRunService {
           'deminimisInvoice',
           'zeroValueInvoice',
           'minimumChargeInvoice',
-          'transactionReference'
+          'transactionReference',
+          'rebilledType',
+          'rebilledInvoiceId'
         )
       })
       .modifyGraph('invoices.licences', (builder) => {


### PR DESCRIPTION
https://trello.com/c/nHyddqSo/1969-s-include-re-billing-data-in-view-bill-run-response

Alongside adding the rebililng fields to the View Bill Run presenter, we also need to add them to the query that supplies the data for the presenter, which we do in this change.