### PR TITLE
Add rebilling fields to View Bill Run Invoice query

### DIFF
--- a/app/services/view_bill_run_invoice.service.js
+++ b/app/services/view_bill_run_invoice.service.js
@@ -37,7 +37,9 @@ class ViewBillRunInvoiceService {
         'minimumChargeInvoice',
         'transactionReference',
         'debitLineValue',
-        'creditLineValue'
+        'creditLineValue',
+        'rebilledType',
+        'rebilledInvoiceId'
       )
       .withGraphFetched('licences.transactions')
       .modifyGraph('licences', (builder) => {


### PR DESCRIPTION
https://trello.com/c/3Uugplg1/1970-s-include-re-billing-data-in-view-invoice-response

Alongside adding the rebilling fields to the View Bill Run Invoice presenter, we also need to add them to the query that supplies the data for the presenter, which we do in this change.
