### PR TITLE
Add Admin Send Transaction File endpoint and stub service

### DIFF
--- a/app/controllers/admin/bill_runs.controller.js
+++ b/app/controllers/admin/bill_runs.controller.js
@@ -1,0 +1,13 @@
+'use strict'
+
+const { AdminSendTransactionFileService } = require('../../services')
+
+class AdminBillRunsController {
+  static async send (_req, h) {
+    await AdminSendTransactionFileService.go()
+
+    return h.response().code(200)
+  }
+}
+
+module.exports = AdminBillRunsController

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -2,35 +2,37 @@
 
 const RootController = require('./root.controller')
 
-const RegimesController = require('./admin/regimes.controller')
-const AuthorisedSystemsController = require('./admin/authorised_systems.controller')
+const AdminBillRunsController = require('./admin/bill_runs.controller')
 const AirbrakeController = require('./admin/health/airbrake.controller')
+const AuthorisedSystemsController = require('./admin/authorised_systems.controller')
 const CustomersController = require('./admin/customers.controller')
 const DatabaseController = require('./admin/health/database.controller')
-const TestBillRunsController = require('./admin/test/test_bill_runs.controller')
-const TestCustomerFilesController = require('./admin/test/test_customer_files.controller')
-const TestTransactionsController = require('./admin/test/test_transactions.controller')
 const NotSupportedController = require('./not_supported.controller')
 const PresrocBillRunsController = require('./presroc/bill_runs.controller')
 const PresrocBillRunsInvoicesController = require('./presroc/bill_runs_invoices.controller')
 const PresrocBillRunsTransactionsController = require('./presroc/bill_runs_transactions.controller')
 const PresrocCalculateChargeController = require('./presroc/calculate_charge.controller')
 const PresrocCustomerDetailsController = require('./presroc/customer_details.controller')
+const RegimesController = require('./admin/regimes.controller')
+const TestBillRunsController = require('./admin/test/test_bill_runs.controller')
+const TestCustomerFilesController = require('./admin/test/test_customer_files.controller')
+const TestTransactionsController = require('./admin/test/test_transactions.controller')
 
 module.exports = {
-  RootController,
-  RegimesController,
+  AdminBillRunsController,
   AirbrakeController,
   AuthorisedSystemsController,
   CustomersController,
   DatabaseController,
-  TestBillRunsController,
-  TestCustomerFilesController,
-  TestTransactionsController,
+  NotSupportedController,
   PresrocBillRunsController,
-  PresrocCalculateChargeController,
   PresrocBillRunsInvoicesController,
   PresrocBillRunsTransactionsController,
+  PresrocCalculateChargeController,
   PresrocCustomerDetailsController,
-  NotSupportedController
+  RegimesController,
+  RootController,
+  TestBillRunsController,
+  TestCustomerFilesController,
+  TestTransactionsController
 }

--- a/app/routes/bill_run.routes.js
+++ b/app/routes/bill_run.routes.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const {
+  AdminBillRunsController,
   NotSupportedController,
   PresrocBillRunsController
 } = require('../controllers')
@@ -45,6 +46,11 @@ const routes = [
     method: 'DELETE',
     path: '/v2/{regimeId}/bill-runs/{billRunId}',
     handler: PresrocBillRunsController.delete
+  },
+  {
+    method: 'PATCH',
+    path: '/admin/{regimeId}/bill-runs/{billRunId}/send',
+    handler: AdminBillRunsController.send
   }
 ]
 

--- a/app/services/admin_send_transaction_file.service.js
+++ b/app/services/admin_send_transaction_file.service.js
@@ -1,0 +1,16 @@
+'use strict'
+
+/**
+ * @module AdminSendTransactionFileService
+ */
+
+class AdminSendTransactionFileService {
+  /**
+   * Will organise the generation and sending of a transaction file with a status of `pending`.
+   */
+  static async go () {
+    return true
+  }
+}
+
+module.exports = AdminSendTransactionFileService

--- a/app/services/index.js
+++ b/app/services/index.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const AdminSendTransactionFileService = require('./admin_send_transaction_file.service')
 const ApproveBillRunService = require('./approve_bill_run.service')
 const AuthorisationService = require('./plugins/authorisation.service')
 const BaseNextFileReferenceService = require('./base_next_file_reference.service')
@@ -61,6 +62,7 @@ const ViewBillRunInvoiceService = require('./view_bill_run_invoice.service')
 const ViewBillRunService = require('./view_bill_run.service')
 
 module.exports = {
+  AdminSendTransactionFileService,
   ApproveBillRunService,
   AuthorisationService,
   BaseNextFileReferenceService,

--- a/test/controllers/admin/bill_runs.controller.test.js
+++ b/test/controllers/admin/bill_runs.controller.test.js
@@ -1,0 +1,75 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, before, beforeEach, after } = exports.lab = Lab.script()
+const { expect } = Code
+
+// For running our service
+const { deployment } = require('../../../server')
+
+// Test helpers
+const {
+  AuthorisationHelper,
+  AuthorisedSystemHelper,
+  BillRunHelper,
+  DatabaseHelper,
+  RegimeHelper
+} = require('../../support/helpers')
+
+// Things we need to stub
+const JsonWebToken = require('jsonwebtoken')
+
+describe('Presroc Bill Runs controller', () => {
+  const clientID = '1234546789'
+  let server
+  let authToken
+  let regime
+  let authorisedSystem
+  let billRun
+
+  before(async () => {
+    server = await deployment()
+    authToken = AuthorisationHelper.nonAdminToken(clientID)
+
+    Sinon
+      .stub(JsonWebToken, 'verify')
+      .returns(AuthorisationHelper.decodeToken(authToken))
+  })
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+
+    regime = await RegimeHelper.addRegime('wrls', 'WRLS')
+    authorisedSystem = await AuthorisedSystemHelper.addSystem(clientID, 'system1', [regime])
+  })
+
+  after(async () => {
+    Sinon.restore()
+  })
+
+  describe('Send bill run: PATCH /admin/{regimeId}/bill-runs/{billRunId}/send', () => {
+    const options = (token, billRunId) => {
+      return {
+        method: 'PATCH',
+        url: `/admin/wrls/bill-runs/${billRunId}/send`,
+        headers: { authorization: `Bearer ${token}` }
+      }
+    }
+
+    beforeEach(async () => {
+      billRun = await BillRunHelper.addBillRun(authorisedSystem.id, regime.id)
+    })
+
+    describe('When the request is valid', () => {
+      it('returns success status 200', async () => {
+        const response = await server.inject(options(authToken, billRun.id))
+
+        expect(response.statusCode).to.equal(200)
+      })
+    })
+  })
+})

--- a/test/services/admin_send_transaction_file.service.test.js
+++ b/test/services/admin_send_transaction_file.service.test.js
@@ -1,0 +1,21 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Thing under test
+const { AdminSendTransactionFileService } = require('../../app/services')
+
+describe('Admin Send Transaction File service', () => {
+  describe('When the service is called', () => {
+    it('returns `true`', async () => {
+      const result = await AdminSendTransactionFileService.go()
+
+      expect(result).to.be.true()
+    })
+  })
+})


### PR DESCRIPTION
https://trello.com/c/ntPvucIj/1974-enable-admin-endpoint-to-manually-trigger-a-transaction-file-v2

The first step is to create the endpoint `PATCH /admin/{regimeId}/bill-runs/{billRunId}/send` which calls an `AdminSendTransactionFileService` stub.