### PR TITLE
Revised Admin Send Transaction File endpoint

### DIFF
--- a/app/controllers/admin/bill_runs.controller.js
+++ b/app/controllers/admin/bill_runs.controller.js
@@ -1,0 +1,14 @@
+'use strict'
+
+const { SendTransactionFileService } = require('../../services')
+
+class AdminBillRunsController {
+  static async send (req, h) {
+    // Initiate generate/send process in the background
+    SendTransactionFileService.go(req.app.regime, req.app.billRun, req.app.notifier)
+
+    return h.response().code(204)
+  }
+}
+
+module.exports = AdminBillRunsController

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -2,35 +2,37 @@
 
 const RootController = require('./root.controller')
 
-const RegimesController = require('./admin/regimes.controller')
-const AuthorisedSystemsController = require('./admin/authorised_systems.controller')
+const AdminBillRunsController = require('./admin/bill_runs.controller')
 const AirbrakeController = require('./admin/health/airbrake.controller')
+const AuthorisedSystemsController = require('./admin/authorised_systems.controller')
 const CustomersController = require('./admin/customers.controller')
 const DatabaseController = require('./admin/health/database.controller')
-const TestBillRunsController = require('./admin/test/test_bill_runs.controller')
-const TestCustomerFilesController = require('./admin/test/test_customer_files.controller')
-const TestTransactionsController = require('./admin/test/test_transactions.controller')
 const NotSupportedController = require('./not_supported.controller')
 const PresrocBillRunsController = require('./presroc/bill_runs.controller')
 const PresrocBillRunsInvoicesController = require('./presroc/bill_runs_invoices.controller')
 const PresrocBillRunsTransactionsController = require('./presroc/bill_runs_transactions.controller')
 const PresrocCalculateChargeController = require('./presroc/calculate_charge.controller')
 const PresrocCustomerDetailsController = require('./presroc/customer_details.controller')
+const RegimesController = require('./admin/regimes.controller')
+const TestBillRunsController = require('./admin/test/test_bill_runs.controller')
+const TestCustomerFilesController = require('./admin/test/test_customer_files.controller')
+const TestTransactionsController = require('./admin/test/test_transactions.controller')
 
 module.exports = {
-  RootController,
-  RegimesController,
+  AdminBillRunsController,
   AirbrakeController,
   AuthorisedSystemsController,
   CustomersController,
   DatabaseController,
-  TestBillRunsController,
-  TestCustomerFilesController,
-  TestTransactionsController,
+  NotSupportedController,
   PresrocBillRunsController,
-  PresrocCalculateChargeController,
   PresrocBillRunsInvoicesController,
   PresrocBillRunsTransactionsController,
+  PresrocCalculateChargeController,
   PresrocCustomerDetailsController,
-  NotSupportedController
+  RegimesController,
+  RootController,
+  TestBillRunsController,
+  TestCustomerFilesController,
+  TestTransactionsController
 }

--- a/app/routes/bill_run.routes.js
+++ b/app/routes/bill_run.routes.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const {
+  AdminBillRunsController,
   NotSupportedController,
   PresrocBillRunsController
 } = require('../controllers')
@@ -45,6 +46,11 @@ const routes = [
     method: 'DELETE',
     path: '/v2/{regimeId}/bill-runs/{billRunId}',
     handler: PresrocBillRunsController.delete
+  },
+  {
+    method: 'PATCH',
+    path: '/admin/{regimeId}/bill-runs/{billRunId}/send',
+    handler: AdminBillRunsController.send
   }
 ]
 

--- a/app/services/plugins/request_bill_run.service.js
+++ b/app/services/plugins/request_bill_run.service.js
@@ -63,7 +63,7 @@ class RequestBillRunService {
   /**
    * Validate that the bill run exists and is linked to the specified regime.
    */
-  static _validateBillRun (billRun, billRunId, regime, method) {
+  static _validateBillRun (billRun, billRunId, regime) {
     if (!billRun) {
       throw Boom.notFound(`Bill run ${billRunId} is unknown.`)
     }

--- a/app/services/plugins/request_bill_run.service.js
+++ b/app/services/plugins/request_bill_run.service.js
@@ -26,7 +26,9 @@ class RequestBillRunService {
    * - that the request relates to an existing bill run (`POST` a new bill run is ignored)
    * - that we can find the bill run
    * - the bill run is linked to the requested regime which ensures the client system has access to it
-   * - that if the request involves editing the bill run its status is such that it can be changed
+   * - that if the request involves editing the bill run its status is such that it can be changed (note that we do not
+   *   perform this check if the request path contains `/admin/` to allow eg. retrying transaction file generation of a
+   *   pending bill run.)
    *
    * If any of these checks fail the relevant {@module Boom} error is thrown.
    *
@@ -39,17 +41,18 @@ class RequestBillRunService {
    * {@module BillRunModel}. Else it returns `null`
    */
   static async go (path, method, regime, billRunId) {
-    if (!this._billRunRelated(path)) {
+    if (!this._billRunRelatedPath(path)) {
       return null
     }
 
     const billRun = await this._billRun(billRunId)
     this._validateBillRun(billRun, billRunId, regime, method)
+    this._validateCanEditBillRun(billRun, path, method)
 
     return billRun
   }
 
-  static _billRunRelated (path) {
+  static _billRunRelatedPath (path) {
     return /\/bill-runs\//i.test(path)
   }
 
@@ -57,6 +60,9 @@ class RequestBillRunService {
     return BillRunModel.query().findById(billRunId)
   }
 
+  /**
+   * Validate that the bill run exists and is linked to the specified regime.
+   */
   static _validateBillRun (billRun, billRunId, regime, method) {
     if (!billRun) {
       throw Boom.notFound(`Bill run ${billRunId} is unknown.`)
@@ -65,10 +71,22 @@ class RequestBillRunService {
     if (billRun.regimeId !== regime.id) {
       throw Boom.badData(`Bill run ${billRunId} is not linked to regime ${regime.slug}.`)
     }
+  }
 
-    if (!billRun.$editable() && method !== 'get') {
+  /**
+   * Validate that the bill run can be edited if the http method is one that requires it to be editable. We ignore this
+   * if the path contains `/admin/`.
+   */
+  static _validateCanEditBillRun (billRun, path, method) {
+    const adminPath = this._adminPath(path)
+
+    if (!adminPath && !billRun.$editable() && method !== 'get') {
       throw Boom.conflict(`Bill run ${billRun.id} cannot be edited because its status is ${billRun.status}.`)
     }
+  }
+
+  static _adminPath (path) {
+    return /\/admin\//i.test(path)
   }
 }
 

--- a/test/controllers/admin/bill_runs.controller.test.js
+++ b/test/controllers/admin/bill_runs.controller.test.js
@@ -1,0 +1,91 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, before, beforeEach, after, afterEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// For running our service
+const { deployment } = require('../../../server')
+
+// Test helpers
+const {
+  AuthorisationHelper,
+  AuthorisedSystemHelper,
+  BillRunHelper,
+  DatabaseHelper,
+  RegimeHelper
+} = require('../../support/helpers')
+
+// Things we need to stub
+const JsonWebToken = require('jsonwebtoken')
+const { SendTransactionFileService } = require('../../../app/services')
+
+describe('Presroc Bill Runs controller', () => {
+  const clientID = '1234546789'
+  let server
+  let authToken
+  let regime
+  let authorisedSystem
+  let billRun
+  let sendStub
+
+  before(async () => {
+    server = await deployment()
+    authToken = AuthorisationHelper.nonAdminToken(clientID)
+
+    Sinon
+      .stub(JsonWebToken, 'verify')
+      .returns(AuthorisationHelper.decodeToken(authToken))
+  })
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+
+    regime = await RegimeHelper.addRegime('wrls', 'WRLS')
+    authorisedSystem = await AuthorisedSystemHelper.addSystem(clientID, 'system1', [regime])
+
+    sendStub = Sinon.stub(SendTransactionFileService, 'go')
+  })
+
+  after(async () => {
+    Sinon.restore()
+  })
+
+  afterEach(async () => {
+    sendStub.restore()
+  })
+
+  describe('Send bill run: PATCH /admin/{regimeId}/bill-runs/{billRunId}/send', () => {
+    const options = (token, billRunId) => {
+      return {
+        method: 'PATCH',
+        url: `/admin/wrls/bill-runs/${billRunId}/send`,
+        headers: { authorization: `Bearer ${token}` }
+      }
+    }
+
+    beforeEach(async () => {
+      billRun = await BillRunHelper.addBillRun(authorisedSystem.id, regime.id)
+    })
+
+    describe('When the request is valid', () => {
+      it('returns success status 204', async () => {
+        const response = await server.inject(options(authToken, billRun.id))
+
+        expect(response.statusCode).to.equal(204)
+      })
+
+      it('calls SendTransactionFileService with the regime and bill run', async () => {
+        await server.inject(options(authToken, billRun.id))
+
+        expect(sendStub.calledOnce).to.be.true()
+        expect(sendStub.getCall(0).args[0].id).to.equal(regime.id)
+        expect(sendStub.getCall(0).args[1].id).to.equal(billRun.id)
+      })
+    })
+  })
+})

--- a/test/controllers/admin/bill_runs.controller.test.js
+++ b/test/controllers/admin/bill_runs.controller.test.js
@@ -69,7 +69,7 @@ describe('Presroc Bill Runs controller', () => {
     }
 
     beforeEach(async () => {
-      billRun = await BillRunHelper.addBillRun(authorisedSystem.id, regime.id)
+      billRun = await BillRunHelper.addBillRun(authorisedSystem.id, regime.id, 'A', 'pending')
     })
 
     describe('When the request is valid', () => {

--- a/test/services/plugins/request_bill_run.service.test.js
+++ b/test/services/plugins/request_bill_run.service.test.js
@@ -21,6 +21,10 @@ describe('Request bill run service', () => {
     return `/test/wrls/bill-runs/${id}`
   }
 
+  const adminPath = id => {
+    return `/admin/wrls/bill-runs/${id}`
+  }
+
   beforeEach(async () => {
     await DatabaseHelper.clean()
   })
@@ -43,6 +47,24 @@ describe('Request bill run service', () => {
           const result = await RequestBillRunService.go(billRunPath(billRun.id), 'post', regime, billRun.id)
 
           expect(result.id).to.equal(billRun.id)
+        })
+
+        describe('and the path contains `/admin/`', () => {
+          it('returns the matching bill run', async () => {
+            const result = await RequestBillRunService.go(adminPath(billRun.id), 'post', regime, billRun.id)
+
+            expect(result.id).to.equal(billRun.id)
+          })
+        })
+      })
+
+      describe('that cannot be edited', () => {
+        describe('but the path contains `/admin/`', () => {
+          it('returns the matching bill run', async () => {
+            const result = await RequestBillRunService.go(adminPath(billRun.id), 'post', regime, billRun.id)
+
+            expect(result.id).to.equal(billRun.id)
+          })
         })
       })
     })
@@ -109,6 +131,14 @@ describe('Request bill run service', () => {
         const result = await RequestBillRunService.go('/test/wrls/invoice-runs/12345', 'get', regime, '12345')
 
         expect(result).to.be.null()
+      })
+
+      describe('and the path contains `/admin/`', () => {
+        it("returns 'null'", async () => {
+          const result = await RequestBillRunService.go('/admin/wrls/invoice-runs/12345', 'get', regime, '12345')
+
+          expect(result).to.be.null()
+        })
       })
     })
 


### PR DESCRIPTION
https://trello.com/c/ntPvucIj/1974-enable-admin-endpoint-to-manually-trigger-a-transaction-file-v2

After [initially raising a PR](https://github.com/DEFRA/sroc-charging-module-api/pull/428) to create the endpoint and a stub `AdminSendTransactionFileService`, we realised once we started work on developing the admin service that this wouldn't be necessary -- we can simply call the existing `SendTransactionFileService` from the admin controller. We therefore pulled the review request for the previous PR and raised this one to create the admin endpoint and call `SendTransactionFileService` from within it.

While manually checking the endpoint, we found that the request would be rejected by the `RequestBillRunService` plugin before reaching the controller; this was due to the bill run status being `pending` which is rejected by the plugin's validation. We have therefore changed the plugin's validation so the 'editable' check is not performed if an `/admin/` path is requested.