### PR TITLE
Add nuke-db npm script

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -109,6 +109,21 @@
       }
     },
     {
+      "label": "🗄️💥 DB NUKE (CMA)",
+      "detail": "Will drop then re-create both db's",
+      "type": "shell",
+      "command": "docker-compose exec app /bin/sh -c 'npm run nuke-db && npm run nuke-test-db'",
+      "group": "test",
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": true,
+        "panel": "shared",
+        "showReuseMessage": false,
+        "clear": true
+      }
+    },
+    {
       "label": "💻 OPEN (CMA)",
       "detail": "Will open /bin/sh in the running 'app' container",
       "type": "shell",

--- a/db/drop.database.js
+++ b/db/drop.database.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const environment = process.env.NODE_ENV || 'development'
+
+const dbConfig = require('../knexfile')[environment]
+
+const databaseName = dbConfig.connection.database
+
+// Connect to maintenance database. We can't use `knexfile.js` and require it as we would in other places because it
+// will already have instantiated using the actual DB. And we don't want to connect to the main DB because you cannot
+// drop a DB with active connections!
+// So we have to grab our config and instantiate it ourselves here so we can connect against the default 'postgres' DB.
+// https://stackoverflow.com/a/31428260/6117745
+const knex = require('knex')({
+  client: 'pg',
+  connection: {
+    host: dbConfig.connection.host,
+    port: dbConfig.connection.port,
+    user: dbConfig.connection.user,
+    password: dbConfig.connection.password,
+    database: 'postgres',
+    charset: 'utf8'
+  }
+})
+
+const up = async function (knex) {
+  try {
+    // We'll get errors if we try to drop the db when there are active connections. So, we use this command first to
+    // drop any active connections it finds.
+    // https://www.postgresqltutorial.com/postgresql-drop-database/
+    console.log(`Dropping active connections to ${databaseName}`)
+    await knex.raw(`SELECT pg_terminate_backend (pid) FROM pg_stat_activity WHERE pg_stat_activity.datname = '${databaseName}'`)
+
+    await knex.raw(`DROP DATABASE IF EXISTS ${databaseName}`)
+    console.log(`Successfully dropped ${databaseName}`)
+  } catch (error) {
+    console.error(`Could not drop ${databaseName}: ${error.message}`)
+  } finally {
+    // Kill the connection after running the command else the terminal will
+    // appear to hang
+    await knex.destroy()
+  }
+}
+
+up(knex)

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "clean-test-db": "NODE_ENV=test node db/clean.database.js",
     "reset-db": "npm run clean-db && npm run rollback-db && npm run migrate-db && npm run seed-db",
     "reset-test-db": "npm run clean-test-db && npm run rollback-test-db && npm run migrate-test-db",
+    "nuke-db": "node db/drop.database.js && npm run create-db",
+    "nuke-test-db": "NODE_ENV=test node db/drop.database.js && npm run create-test-db",
     "customer-files-task": "node app/tasks/index.js CustomerFilesTask"
   },
   "repository": {


### PR DESCRIPTION
When migrations go bad, they go _real_ bad! Sometimes, when working locally our only solution is to drop the whole environment and start again.

As an interim step, we'd like the option of being able to simply 'nuke' the DB. Essentially drop it completely and start again.

This change adds a `package.json` script that will allow us to do that.