### PR TITLE
Merge VSCode db setup tasks

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -95,24 +95,9 @@
     },
     {
       "label": "🗄️ DB (CMA)",
-      "detail": "Will clean the DB then rollback all changes and re-run migrations and seeds for the main db",
+      "detail": "Will setup (or reset) both the main and test db's",
       "type": "shell",
-      "command": "docker-compose exec app npm run reset-db",
-      "group": "test",
-      "presentation": {
-        "echo": true,
-        "reveal": "always",
-        "focus": true,
-        "panel": "shared",
-        "showReuseMessage": false,
-        "clear": true
-      }
-    },
-    {
-      "label": "🗄️✅ DB TEST (CMA)",
-      "detail": "Will clean the DB then rollback all changes and re-run migrations for the test db",
-      "type": "shell",
-      "command": "docker-compose exec app /bin/sh -c 'npm run create-test-db && npm run reset-test-db'",
+      "command": "docker-compose exec app /bin/sh -c 'npm run reset-db && npm run create-test-db && npm run reset-test-db'",
       "group": "test",
       "presentation": {
         "echo": true,

--- a/README.md
+++ b/README.md
@@ -52,17 +52,13 @@ With the palette open search for **Run test task** and once highlighted select i
 
 You should see a new terminal open up and [Docker Compose](https://docs.docker.com/compose/) begin to start building the images. Once that is done it will switch to running the API in docker.
 
-### Prep the database
+### Prep the databases
 
-The database is automatically created but you still need to run migrations and seed it. Again using the command palette and the **Run test task** option, find and select **🗄️ DB (CMA)**.
+The main database is automatically created but the 'test' database is not. Plus both need the [DB migrations](/db/migrations) to be run against them, and the main database needs to be [seeded](/db/seeds).
 
-The API should now be ready to use.
+The good news is all this is automated. Again, using the command palette and the **Run test task** option find and select **🗄️ DB (CMA)**. It will setup both databases and leave the API ready for use.
 
-### Prep for testing
-
-Before we can run any tests the 'test' database needs to be created and migrations run against it. Using the command palette and the **Run test task** option, find and select **🗄️✅ DB TEST (CMA)**.
-
-This will both create the test database and run migrations against it. It is also safe to run repeatedly should you need to rebuild it.
+> You can also use this same command to reset the databases at anytime
 
 ### Non-vscode users
 


### PR DESCRIPTION
A little while ago we did some work to [Simplify the VSCode tasks](https://github.com/DEFRA/sroc-charging-module-api/pull/341)

In that change we got the DB setup commands down to 2; one for the main DB and the other for the test DB. Since then  we've come to realise if we need to reset the main DB, it's a given we also need to reset the test DB.

So, this is a small quality of life tweak to continue to try and keep the tasks list as clean and short as possible, and make our daily lives a bit easier. In this change, we merge the DB reset commands into one VSCode task.