### PR TITLE
Create AdminSendTransactionFileService

### DIFF
--- a/app/services/admin_send_transaction_file.service.js
+++ b/app/services/admin_send_transaction_file.service.js
@@ -1,0 +1,39 @@
+'use strict'
+
+/**
+ * @module AdminSendTransactionFileService
+ */
+
+const SendTransactionFileService = require('./send_transaction_file.service')
+
+// We require BoomNotifier this way as the usual way of destructuring it results in a circular dependency error
+const BoomNotifier = require('../lib/boom_notifier')
+
+const Boom = require('@hapi/boom')
+
+class AdminSendTransactionFileService {
+  /**
+   * Service which allows SendTransactionFileService to be run asyncronously, throwing an error if validation fails or
+   * if an error occurs during the sending of the transaction file.
+   *
+   * It is intended to be called by an admin endpoint as an admin user will want to see any errors which occur without
+   * having to check the logs, whereas the non-admin use case is that the transaction file is sent syncronously as a
+   * background task.
+   *
+   * @param {module:RegimeModel} regime The regime that the bill run belongs to.
+   * @param {module:BillRun} billRun The bill run we want to send the transaction file for.
+   */
+  static async go (regime, billRun) {
+    this._validate(billRun)
+
+    await SendTransactionFileService.go(regime, billRun, BoomNotifier)
+  }
+
+  static _validate (billRun) {
+    if (!billRun.$pending()) {
+      throw Boom.conflict(`Bill run ${billRun.id} does not have a status of 'pending'.`)
+    }
+  }
+}
+
+module.exports = AdminSendTransactionFileService

--- a/app/services/index.js
+++ b/app/services/index.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const AdminSendTransactionFileService = require('./admin_send_transaction_file.service')
 const ApproveBillRunService = require('./approve_bill_run.service')
 const AuthorisationService = require('./plugins/authorisation.service')
 const BaseNextFileReferenceService = require('./base_next_file_reference.service')
@@ -61,6 +62,7 @@ const ViewBillRunInvoiceService = require('./view_bill_run_invoice.service')
 const ViewBillRunService = require('./view_bill_run.service')
 
 module.exports = {
+  AdminSendTransactionFileService,
   ApproveBillRunService,
   AuthorisationService,
   BaseNextFileReferenceService,

--- a/test/services/admin_send_transaction_file.service.test.js
+++ b/test/services/admin_send_transaction_file.service.test.js
@@ -1,0 +1,65 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const {
+  BillRunHelper,
+  DatabaseHelper,
+  GeneralHelper,
+  RegimeHelper
+} = require('../support/helpers')
+
+// Things to stub
+const { SendTransactionFileService } = require('../../app/services')
+
+// Thing under test
+const { AdminSendTransactionFileService } = require('../../app/services')
+
+describe('Admin Send Transaction File service', () => {
+  let regime
+  let billRun
+  let sendTransactionFileStub
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+
+    regime = await RegimeHelper.addRegime('wrls', 'WRLS')
+    billRun = await BillRunHelper.addBillRun(GeneralHelper.uuid4(), regime.id)
+
+    sendTransactionFileStub = Sinon.stub(SendTransactionFileService, 'go')
+  })
+
+  afterEach(async () => {
+    Sinon.restore()
+  })
+
+  describe('When the transaction file can be sent', () => {
+    describe('because the bill run status is `pending`', () => {
+      it('calls SendTransactionFileService with the correct params', async () => {
+        billRun.status = 'pending'
+
+        await AdminSendTransactionFileService.go(regime, billRun)
+
+        expect(sendTransactionFileStub.calledOnceWith(regime, billRun)).to.be.true()
+      })
+    })
+  })
+
+  describe('When the transaction file cannot be sent', () => {
+    describe('because the bill run status is not `pending`', () => {
+      it('throws an error', async () => {
+        const err = await expect(AdminSendTransactionFileService.go(regime, billRun)).to.reject()
+
+        expect(err).to.be.an.error()
+        expect(err.output.payload.message).to.equal(`Bill run ${billRun.id} does not have a status of 'pending'.`)
+      })
+    })
+  })
+})


### PR DESCRIPTION
https://trello.com/c/ntPvucIj/1974-enable-admin-endpoint-to-manually-trigger-a-transaction-file-v2

We continue with our work to have the admin endpoint run file generation syncronously by creating a new `AdminSendTransactionFileService` which performs initial status validation, throws an error if it fails, then calls the existing `SendTransactionFileService`, passing in our new `BoomNotifier` so that any errors which occurred will be thrown as well as logged (and therefore will result in a response being passed back to the admin user).