### PR TITLE
Use admin send transaction file service in endpoint

### DIFF
--- a/app/controllers/admin/bill_runs.controller.js
+++ b/app/controllers/admin/bill_runs.controller.js
@@ -1,13 +1,12 @@
 'use strict'
 
-const { SendTransactionFileService } = require('../../services')
+const { AdminSendTransactionFileService } = require('../../services')
 
 class AdminBillRunsController {
   static async send (req, h) {
-    // Initiate generate/send process in the background
-    SendTransactionFileService.go(req.app.regime, req.app.billRun, req.app.notifier)
+    await AdminSendTransactionFileService.go(req.app.regime, req.app.billRun)
 
-    return h.response().code(204)
+    return h.response().code(201)
   }
 }
 

--- a/app/controllers/admin/bill_runs.controller.js
+++ b/app/controllers/admin/bill_runs.controller.js
@@ -6,7 +6,7 @@ class AdminBillRunsController {
   static async send (req, h) {
     await AdminSendTransactionFileService.go(req.app.regime, req.app.billRun)
 
-    return h.response().code(201)
+    return h.response().code(204)
   }
 }
 

--- a/app/services/admin_send_transaction_file.service.js
+++ b/app/services/admin_send_transaction_file.service.js
@@ -26,7 +26,7 @@ class AdminSendTransactionFileService {
   static async go (regime, billRun) {
     this._validate(billRun)
 
-    await SendTransactionFileService.go(regime, billRun, BoomNotifier)
+    await SendTransactionFileService.go(regime, billRun, new BoomNotifier())
   }
 
   static _validate (billRun) {

--- a/test/controllers/admin/bill_runs.controller.test.js
+++ b/test/controllers/admin/bill_runs.controller.test.js
@@ -22,9 +22,9 @@ const {
 
 // Things we need to stub
 const JsonWebToken = require('jsonwebtoken')
-const { SendTransactionFileService } = require('../../../app/services')
+const { AdminSendTransactionFileService } = require('../../../app/services')
 
-describe('Presroc Bill Runs controller', () => {
+describe('Admin Bill Runs controller', () => {
   const clientID = '1234546789'
   let server
   let authToken
@@ -48,7 +48,7 @@ describe('Presroc Bill Runs controller', () => {
     regime = await RegimeHelper.addRegime('wrls', 'WRLS')
     authorisedSystem = await AuthorisedSystemHelper.addSystem(clientID, 'system1', [regime])
 
-    sendStub = Sinon.stub(SendTransactionFileService, 'go')
+    sendStub = Sinon.stub(AdminSendTransactionFileService, 'go')
   })
 
   after(async () => {
@@ -73,10 +73,10 @@ describe('Presroc Bill Runs controller', () => {
     })
 
     describe('When the request is valid', () => {
-      it('returns success status 204', async () => {
+      it('returns success status 201', async () => {
         const response = await server.inject(options(authToken, billRun.id))
 
-        expect(response.statusCode).to.equal(204)
+        expect(response.statusCode).to.equal(201)
       })
 
       it('calls SendTransactionFileService with the regime and bill run', async () => {

--- a/test/controllers/admin/bill_runs.controller.test.js
+++ b/test/controllers/admin/bill_runs.controller.test.js
@@ -76,7 +76,7 @@ describe('Admin Bill Runs controller', () => {
       it('returns success status 201', async () => {
         const response = await server.inject(options(authToken, billRun.id))
 
-        expect(response.statusCode).to.equal(201)
+        expect(response.statusCode).to.equal(204)
       })
 
       it('calls SendTransactionFileService with the regime and bill run', async () => {


### PR DESCRIPTION
https://trello.com/c/ntPvucIj/1974-enable-admin-endpoint-to-manually-trigger-a-transaction-file-v2

The final stage of changing our admin endpoint to behave syncronously is to update it to use the newly-created `AdminSendTransactionFileService`.

While manually testing we found a small issue with how `AdminSendTransactionFileService` was passing `BoomNotifier` to `SendTransactionFileService` so we resolved this.