### PR TITLE
Remove rebilling endpoint feature flag

### DIFF
--- a/app/routes/bill_run_invoice.routes.js
+++ b/app/routes/bill_run_invoice.routes.js
@@ -16,13 +16,7 @@ const routes = [
   {
     method: 'PATCH',
     path: '/v2/{regimeId}/bill-runs/{billRunId}/invoices/{invoiceId}/rebill',
-    handler: PresrocBillRunsInvoicesController.rebill,
-    options: {
-      description: 'Feature not yet complete.',
-      auth: {
-        scope: ['admin']
-      }
-    }
+    handler: PresrocBillRunsInvoicesController.rebill
   }
 ]
 


### PR DESCRIPTION
We have been asked to enable rebilling so that WRLS colleagues can start integration testing, which we do in this PR. Note that we intend to revert this to make rebilling inaccessible prior to go-live.