### PR TITLE
Fix defects in customer data validation

### DIFF
--- a/app/translators/customer.translator.js
+++ b/app/translators/customer.translator.js
@@ -22,7 +22,7 @@ class CustomerTranslator extends BaseTranslator {
       addressLine4: Joi.string().max(240),
       addressLine5: Joi.string().max(60),
       addressLine6: Joi.string().max(60),
-      postcode: Joi.string().max(60)
+      postcode: Joi.string().max(60).required()
     })
   }
 

--- a/db/migrations/20210518115807_create_customers.js
+++ b/db/migrations/20210518115807_create_customers.js
@@ -13,14 +13,14 @@ exports.up = async function (knex) {
       table.uuid('regime_id').notNullable()
       table.string('region').notNullable()
       table.string('customer_reference').notNullable()
-      table.string('customer_name').notNullable()
+      table.string('customer_name', 360).notNullable()
       table.string('address_line_1').notNullable()
       table.string('address_line_2')
       table.string('address_line_3')
       table.string('address_line_4')
       table.string('address_line_5')
       table.string('address_line_6')
-      table.string('postcode')
+      table.string('postcode').notNullable()
       table.uuid('customer_file_id').references('customer_files.id')
 
       // Add unique constraint

--- a/test/services/create_customer_details.service.test.js
+++ b/test/services/create_customer_details.service.test.js
@@ -71,7 +71,15 @@ describe('Create Customer Details service', () => {
         const err = await expect(CreateCustomerDetailsService.go({ INVALID_PAYLOAD: 'INVALID' }, regime)).to.reject()
 
         expect(err).to.be.an.error()
-        expect(err.output.payload.message).to.equal('"region" is required. "customerReference" is required. "customerName" is required. "addressLine1" is required')
+        const requiredMessages = err.output.payload.message.split('. ')
+
+        expect(requiredMessages).to.only.contain([
+          '"region" is required',
+          '"customerReference" is required',
+          '"customerName" is required',
+          '"addressLine1" is required',
+          '"postcode" is required'
+        ])
       })
     })
   })


### PR DESCRIPTION
https://trello.com/c/gRWL23rB/1963-validate-customer-change-data-v2

Testing found the following defects, which this PR fixes:
- Customer name accept a maximum of 360 characters but will not accept more than 255; fixed by updating the migration to specify the field length.
- Postcode is not a mandatory field; fixed by making it required in the validation, and added `.notNullable()` to its definition in the migration.