### PR TITLE
Fix missing admin auth scope on bill run /send

### DIFF
--- a/app/routes/bill_run.routes.js
+++ b/app/routes/bill_run.routes.js
@@ -50,7 +50,12 @@ const routes = [
   {
     method: 'PATCH',
     path: '/admin/{regimeId}/bill-runs/{billRunId}/send',
-    handler: AdminBillRunsController.send
+    handler: AdminBillRunsController.send,
+    options: {
+      auth: {
+        scope: ['admin']
+      }
+    }
   }
 ]
 

--- a/test/controllers/admin/bill_runs.controller.test.js
+++ b/test/controllers/admin/bill_runs.controller.test.js
@@ -25,7 +25,6 @@ const JsonWebToken = require('jsonwebtoken')
 const { AdminSendTransactionFileService } = require('../../../app/services')
 
 describe('Admin Bill Runs controller', () => {
-  const clientID = '1234546789'
   let server
   let authToken
   let regime
@@ -35,7 +34,7 @@ describe('Admin Bill Runs controller', () => {
 
   before(async () => {
     server = await deployment()
-    authToken = AuthorisationHelper.nonAdminToken(clientID)
+    authToken = AuthorisationHelper.adminToken()
 
     Sinon
       .stub(JsonWebToken, 'verify')
@@ -46,7 +45,7 @@ describe('Admin Bill Runs controller', () => {
     await DatabaseHelper.clean()
 
     regime = await RegimeHelper.addRegime('wrls', 'WRLS')
-    authorisedSystem = await AuthorisedSystemHelper.addSystem(clientID, 'system1', [regime])
+    authorisedSystem = await AuthorisedSystemHelper.addAdminSystem(null, 'admin', 'active', regime)
 
     sendStub = Sinon.stub(AdminSendTransactionFileService, 'go')
   })


### PR DESCRIPTION
https://trello.com/c/ntPvucIj

Spotted when working on another change that the admin bill runs `/send` endpoint (intended to re-try sending the transaction file for 'pending' bill runs) is missing the route `options` property, specifically one which sets the auth scope as `admin`.

This change fixes it and the tests.