### PR TITLE
Add filtered routes service

### DIFF
--- a/app/plugins/router.plugin.js
+++ b/app/plugins/router.plugin.js
@@ -11,6 +11,9 @@
  * @module router
  */
 
+const { FilterRoutesService } = require('../services')
+const { AuthenticationConfig } = require('../../config')
+
 const {
   AirbrakeRoutes,
   AuthorisedSystemRoutes,
@@ -46,7 +49,9 @@ const routes = [
 const RouterPlugin = {
   name: 'router',
   register: (server, _options) => {
-    server.route(routes)
+    const filteredRoutes = FilterRoutesService.go(routes, AuthenticationConfig.environment)
+
+    server.route(filteredRoutes)
   }
 }
 

--- a/app/plugins/router.plugin.js
+++ b/app/plugins/router.plugin.js
@@ -43,11 +43,11 @@ const routes = [
   ...CalculateChargeRoutes
 ]
 
-const router = {
+const RouterPlugin = {
   name: 'router',
   register: (server, _options) => {
     server.route(routes)
   }
 }
 
-module.exports = router
+module.exports = RouterPlugin

--- a/app/plugins/router.plugin.js
+++ b/app/plugins/router.plugin.js
@@ -8,7 +8,7 @@
  * things like filter what actually gets registered. A working example might be an endpoints used to support testing and
  * debugging which we don't want registered in the actual production environment.
  *
- * @module router
+ * @module RouterPlugin
  */
 
 const { FilterRoutesService } = require('../services')

--- a/app/plugins/router.plugin.js
+++ b/app/plugins/router.plugin.js
@@ -49,6 +49,8 @@ const routes = [
 const RouterPlugin = {
   name: 'router',
   register: (server, _options) => {
+    // Filter our any routes which should not be registered. Typically, these will be unfinished endpoints we filter
+    // out when running in production
     const filteredRoutes = FilterRoutesService.go(routes, AuthenticationConfig.environment)
 
     server.route(filteredRoutes)

--- a/app/routes/bill_run_invoice.routes.js
+++ b/app/routes/bill_run_invoice.routes.js
@@ -16,7 +16,12 @@ const routes = [
   {
     method: 'PATCH',
     path: '/v2/{regimeId}/bill-runs/{billRunId}/invoices/{invoiceId}/rebill',
-    handler: PresrocBillRunsInvoicesController.rebill
+    handler: PresrocBillRunsInvoicesController.rebill,
+    options: {
+      app: {
+        excludeFromProd: true
+      }
+    }
   }
 ]
 

--- a/app/services/index.js
+++ b/app/services/index.js
@@ -21,6 +21,7 @@ const DeleteBillRunService = require('./delete_bill_run.service')
 const DeleteFileService = require('./delete_file.service')
 const DeleteInvoiceService = require('./delete_invoice.service')
 const FetchAndValidateBillRunInvoiceService = require('./fetch_and_validate_bill_run_invoice.service')
+const FilterRoutesService = require('./plugins/filter_routes.service')
 const GenerateBillRunService = require('./generate_bill_run.service')
 const GenerateBillRunValidationService = require('./generate_bill_run_validation.service')
 const GenerateCustomerFileService = require('./generate_customer_file.service')
@@ -83,6 +84,7 @@ module.exports = {
   DeleteFileService,
   DeleteInvoiceService,
   FetchAndValidateBillRunInvoiceService,
+  FilterRoutesService,
   GenerateBillRunService,
   GenerateBillRunValidationService,
   GenerateCustomerFileService,

--- a/app/services/plugins/filter_routes.service.js
+++ b/app/services/plugins/filter_routes.service.js
@@ -16,6 +16,10 @@ class FilterRoutesService {
    * running in production. We also include pre-production in our protected environments so we can test and ensure
    * an endpoint does not get registered as part of our release testing and sign-off.
    *
+   * We identify routes to filter because they have a custom `excludeFromProd` property which has been added to the
+   * {@link https://hapi.dev/api/?v=20.1.3#-routeoptionsapp|route options app property} the Hapi provided place apps
+   * can store route configuration
+   *
    * This service is used by the `RouterPlugin` to check which routes need filtering before it then registers them with
    * the Hapi server instance.
    *
@@ -38,21 +42,7 @@ class FilterRoutesService {
   }
 
   static _filteredRoutes (routes) {
-    return routes.filter(route => !this._pathsToBeFiltered().includes(route.path))
-  }
-
-  /**
-   * Returns an array of strings, each of which is a path, for example,
-   * `'/v2/{regimeId}/bill-runs/{billRunId}/invoices/{invoiceId}/rebill'` which should be filtered out when registering
-   * routes in a production environment.
-   *
-   * It is expected we'll generally add to this when we add a new endpoint, and then remove the path when the endpoint
-   * is signed off and ready for use.
-   *
-   * @returns an array of 'paths' to be used when filtering the routes
-   */
-  static _pathsToBeFiltered () {
-    return []
+    return routes.filter(route => !route?.options?.app?.excludeFromProd)
   }
 }
 

--- a/app/services/plugins/filter_routes.service.js
+++ b/app/services/plugins/filter_routes.service.js
@@ -1,0 +1,13 @@
+'use strict'
+
+/**
+ * @module FilterRoutesService
+ */
+
+class FilterRoutesService {
+  static go (routes, environment) {
+    return routes
+  }
+}
+
+module.exports = FilterRoutesService

--- a/app/services/plugins/filter_routes.service.js
+++ b/app/services/plugins/filter_routes.service.js
@@ -5,6 +5,26 @@
  */
 
 class FilterRoutesService {
+  /**
+   * When running in a production environment ('pre' or 'prd') filter the routes we register with Hapi.
+   *
+   * Initially conceived as a very simple 'feature toggle' solution. In the main our features are related to endpoints;
+   * a new feature typically means a new endpoint. We want the ability to work on new features, but still push other
+   * changes, for example, patches and fixes into production.
+   *
+   * So, we use this service to ensure any endpoint that is still being worked on is not available when the API is
+   * running in production. We also include pre-production in our protected environments so we can test and ensure
+   * an endpoint does not get registered as part of our release testing and sign-off.
+   *
+   * This service is used by the `RouterPlugin` to check which routes need filtering before it then registers them with
+   * the Hapi server instance.
+   *
+   * @param {Object[]} routes An array of Hapi routes expected to be provided by the `RouterPlugin`
+   * @param {string} environment The current environment ('dev', 'tst', 'tra', 'pre' or 'prd')
+   *
+   * @returns {Object[]} an array of Hapi routes, filtered depending on the current environment and whether any paths
+   * have been registered as needing filtering
+   */
   static go (routes, environment) {
     if (this._protectedEnvironment(environment)) {
       return this._filteredRoutes(routes)

--- a/app/services/plugins/filter_routes.service.js
+++ b/app/services/plugins/filter_routes.service.js
@@ -6,7 +6,33 @@
 
 class FilterRoutesService {
   static go (routes, environment) {
+    if (this._protectedEnvironment(environment)) {
+      return this._filteredRoutes(routes)
+    }
+
     return routes
+  }
+
+  static _protectedEnvironment (environment) {
+    return ['pre', 'prd'].includes(environment)
+  }
+
+  static _filteredRoutes (routes) {
+    return routes.filter(route => !this._pathsToBeFiltered().includes(route.path))
+  }
+
+  /**
+   * Returns an array of strings, each of which is a path, for example,
+   * `'/v2/{regimeId}/bill-runs/{billRunId}/invoices/{invoiceId}/rebill'` which should be filtered out when registering
+   * routes in a production environment.
+   *
+   * It is expected we'll generally add to this when we add a new endpoint, and then remove the path when the endpoint
+   * is signed off and ready for use.
+   *
+   * @returns an array of 'paths' to be used when filtering the routes
+   */
+  static _pathsToBeFiltered () {
+    return []
   }
 }
 

--- a/test/services/plugins/filter_routes.service.test.js
+++ b/test/services/plugins/filter_routes.service.test.js
@@ -1,0 +1,42 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const { GeneralHelper } = require('../../support/helpers')
+
+// Thing under test
+const { FilterRoutesService } = require('../../../app/services')
+
+describe('Filter routes service', () => {
+  const routes = [
+    { path: '/' },
+    { path: '/admin' },
+    { path: '/v2/bill-runs' },
+    { path: '/v2/bill-runs/unfinished' }
+  ]
+
+  describe('when the environment is non-production', () => {
+    it('returns the routes unchanged', () => {
+      const result = FilterRoutesService.go(routes, 'dev')
+
+      expect(result).to.equal(routes)
+    })
+  })
+
+  describe('when the environment is production', () => {
+    it('returns the routes filtered', () => {
+      const filteredRoutes = GeneralHelper.cloneObject(routes)
+      filteredRoutes.pop()
+
+      const result = FilterRoutesService.go(routes, 'dev')
+
+      expect(result).to.equal(filteredRoutes)
+    })
+  })
+})

--- a/test/services/plugins/filter_routes.service.test.js
+++ b/test/services/plugins/filter_routes.service.test.js
@@ -3,8 +3,9 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it } = exports.lab = Lab.script()
+const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
@@ -30,11 +31,19 @@ describe('Filter routes service', () => {
   })
 
   describe('when the environment is production', () => {
+    beforeEach(() => {
+      Sinon.stub(FilterRoutesService, '_pathsToBeFiltered').returns(['/v2/bill-runs/unfinished'])
+    })
+
+    afterEach(() => {
+      Sinon.restore()
+    })
+
     it('returns the routes filtered', () => {
       const filteredRoutes = GeneralHelper.cloneObject(routes)
       filteredRoutes.pop()
 
-      const result = FilterRoutesService.go(routes, 'dev')
+      const result = FilterRoutesService.go(routes, 'prd')
 
       expect(result).to.equal(filteredRoutes)
     })

--- a/test/services/plugins/filter_routes.service.test.js
+++ b/test/services/plugins/filter_routes.service.test.js
@@ -3,9 +3,8 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
-const Sinon = require('sinon')
 
-const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
+const { describe, it } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
@@ -19,7 +18,10 @@ describe('Filter routes service', () => {
     { path: '/' },
     { path: '/admin' },
     { path: '/v2/bill-runs' },
-    { path: '/v2/bill-runs/unfinished' }
+    {
+      path: '/v2/bill-runs/unfinished',
+      options: { app: { excludeFromProd: true } }
+    }
   ]
 
   describe('when the environment is non-production', () => {
@@ -31,14 +33,6 @@ describe('Filter routes service', () => {
   })
 
   describe('when the environment is production', () => {
-    beforeEach(() => {
-      Sinon.stub(FilterRoutesService, '_pathsToBeFiltered').returns(['/v2/bill-runs/unfinished'])
-    })
-
-    afterEach(() => {
-      Sinon.restore()
-    })
-
     it('returns the routes filtered', () => {
       const filteredRoutes = GeneralHelper.cloneObject(routes)
       filteredRoutes.pop()


### PR DESCRIPTION
https://trello.com/c/sMC4Ns4D

In [Add auth scope to invoice rebill endpoint](https://github.com/DEFRA/sroc-charging-module-api/pull/411) we brought the invoice rebilling endpoint into the `admin` auth scope as a way of controlling access to it because it's not yet finished. We didn't want anyone inadvertently using it before it's ready.

But then in [Remove rebilling endpoint feature flag](https://github.com/DEFRA/sroc-charging-module-api/pull/436) we had to take it off again to allow our client systems to be able to access the endpoint to start their work.

The idea was that we would re-add the scope before go-live, and then take it off again to allow testing. Just writing it down and reading it back we can see that way lies madness!

But then inspiration hit! We just need to _not_ register the route when running in `production` and `pre-production`. It's fine to have it available to standard client users in our other environments and when running locally. So, if we add some logic to filter out unfinished routes as part of the router plugin we'd have a much more maintainable solution.

So, this change adds a new service which when passed an array of routes, will filter out any it knows to be protected based on the current environment and returned a filtered version ready for registering with Hapi.