### PR TITLE
Develop Request Licence plugin

### DIFF
--- a/app/plugins/index.js
+++ b/app/plugins/index.js
@@ -12,6 +12,7 @@ const MissingPayloadPlugin = require('./missing_payload.plugin')
 const PayloadCleanerPlugin = require('./payload_cleaner.plugin')
 const RequestBillRunPlugin = require('./request_bill_run.plugin')
 const RequestInvoicePlugin = require('./request_invoice.plugin')
+const RequestLicencePlugin = require('./request_licence.plugin')
 const RequestNotifierPlugin = require('./request_notifier.plugin')
 const RouterPlugin = require('./router.plugin')
 const StopPlugin = require('./stop.plugin')
@@ -45,6 +46,7 @@ module.exports = {
   RequestBillRunPlugin,
   RequestNotifierPlugin,
   RequestInvoicePlugin,
+  RequestLicencePlugin,
   RouterPlugin,
   StopPlugin,
   VersionInfoPlugin

--- a/app/plugins/request_licence.plugin.js
+++ b/app/plugins/request_licence.plugin.js
@@ -1,0 +1,31 @@
+'use strict'
+
+/**
+ * Determines if the request is related to a licence and does the work of first finding it, then validating if the
+ * request is valid, ie. that the licence exists.
+ *
+ * This sits as a partner plugin with RequestBillRun, so that by the time we get to a controller we have already
+ * retrieved and validated any bill run and licence included in the url.
+ *
+ * In this case most of the work is done by the {@module RequestLicednceService}. If licence is found and valid for the
+ * request the plugin adds the {@module LicenceModel} instance to `request.app` as per the
+ * {@link https://hapi.dev/api/?v=20.1.0#-requestapp|Hapi documentation} to make it available to all controllers.
+ *
+ * @module RequestLicencePlugin
+ */
+
+const { RequestLicenceService } = require('../services')
+
+const RequestLicencePlugin = {
+  name: 'request_licence',
+  register: (server, _options) => {
+    server.ext('onPreHandler', async (request, h) => {
+      const { licenceId } = request.params
+      request.app.licence = await RequestLicenceService.go(request.path, licenceId)
+
+      return h.continue
+    })
+  }
+}
+
+module.exports = RequestLicencePlugin

--- a/app/plugins/request_licence.plugin.js
+++ b/app/plugins/request_licence.plugin.js
@@ -7,7 +7,7 @@
  * This sits as a partner plugin with RequestBillRun, so that by the time we get to a controller we have already
  * retrieved and validated any bill run and licence included in the url.
  *
- * In this case most of the work is done by the {@module RequestLicednceService}. If licence is found and valid for the
+ * In this case most of the work is done by the {@module RequestLicenceService}. If licence is found and valid for the
  * request the plugin adds the {@module LicenceModel} instance to `request.app` as per the
  * {@link https://hapi.dev/api/?v=20.1.0#-requestapp|Hapi documentation} to make it available to all controllers.
  *

--- a/app/services/index.js
+++ b/app/services/index.js
@@ -42,6 +42,7 @@ const ObjectCleaningService = require('./plugins/object_cleaning.service')
 const PrepareCustomerFileService = require('./prepare_customer_file.service')
 const RequestBillRunService = require('./plugins/request_bill_run.service')
 const RequestInvoiceService = require('./plugins/request_invoice.service')
+const RequestLicenceService = require('./plugins/request_licence.service')
 const RulesService = require('./rules.service')
 const SendBillRunReferenceService = require('./send_bill_run_reference.service')
 const SendCustomerFileService = require('./send_customer_file.service')
@@ -104,6 +105,7 @@ module.exports = {
   PrepareCustomerFileService,
   RequestBillRunService,
   RequestInvoiceService,
+  RequestLicenceService,
   RulesService,
   SendBillRunReferenceService,
   SendCustomerFileService,

--- a/app/services/plugins/request_licence.service.js
+++ b/app/services/plugins/request_licence.service.js
@@ -1,0 +1,49 @@
+'use strict'
+
+/**
+ * @module RequestLicenceService
+ */
+
+const Boom = require('@hapi/boom')
+
+const { LicenceModel } = require('../../models')
+
+class RequestLicenceService {
+  /**
+   * Find a licence and determine if it's valid for the request.
+   *
+   * It checks that the request relates to a licence that exists. If this check fails a {@module Boom} error is thrown.
+   *
+   * @param {string} path The full request path. Used to determine if it's licence related
+   * @param {string} licenceId The id of the requested licence
+   *
+   * @returns {Object} If the request is licence related and it's valid it returns an instance of
+   * {@module LicenceModel}. Else it returns `null`
+   */
+  static async go (path, licenceId) {
+    if (!this._licenceRelated(path)) {
+      return null
+    }
+
+    const licence = await this._licence(licenceId)
+    this._validateLicence(licence, licenceId)
+
+    return licence
+  }
+
+  static _licenceRelated (path) {
+    return /\/licences\//i.test(path)
+  }
+
+  static _licence (licenceId) {
+    return LicenceModel.query().findById(licenceId)
+  }
+
+  static _validateLicence (licence, licenceId) {
+    if (!licence) {
+      throw Boom.notFound(`Licence ${licenceId} is unknown.`)
+    }
+  }
+}
+
+module.exports = RequestLicenceService

--- a/server.js
+++ b/server.js
@@ -16,6 +16,7 @@ const {
   PayloadCleanerPlugin,
   RequestBillRunPlugin,
   RequestInvoicePlugin,
+  RequestLicencePlugin,
   RequestNotifierPlugin,
   RouterPlugin,
   StopPlugin,
@@ -45,9 +46,10 @@ exports.deployment = async start => {
   await server.register(DbErrorsPlugin)
   await server.register(VersionInfoPlugin)
   await server.register(RequestBillRunPlugin)
-  // We register the invoice plugin after the bill run plugin as the bill run plugin performs validation that is assumed
-  // to be done by the time we get to the invoice plugin
+  // We register the invoice and licence plugins after the bill run plugin as the bill run plugin performs validation
+  // that is assumed to be done by the time we get to these plugins
   await server.register(RequestInvoicePlugin)
+  await server.register(RequestLicencePlugin)
 
   // Register non-production plugins
   if (ServerConfig.environment === 'development') {

--- a/test/services/plugins/request_licence.service.test.js
+++ b/test/services/plugins/request_licence.service.test.js
@@ -27,7 +27,7 @@ describe('Request licence service', () => {
   let invoice
   let licence
 
-  const invoicePath = id => {
+  const licencePath = id => {
     return `/test/wrls/bill-runs/_/licences/${id}`
   }
 
@@ -45,7 +45,7 @@ describe('Request licence service', () => {
 
     describe('and is for a valid licence', () => {
       it('returns the licence', async () => {
-        const result = await RequestLicenceService.go(invoicePath(invoice.id), licence.id)
+        const result = await RequestLicenceService.go(licencePath(invoice.id), licence.id)
 
         expect(result).to.be.an.instanceOf(LicenceModel)
         expect(result.id).to.equal(licence.id)
@@ -57,7 +57,7 @@ describe('Request licence service', () => {
         it('returns null', async () => {
           const unknownLicenceId = GeneralHelper.uuid4()
           const err = await expect(
-            RequestLicenceService.go(invoicePath(unknownLicenceId), unknownLicenceId)
+            RequestLicenceService.go(licencePath(unknownLicenceId), unknownLicenceId)
           ).to.reject()
 
           expect(err).to.be.an.error()

--- a/test/services/plugins/request_licence.service.test.js
+++ b/test/services/plugins/request_licence.service.test.js
@@ -1,0 +1,79 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const {
+  BillRunHelper,
+  DatabaseHelper,
+  GeneralHelper,
+  InvoiceHelper,
+  LicenceHelper,
+  RegimeHelper
+} = require('../../support/helpers')
+
+// Thing under test
+const { RequestLicenceService } = require('../../../app/services')
+const { LicenceModel } = require('../../../app/models')
+
+describe('Request licence service', () => {
+  let regime
+  let billRun
+  let invoice
+  let licence
+
+  const invoicePath = id => {
+    return `/test/wrls/bill-runs/_/licences/${id}`
+  }
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+  })
+
+  describe("When the request is 'licence' related", () => {
+    beforeEach(async () => {
+      regime = await RegimeHelper.addRegime('wrls', 'WRLS')
+      billRun = await BillRunHelper.addBillRun(GeneralHelper.uuid4(), regime.id)
+      invoice = await InvoiceHelper.addInvoice(billRun.id, 'CUSTOMER', '2021')
+      licence = await LicenceHelper.addLicence(billRun.id, 'LICENCE', invoice.id)
+    })
+
+    describe('and is for a valid licence', () => {
+      it('returns the licence', async () => {
+        const result = await RequestLicenceService.go(invoicePath(invoice.id), licence.id)
+
+        expect(result).to.be.an.instanceOf(LicenceModel)
+        expect(result.id).to.equal(licence.id)
+      })
+    })
+
+    describe('but is for an invalid licence', () => {
+      describe('because no matching licence exists', () => {
+        it('returns null', async () => {
+          const unknownLicenceId = GeneralHelper.uuid4()
+          const err = await expect(
+            RequestLicenceService.go(invoicePath(unknownLicenceId), unknownLicenceId)
+          ).to.reject()
+
+          expect(err).to.be.an.error()
+          expect(err.output.payload.message).to.equal(`Licence ${unknownLicenceId} is unknown.`)
+        })
+      })
+    })
+  })
+
+  describe("When the request isn't licence related", () => {
+    describe("because it's nothing to do with licences", () => {
+      it('returns null', async () => {
+        const result = await RequestLicenceService.go('/bill-runs/blah', GeneralHelper.uuid4())
+
+        expect(result).to.be.null()
+      })
+    })
+  })
+})


### PR DESCRIPTION
https://trello.com/c/q3yaHhS7/1982-remove-transactions-v2-licence-level

We have plugins to retrieve and validate bill runs and invoices whenever an endpoint with `bill-runs` and/or `invoices` is hit. The "delete licence" endpoint is the first `licences` endpoint so we develop a similar `RequestLicence` plugin and service to retrieve and validate the requested licence.

Note that this code is very similar to the existing `RequestBillRun` and `RequestInvoice` services and is therefore a prime candidate for refactoring into a base request service with bill run, invoice and licence services that inherit from it; we will consider this for a future PR.