### PR TITLE
Fix generated bill run status after add trans.

### DIFF
--- a/app/models/bill_run.model.js
+++ b/app/models/bill_run.model.js
@@ -103,10 +103,21 @@ class BillRunModel extends BaseModel {
 
     const { id } = await BillRunModel.query(trx)
       .findById(transaction.billRunId)
-      .patch(patch)
+      .patch(this._addResetPatch(patch))
       .returning('id')
 
     return id
+  }
+
+  static _addResetPatch (currentPatch = {}) {
+    return {
+      ...currentPatch,
+      status: 'initialised',
+      invoiceCount: 0,
+      invoiceValue: 0,
+      creditNoteCount: 0,
+      creditNoteValue: 0
+    }
   }
 
   /**

--- a/app/models/bill_run.model.js
+++ b/app/models/bill_run.model.js
@@ -87,6 +87,10 @@ class BillRunModel extends BaseModel {
    * Use this method to update a bill run (determined by the bill run ID in the `transaction` param) based on the
    * transaction.
    *
+   * We also reset it's summary information (`invoiceCount`, `creditNoteCount` etc) and put the status back to
+   * `initialised` to reflect the fact a client system will need to regenerate the bill run so we can take into account
+   * the changes made by the transaction.
+   *
    * > Note - a similar process is done for invoices and licences though they have the additional task of determining
    * if a new invoice or licence record needs to be created first
    *
@@ -109,6 +113,22 @@ class BillRunModel extends BaseModel {
     return id
   }
 
+  /**
+   * Add 'reset' details to a patch that is to be used to update the bill run
+   *
+   * When a transaction is added to a bill run, if the bill run has alrerady been generated we need to 'reset' it
+   * because the transaction might have made changes that would invalidate the current information.
+   *
+   * This could be on top of existing changes being made, for example to the tally fields. As this is unique to bill
+   * runs we have the logic here rather than in the `CreateTransactionTallyService`.
+   *
+   * @param {Object} [currentPatch] The current patch about to be applied. Default to an empty object for use cases
+   * where all you want to do is reset the bill run, for example, when removing the last invoice on a generated bill
+   * run
+   *
+   * @returns {Object} a new patch object based on the provided patch and what is needed to reset the bill run summary
+   * information
+   */
   static _addResetPatch (currentPatch = {}) {
     return {
       ...currentPatch,

--- a/test/services/create_transaction.service.test.js
+++ b/test/services/create_transaction.service.test.js
@@ -29,7 +29,7 @@ const { RulesService } = require('../../app/services')
 // Thing under test
 const { CreateTransactionService } = require('../../app/services')
 
-describe.only('Create Transaction service', () => {
+describe('Create Transaction service', () => {
   let billRun
   let authorisedSystem
   let regime

--- a/test/services/create_transaction.service.test.js
+++ b/test/services/create_transaction.service.test.js
@@ -29,7 +29,7 @@ const { RulesService } = require('../../app/services')
 // Thing under test
 const { CreateTransactionService } = require('../../app/services')
 
-describe('Create Transaction service', () => {
+describe.only('Create Transaction service', () => {
   let billRun
   let authorisedSystem
   let regime
@@ -51,17 +51,42 @@ describe('Create Transaction service', () => {
   })
 
   describe('When the data is valid', () => {
-    let transaction
-    let result
+    describe('and the bill run has not been generated', () => {
+      let result
 
-    beforeEach(async () => {
-      Sinon.stub(RulesService, 'go').returns(chargeFixtures.simple.rulesService)
-      transaction = await CreateTransactionService.go(payload, billRun, authorisedSystem, regime)
-      result = await TransactionModel.query().findById(transaction.transaction.id)
+      beforeEach(async () => {
+        Sinon.stub(RulesService, 'go').returns(chargeFixtures.simple.rulesService)
+        const transaction = await CreateTransactionService.go(payload, billRun, authorisedSystem, regime)
+        result = await TransactionModel.query().findById(transaction.transaction.id)
+      })
+
+      it('creates a transaction', async () => {
+        expect(result.id).to.exist()
+      })
     })
 
-    it('creates a transaction', async () => {
-      expect(result.id).to.exist()
+    describe('and the bill run has been generated', () => {
+      let result
+
+      beforeEach(async () => {
+        Sinon.stub(RulesService, 'go').returns(chargeFixtures.simple.rulesService)
+        const transaction = await CreateTransactionService.go(payload, billRun, authorisedSystem, regime)
+        result = await TransactionModel.query().findById(transaction.transaction.id)
+      })
+
+      it('creates a transaction', async () => {
+        expect(result.id).to.exist()
+      })
+
+      it("resets the bill run to 'initialised'", async () => {
+        await BillRunHelper.generateBillRun(billRun.id)
+        await CreateTransactionService.go(payload, billRun, authorisedSystem, regime)
+
+        const refreshedBillRun = await billRun.$query()
+
+        expect(refreshedBillRun.status).to.equal('initialised')
+        expect(refreshedBillRun.invoiceCount).to.equal(0)
+      })
     })
   })
 

--- a/test/support/helpers/bill_run.helper.js
+++ b/test/support/helpers/bill_run.helper.js
@@ -23,6 +23,37 @@ class BillRunHelper {
       })
       .returning('*')
   }
+
+  /**
+   * Mock generate a bill run
+   *
+   * We do not _actually_ generate a bill run with this helper. We simply update the bill run record to reflect what a
+   * generated bill run would look like
+   *
+   * @param {string} billRunId Id of the bill run to update as 'generated'
+   * @param {Object} [overrides] JSON object of values which will override those used by the helper. By default, this
+   * helper will updated the `invoiceCount` to 1 and the `invoiceValue` to 5000. Use this to set other values, or to set
+   * the credit note properties
+   *
+   * @returns {module:BillRunModel} An updated instance of `BillRunModel` for the bill run specified
+   */
+  static generateBillRun (billRunId, overrides = {}) {
+    return BillRunModel.query()
+      .findById(billRunId)
+      .patch({
+        ...this._defaultGenerateBillRunPatch(),
+        ...overrides
+      })
+      .returning('*')
+  }
+
+  static _defaultGenerateBillRunPatch () {
+    return {
+      status: 'generated',
+      invoiceCount: 1,
+      invoiceValue: 5000
+    }
+  }
 }
 
 module.exports = BillRunHelper


### PR DESCRIPTION
We've spotted an edge case the CM isn't handling. Once a bill run is `generated` we allow 2 kinds of edits

- deleting an invoice
- adding a transaction

Our commitment to client systems is that the invoice and credit note values of a generated bill run are correct. When deleting an invoice, we are able to (and appear to be!) correctly recalculating the invoice and credit note values to reflect the change.

Adding a transaction is harder. What was an invoice could suddenly become a credit note, a zero value transaction, or something even more complicated like minimum charge. Because of this the expectation was that the status would have to go back to `initialised` and the client system would be required to call the `/generate` endpoint again.

A recent test has highlighted we're not doing that. We are leaving the status as `generated` which means the values are incorrect. We are breaking that commitment to our client systems.

This change fixes the issue, by ensuring we set the bill run status to initialised (and reset the invoice and credit note values) whenever a transaction is added.