### PR TITLE
Develop initial DeleteLicenceService

### DIFF
--- a/app/services/delete_licence.service.js
+++ b/app/services/delete_licence.service.js
@@ -1,0 +1,34 @@
+'use strict'
+
+/**
+ * @module DeleteLicenceService
+ */
+
+const { LicenceModel } = require('../models')
+
+class DeleteLicenceService {
+  /**
+   * Deletes a licence along with its transactions. Intended to be run as a background task by a controller, ie. called
+   * without an await. Note that the licence will _not_ be validated to ensure it is linked to the bill run; it is
+   * expected that this will be done from the calling controller so that it can present the appropriate error to the
+   * user immediately.
+   *
+   * @param {module:LicenceModel} licence The licence to be deleted.
+   * @param {@module:RequestNotifier} notifier Instance of `RequestNotifier` class. We use it to log errors rather than
+   * throwing them as this service is intended to run in the background.
+   */
+  static async go (licence, notifier) {
+    try {
+      await LicenceModel.transaction(async trx => {
+        // We only need to delete the licence as it will cascade down to the transaction level.
+        await LicenceModel
+          .query(trx)
+          .deleteById(licence.id)
+      })
+    } catch (error) {
+      notifier.omfg('Error deleting licence', { id: licence.id, error })
+    }
+  }
+}
+
+module.exports = DeleteLicenceService

--- a/app/services/index.js
+++ b/app/services/index.js
@@ -20,6 +20,7 @@ const DbErrorsService = require('./plugins/db_errors.service')
 const DeleteBillRunService = require('./delete_bill_run.service')
 const DeleteFileService = require('./delete_file.service')
 const DeleteInvoiceService = require('./delete_invoice.service')
+const DeleteLicenceService = require('./delete_licence.service')
 const FetchAndValidateBillRunInvoiceService = require('./fetch_and_validate_bill_run_invoice.service')
 const FilterRoutesService = require('./plugins/filter_routes.service')
 const GenerateBillRunService = require('./generate_bill_run.service')
@@ -84,6 +85,7 @@ module.exports = {
   DeleteBillRunService,
   DeleteFileService,
   DeleteInvoiceService,
+  DeleteLicenceService,
   FetchAndValidateBillRunInvoiceService,
   FilterRoutesService,
   GenerateBillRunService,

--- a/test/services/delete_licence.service.test.js
+++ b/test/services/delete_licence.service.test.js
@@ -1,0 +1,82 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const {
+  AuthorisedSystemHelper,
+  BillRunHelper,
+  DatabaseHelper,
+  GeneralHelper,
+  RegimeHelper,
+  TransactionHelper
+} = require('../support/helpers')
+
+const {
+  TransactionModel,
+  LicenceModel
+} = require('../../app/models')
+
+// Thing under test
+const { DeleteLicenceService } = require('../../app/services')
+
+describe('Delete Licence service', () => {
+  let regime
+  let authorisedSystem
+  let billRun
+  let transaction
+  let licence
+  let notifierFake
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+
+    regime = await RegimeHelper.addRegime('wrls', 'WRLS')
+    authorisedSystem = await AuthorisedSystemHelper.addSystem('1234546789', 'system1', [regime])
+
+    billRun = await BillRunHelper.addBillRun(authorisedSystem.id, regime.id)
+    transaction = await TransactionHelper.addTransaction(billRun.id)
+    licence = await LicenceModel.query().findById(transaction.licenceId)
+
+    // Create a fake function to stand in place of Notifier.omfg()
+    notifierFake = { omfg: Sinon.fake() }
+  })
+
+  afterEach(async () => {
+    Sinon.restore()
+  })
+
+  describe('When a valid licence is supplied', () => {
+    it('deletes the licence', async () => {
+      await DeleteLicenceService.go(licence, notifierFake)
+
+      const result = await LicenceModel.query().findById(transaction.licenceId)
+
+      expect(result).to.not.exist()
+    })
+
+    it('deletes the licence transactions', async () => {
+      await DeleteLicenceService.go(licence, notifierFake)
+
+      const transactions = await TransactionModel.query().select().where({ billRunId: billRun.id })
+
+      expect(transactions).to.be.empty()
+    })
+  })
+
+  describe('When an error occurs', () => {
+    it('calls the notifier', async () => {
+      const invalidParamater = GeneralHelper.uuid4()
+      await DeleteLicenceService.go(invalidParamater, notifierFake)
+
+      expect(notifierFake.omfg.callCount).to.equal(1)
+      expect(notifierFake.omfg.firstArg).to.equal('Error deleting licence')
+    })
+  })
+})


### PR DESCRIPTION
https://trello.com/c/RsNVNpvf/1985-remove-licences-delete-licence-and-transactions

This implements the initial `DeleteLicenceService`, which deletes a licence and its transactions. Note that recalculation of the bill run and invoice (including deleting the invoice if this deletion leaves it without any licences/transactions) will be done in future PRs.