### PR TITLE
Fix Client ID unique constraint for rebilling

### DIFF
--- a/app/services/invoice_rebilling_create_transaction.service.js
+++ b/app/services/invoice_rebilling_create_transaction.service.js
@@ -31,6 +31,7 @@ class InvoiceRebillingCreateTransactionService {
    * Returns a new transaction object ready to be persisted in the db, based on the provided transaction with a few
    * changes:
    * - We set the id as `undefined` to avoid conflicting with the existing transaction;
+   * - We set the clientId as `undefined` to avoid the unique constraint on regime and clientID in transactions table
    * - We set other fields we don't want copying as `undefined`;
    * - We set the bill run, invoice and licence ids based on the provided licence;
    * - We invert the credit boolean if required.
@@ -41,6 +42,7 @@ class InvoiceRebillingCreateTransactionService {
       id: undefined,
       createdAt: undefined,
       updatedAt: undefined,
+      clientId: undefined,
       createdBy: authorisedSystem.id,
       billRunId: licence.billRunId,
       invoiceId: licence.invoiceId,

--- a/test/services/invoice_rebilling_create_transaction.service.test.js
+++ b/test/services/invoice_rebilling_create_transaction.service.test.js
@@ -41,6 +41,24 @@ describe('Invoice Rebilling Create Transaction service', () => {
     rebillBillRun = await BillRunHelper.addBillRun(authorisedSystem.id, regime.id)
   })
 
+  describe('when the original transaction contains a client ID', () => {
+    beforeEach(async () => {
+      const invoice = await addRebillInvoice(rebillBillRun.id, 'TH230000222', 2021, null, 'R')
+      const licence = await LicenceHelper.addLicence(rebillBillRun.id, 'TONY/TF9222/37', invoice.id)
+      transaction = await TransactionHelper.addTransaction(
+        originalBillRun.id,
+        { chargeFinancialYear: 2021, clientId: 'CANBEONLYONE' }
+      )
+
+      result = await InvoiceRebillingCreateTransactionService.go(transaction, licence, rebillAuthorisedSystem)
+    })
+
+    it('still can create the new rebilling transaction (the DB unique constraint does not block it)', () => {
+      expect(result.id).to.exist()
+      expect(result.clientId).to.be.null()
+    })
+  })
+
   describe('when the transaction type is not to be inverted', () => {
     let licence
 

--- a/test/services/invoice_rebilling_create_transaction.service.test.js
+++ b/test/services/invoice_rebilling_create_transaction.service.test.js
@@ -55,7 +55,7 @@ describe('Invoice Rebilling Create Transaction service', () => {
 
     it('still can create the new rebilling transaction (the DB unique constraint does not block it)', () => {
       expect(result.id).to.exist()
-      expect(result.clientId).to.be.null()
+      expect(result.clientId).to.be.undefined()
     })
   })
 

--- a/test/services/invoice_rebilling_create_transaction.service.test.js
+++ b/test/services/invoice_rebilling_create_transaction.service.test.js
@@ -84,7 +84,7 @@ describe('Invoice Rebilling Create Transaction service', () => {
       it('with the correct values duplicated', async () => {
       // Create a list of all keys in the transaction object and filter out the ones we don't want to check
         const transactionKeys = Object.keys(transaction)
-        const keysToSkip = ['id', 'billRunId', 'createdAt', 'updatedAt', 'createdBy', 'invoiceId', 'licenceId']
+        const keysToSkip = ['id', 'billRunId', 'createdAt', 'updatedAt', 'createdBy', 'invoiceId', 'licenceId', 'clientId']
         const keysToCheck = transactionKeys.filter(key => !keysToSkip.includes(key))
 
         // Iterate over the remaining keys and check that the result's value matches the original transaction's value
@@ -96,7 +96,7 @@ describe('Invoice Rebilling Create Transaction service', () => {
       it('with the correct values not duplicated', async () => {
         // Create a list of all keys in the transaction object and filter out the ones we don't want to check
         const transactionKeys = Object.keys(transaction)
-        const keysToInclude = ['id', 'billRunId', 'createdAt', 'updatedAt', 'createdBy', 'invoiceId', 'licenceId']
+        const keysToInclude = ['id', 'billRunId', 'createdAt', 'updatedAt', 'createdBy', 'invoiceId', 'licenceId', 'clientId']
         const keysToCheck = transactionKeys.filter(key => keysToInclude.includes(key))
 
         // Iterate over the remaining keys and check that the result's value matches the original transaction's value


### PR DESCRIPTION
https://trello.com/c/qkWbpJlf

We have a constraint on the `transaction` record to ensure we don't allow 2 transactions with the same `regime_id` and `client_id` to be inserted. This is how client systems have confidence we don't allow duplicate transactions to get into an invoice.

We forgot about this though when adding the rebilling functionality. All our manual and unit testing did not include having an original invoice with transactions with client ID's set.

In recent testing, we found that the copying of transactions from the original to the rebilling invoices fails because of this constraint.

So, this change fixes the issue to ensure we still prevent duplicate transactions from being added but allow us to create rebilling invoices.