### PR TITLE
Refactor bill run editable and add patchable

### DIFF
--- a/app/models/bill_run.model.js
+++ b/app/models/bill_run.model.js
@@ -141,22 +141,21 @@ class BillRunModel extends BaseModel {
   }
 
   /**
-   * Returns whether the bill run can be 'edited'
+   * Returns whether the bill run can be 'patched'
    *
-   * Once a bill run has been 'sent', which means the transaction file is generated, it cannot be edited. This includes
-   * adding or deleting transactions, or deleting the bill run altogether.
+   * Our PATCH endpoints are `/generate`, `/approve` and `/send` and a bill run can only respond to one of these
+   * requests if it is in a suitable state.
    *
-   * After being 'sent' the bill run status may change to `billed` or `billing_not_required` but it still remains
-   * uneditable.
+   * Once a bill run has been 'sent', which means the transaction file is generated, it cannot be further 'patched'.
    *
-   * A bill run is also uneditable if it's in the middle of generating its summary. We can't allow changes which will
-   * cause the generated result to be invalid.
+   * A bill run is also unpatchable if it's in the middle of something, for example, generating its summary or sending
+   * the transaction file.
    *
-   * Finally, a bill run is uneditable if the status is `deleting`. This gets set when a `DELETE` request is received.
+   * Finally, a bill run is unpatchable if the status is `deleting`. This gets set when a `DELETE` request is received.
    * We don't expect client systems to ever see this but large bill runs can take some seconds to finish deleting. So,
    * we set the `deleting` status just in case someone tries to interact with the bill run during this time.
    */
-  $editable () {
+  $patchable () {
     return ['initialised', 'generated', 'approved'].includes(this.status)
   }
 

--- a/app/models/bill_run.model.js
+++ b/app/models/bill_run.model.js
@@ -141,6 +141,23 @@ class BillRunModel extends BaseModel {
   }
 
   /**
+   * Returns whether the bill run can be 'edited'
+   *
+   * If a bill run has a status of `initialised` or `generated` it can be edited. This means transactions can be added,
+   * invoices or licences deleted, or the bill run itself deleted.
+   *
+   * Once `approved` a bill run cannot be edited. This is different from `$patchable()` for example, which is concerned
+   * with processing the bill run. Once `approved` we want to be able to `/send` a bill run but we don't want to allow
+   * a transaction to be added.
+   *
+   * This also protects against trying to make changes when the bill run is being processed. So interim states like
+   * `generating`, `pending`, and `deleting` are also not classed as 'editable'.
+   */
+  $editable () {
+    return ['initialised', 'generated'].includes(this.status)
+  }
+
+  /**
    * Returns whether the bill run can be 'patched'
    *
    * Our PATCH endpoints are `/generate`, `/approve` and `/send` and a bill run can only respond to one of these

--- a/app/services/plugins/request_bill_run.service.js
+++ b/app/services/plugins/request_bill_run.service.js
@@ -74,8 +74,12 @@ class RequestBillRunService {
   }
 
   /**
-   * Validate that the bill run can be edited if the http method is one that requires it to be editable. We ignore this
-   * if the path contains `/admin/`.
+   * Validate that the bill run can be updated if the http method is one that requires it to be changed
+   *
+   * If the request is a `PATCH` for a 'billed' bill run we need to reject it. Same for a `POST` or `DELETE` request
+   * for an 'approved' bill run.
+   *
+   * This method determines the validation to apply based on the request type.
    */
   static _validateCanUpdateBillRun (billRun, path, method) {
     switch (method) {

--- a/app/services/plugins/request_bill_run.service.js
+++ b/app/services/plugins/request_bill_run.service.js
@@ -26,7 +26,7 @@ class RequestBillRunService {
    * - that the request relates to an existing bill run (`POST` a new bill run is ignored)
    * - that we can find the bill run
    * - the bill run is linked to the requested regime which ensures the client system has access to it
-   * - that if the request involves editing the bill run its status is such that it can be changed (note that we do not
+   * - that if the request involves changing the bill run its status is such that it can be changed (note that we do not
    *   perform this check if the request path contains `/admin/` to allow eg. retrying transaction file generation of a
    *   pending bill run.)
    *
@@ -78,9 +78,14 @@ class RequestBillRunService {
    * if the path contains `/admin/`.
    */
   static _validateCanEditBillRun (billRun, path, method) {
+    // No validation is required if the request just a GET
+    if (method === 'get') {
+      return
+    }
+
     const adminPath = this._adminPath(path)
 
-    if (!adminPath && !billRun.$editable() && method !== 'get') {
+    if (!adminPath && !billRun.$patchable()) {
       throw Boom.conflict(`Bill run ${billRun.id} cannot be edited because its status is ${billRun.status}.`)
     }
   }

--- a/app/services/plugins/request_bill_run.service.js
+++ b/app/services/plugins/request_bill_run.service.js
@@ -81,11 +81,12 @@ class RequestBillRunService {
     switch (method) {
       case 'get':
         // No validation is required if the request just a GET
-        return
+        break
       case 'patch':
-        return this._validateCanPatchBillRun(billRun, path)
+        this._validateCanPatchBillRun(billRun, path)
+        break
       default:
-        return this._validateCanEditBillRun(billRun)
+        this._validateCanEditBillRun(billRun)
     }
   }
 

--- a/test/controllers/presroc/bill_runs.controller.test.js
+++ b/test/controllers/presroc/bill_runs.controller.test.js
@@ -156,7 +156,7 @@ describe('Presroc Bill Runs controller', () => {
           const responsePayload = JSON.parse(response.payload)
 
           expect(response.statusCode).to.equal(409)
-          expect(responsePayload.message).to.equal(`Bill run ${generatingBillRun.id} cannot be edited because its status is generating.`)
+          expect(responsePayload.message).to.equal(`Bill run ${generatingBillRun.id} cannot be patched because its status is generating.`)
         })
       })
     })

--- a/test/models/bill_run.model.test.js
+++ b/test/models/bill_run.model.test.js
@@ -41,6 +41,56 @@ describe('Bill Run Model', () => {
     })
   })
 
+  describe('the $editable() method', () => {
+    it("returns 'true' when the status is 'initialised'", async () => {
+      const instance = BillRunModel.fromJson({ status: 'initialised' })
+
+      expect(instance.$editable()).to.be.true()
+    })
+
+    it("returns 'false' when the status is 'generating'", async () => {
+      const instance = BillRunModel.fromJson({ status: 'generating' })
+
+      expect(instance.$editable()).to.be.false()
+    })
+
+    it("returns 'true' when the status is 'generated'", async () => {
+      const instance = BillRunModel.fromJson({ status: 'generated' })
+
+      expect(instance.$editable()).to.be.true()
+    })
+
+    it("returns 'false' when the status is 'approved'", async () => {
+      const instance = BillRunModel.fromJson({ status: 'approved' })
+
+      expect(instance.$editable()).to.be.false()
+    })
+
+    it("returns 'false' when the status is 'pending'", async () => {
+      const instance = BillRunModel.fromJson({ status: 'pending' })
+
+      expect(instance.$editable()).to.be.false()
+    })
+
+    it("returns 'false' when the status is 'billed'", async () => {
+      const instance = BillRunModel.fromJson({ status: 'billed' })
+
+      expect(instance.$editable()).to.be.false()
+    })
+
+    it("returns 'false' when the status is 'billing_not_required'", async () => {
+      const instance = BillRunModel.fromJson({ status: 'billing_not_required' })
+
+      expect(instance.$editable()).to.be.false()
+    })
+
+    it("returns 'false' when the status is 'deleting'", async () => {
+      const instance = BillRunModel.fromJson({ status: 'deleting' })
+
+      expect(instance.$editable()).to.be.false()
+    })
+  })
+
   describe('the $patchable() method', () => {
     it("returns 'true' when the status is 'initialised'", async () => {
       const instance = BillRunModel.fromJson({ status: 'initialised' })
@@ -80,6 +130,12 @@ describe('Bill Run Model', () => {
 
     it("returns 'false' when the status is 'billing_not_required'", async () => {
       const instance = BillRunModel.fromJson({ status: 'billing_not_required' })
+
+      expect(instance.$patchable()).to.be.false()
+    })
+
+    it("returns 'false' when the status is 'deleting'", async () => {
+      const instance = BillRunModel.fromJson({ status: 'deleting' })
 
       expect(instance.$patchable()).to.be.false()
     })

--- a/test/models/bill_run.model.test.js
+++ b/test/models/bill_run.model.test.js
@@ -41,47 +41,47 @@ describe('Bill Run Model', () => {
     })
   })
 
-  describe('the $editable() method', () => {
+  describe('the $patchable() method', () => {
     it("returns 'true' when the status is 'initialised'", async () => {
       const instance = BillRunModel.fromJson({ status: 'initialised' })
 
-      expect(instance.$editable()).to.be.true()
+      expect(instance.$patchable()).to.be.true()
     })
 
     it("returns 'false' when the status is 'generating'", async () => {
       const instance = BillRunModel.fromJson({ status: 'generating' })
 
-      expect(instance.$editable()).to.be.false()
+      expect(instance.$patchable()).to.be.false()
     })
 
     it("returns 'true' when the status is 'generated'", async () => {
       const instance = BillRunModel.fromJson({ status: 'generated' })
 
-      expect(instance.$editable()).to.be.true()
+      expect(instance.$patchable()).to.be.true()
     })
 
     it("returns 'true' when the status is 'approved'", async () => {
       const instance = BillRunModel.fromJson({ status: 'approved' })
 
-      expect(instance.$editable()).to.be.true()
+      expect(instance.$patchable()).to.be.true()
     })
 
     it("returns 'false' when the status is 'pending'", async () => {
       const instance = BillRunModel.fromJson({ status: 'pending' })
 
-      expect(instance.$editable()).to.be.false()
+      expect(instance.$patchable()).to.be.false()
     })
 
     it("returns 'false' when the status is 'billed'", async () => {
       const instance = BillRunModel.fromJson({ status: 'billed' })
 
-      expect(instance.$editable()).to.be.false()
+      expect(instance.$patchable()).to.be.false()
     })
 
     it("returns 'false' when the status is 'billing_not_required'", async () => {
       const instance = BillRunModel.fromJson({ status: 'billing_not_required' })
 
-      expect(instance.$editable()).to.be.false()
+      expect(instance.$patchable()).to.be.false()
     })
   })
 


### PR DESCRIPTION
We have faced questions recently about what we should do when amending a bill run that has the status of `approved`. Within the team and after speaking to WRLS we are all agreed that once a bill run is marked as `approved` it should not be possible to make changes to it.

Simply removing the status from `BillBunModel.$editable()` though has knock-on repercussions for `/send` a bill run and `/delete` a bill run, plus `/delete` an invoice.

Having checked the scenarios we are dealing with what we really need is the ability to check

- if a bill run is _patchable_, for example, we can call the `/generate`, `/approve` and `/send` requests on it
- if a bill run is _editable_, for example, we can add a transaction or delete an invoice

This change refactors the existing `$editable()` to remove the `approved` status. We then add a new `$patchable()` instance method to the `BillRunModel`. `RequestBillRunService` is then updated to exploit these changes and ensure a bill run can only be changed when appropriate.
