### PR TITLE
Fix minimum charge being calculated at wrong level

### DIFF
--- a/app/models/invoice.model.js
+++ b/app/models/invoice.model.js
@@ -8,7 +8,6 @@ const { Model } = require('objection')
 const BaseUpsertModel = require('./base_upsert.model')
 
 const DEMINIMIS_LIMIT = 500
-const MINIMUM_CHARGE_LIMIT = 2500
 
 class InvoiceModel extends BaseUpsertModel {
   static get tableName () {

--- a/app/models/invoice.model.js
+++ b/app/models/invoice.model.js
@@ -75,12 +75,8 @@ class InvoiceModel extends BaseUpsertModel {
        */
       minimumCharge (query) {
         query
-          .where(builder => builder
-            .where('subjectToMinimumChargeCreditValue', '>', 0)
-          )
-          .orWhere(builder => builder
-            .where('subjectToMinimumChargeDebitValue', '>', 0)
-          )
+          .where('subjectToMinimumChargeCreditValue', '>', 0)
+          .orWhere('subjectToMinimumChargeDebitValue', '>', 0)
           .modify('originalInvoice')
       },
 

--- a/app/models/invoice.model.js
+++ b/app/models/invoice.model.js
@@ -78,11 +78,9 @@ class InvoiceModel extends BaseUpsertModel {
         query
           .where(builder => builder
             .where('subjectToMinimumChargeCreditValue', '>', 0)
-            .where('subjectToMinimumChargeCreditValue', '<', MINIMUM_CHARGE_LIMIT)
           )
           .orWhere(builder => builder
             .where('subjectToMinimumChargeDebitValue', '>', 0)
-            .where('subjectToMinimumChargeDebitValue', '<', MINIMUM_CHARGE_LIMIT)
           )
           .modify('originalInvoice')
       },

--- a/app/services/calculate_minimum_charge.service.js
+++ b/app/services/calculate_minimum_charge.service.js
@@ -59,11 +59,11 @@ class CalculateMinimumChargeService {
     // In some scenarios null will be added to the array -- we will filter these out before we return.
     for (const licence of licences) {
       if (licence.subjectToMinimumChargeCreditValue) {
-        adjustments.push(await this._adjustment(licence, licence.creditLineValue, true))
+        adjustments.push(await this._adjustment(licence, licence.subjectToMinimumChargeCreditValue, true))
       }
 
       if (licence.subjectToMinimumChargeDebitValue) {
-        adjustments.push(await this._adjustment(licence, licence.debitLineValue, false))
+        adjustments.push(await this._adjustment(licence, licence.subjectToMinimumChargeDebitValue, false))
       }
     }
 

--- a/test/services/calculate_minimum_charge.service.test.js
+++ b/test/services/calculate_minimum_charge.service.test.js
@@ -34,7 +34,7 @@ const MINIMUM_CHARGE_LIMIT = 2500
 // Thing under test
 const { CalculateMinimumChargeService } = require('../../app/services')
 
-describe.only('Calculate Minimum Charge service', () => {
+describe('Calculate Minimum Charge service', () => {
   let authorisedSystem
   let regime
   let payload


### PR DESCRIPTION
https://trello.com/c/KaBWf4Bh

Whilst undertaking Business Acceptance Testing (BAT) the WRLS spotted that the CM does not calculate minimum charge at the appropriate level.

The scenario they created was

- create a bill run
- for customer `C01` and licence `L01` add a subject to minimum charge transaction for £20
- for the same customer but licence `L02` add a subject to minimum charge transaction for £50

The _expected_ result is that a minimum charge would still be added to bring the total value of licence `L01` up to £25. The _actual_ result was that no minimum charge was applied.

On investigation, we identified the problem. Essentially, we are currently determining which invoices to consider reviewing for minimum charge based on the total value of minimum charge transactions at **invoice** level. If the total is more than £25 we exclude the invoice and all linked licences from the check.

Secondly, minimum charge is specified at transaction level. So, the scenario could be

- create a bill run
- for customer `C01` and licence `L01` add a subject to minimum charge transaction for £20
- for the same customer and licence add a standard transaction for £50

Having confirmed with our BA, the _expected_ result is that a £5 minimum charge would still be added to licence `L01` to bring the total value of its minimum charge transactions up to £25. The _actual_ result was that no minimum charge was applied.

This change covers

- applying fixes
- adding tests to ensure when we generate a bill run we get the expected result