### PR TITLE
Add delete licence services to controller

### DIFF
--- a/app/controllers/presroc/bill_runs_licences.controller.js
+++ b/app/controllers/presroc/bill_runs_licences.controller.js
@@ -1,7 +1,15 @@
 'use strict'
 
+const { DeleteLicenceService, ValidateBillRunLicenceService } = require('../../services')
+
 class BillRunsLicencesController {
   static async delete (req, h) {
+    // We validate the licence within the controller so a validation error is returned immediately
+    await ValidateBillRunLicenceService.go(req.app.billRun.id, req.app.licence)
+
+    // We start DeleteLicenceService without await so that it runs in the background
+    DeleteLicenceService.go(req.app.licence, req.app.notifier)
+
     return h.response().code(204)
   }
 }

--- a/test/controllers/presroc/bill_runs_licences.controller.test.js
+++ b/test/controllers/presroc/bill_runs_licences.controller.test.js
@@ -74,8 +74,11 @@ describe('Presroc Licences controller', () => {
         .stub(JsonWebToken, 'verify')
         .returns(AuthorisationHelper.decodeToken(authToken))
 
-      validationStub = Sinon.stub(ValidateBillRunLicenceService, 'go').returns()
-      deletionStub = Sinon.stub(DeleteLicenceService, 'go').returns()
+      validationStub = Sinon
+        .stub(ValidateBillRunLicenceService, 'go').returns()
+
+      deletionStub = Sinon
+        .stub(DeleteLicenceService, 'go').returns()
     })
 
     afterEach(async () => {

--- a/test/controllers/presroc/bill_runs_licences.controller.test.js
+++ b/test/controllers/presroc/bill_runs_licences.controller.test.js
@@ -25,6 +25,7 @@ const {
 
 // Things we need to stub
 const JsonWebToken = require('jsonwebtoken')
+const { DeleteLicenceService, ValidateBillRunLicenceService } = require('../../../app/services')
 
 describe('Presroc Licences controller', () => {
   const clientID = '1234546789'
@@ -55,6 +56,9 @@ describe('Presroc Licences controller', () => {
   })
 
   describe('Delete a licence: DELETE /v2/{regimeId}/bill-runs/{billRunId}/licences/{licenceId}', () => {
+    let validationStub
+    let deletionStub
+
     const options = (token, billRunId, licenceId) => {
       return {
         method: 'DELETE',
@@ -69,6 +73,14 @@ describe('Presroc Licences controller', () => {
       Sinon
         .stub(JsonWebToken, 'verify')
         .returns(AuthorisationHelper.decodeToken(authToken))
+
+      validationStub = Sinon.stub(ValidateBillRunLicenceService, 'go').returns()
+      deletionStub = Sinon.stub(DeleteLicenceService, 'go').returns()
+    })
+
+    afterEach(async () => {
+      validationStub.restore()
+      deletionStub.restore()
     })
 
     describe('When the request is valid', () => {
@@ -76,6 +88,18 @@ describe('Presroc Licences controller', () => {
         const response = await server.inject(options(authToken, billRun.id, licence.id))
 
         expect(response.statusCode).to.equal(204)
+      })
+
+      it('calls the licence validation service', async () => {
+        await server.inject(options(authToken, billRun.id, licence.id))
+
+        expect(validationStub.calledOnce).to.be.true()
+      })
+
+      it('calls the licence deletion service', async () => {
+        await server.inject(options(authToken, billRun.id, licence.id))
+
+        expect(deletionStub.calledOnce).to.be.true()
       })
     })
 
@@ -85,6 +109,18 @@ describe('Presroc Licences controller', () => {
           const response = await server.inject(options(authToken, billRun.id, GeneralHelper.uuid4()))
 
           expect(response.statusCode).to.equal(404)
+        })
+
+        it('does not call the licence validation service', async () => {
+          await server.inject(options(authToken, billRun.id, GeneralHelper.uuid4()))
+
+          expect(validationStub.called).to.be.false()
+        })
+
+        it('does not call the licence deletion service', async () => {
+          await server.inject(options(authToken, billRun.id, GeneralHelper.uuid4()))
+
+          expect(deletionStub.called).to.be.false()
         })
       })
     })


### PR DESCRIPTION
https://trello.com/c/ZjWhOdbQ/1984-remove-licences-initial-validation
https://trello.com/c/RsNVNpvf/1985-remove-licences-delete-licence-and-transactions

After implementing the [validate licence](https://github.com/DEFRA/sroc-charging-module-api/pull/445) and [delete licence](https://github.com/DEFRA/sroc-charging-module-api/pull/446) services, we add these to the controller using the established pattern of calling the validation asynchronously so any errors are returned immediately, then calling the deletion synchronously so we can return a `204` response straight away while deletion continues in the background.

Note that at this stage additional work is needed on the delete licence service in order to recalculate bill run and invoice summary info; however this won't affect how we call the service so we can add it to the controller now.