### PR TITLE
Fix missing flags on rebill invoices

### DIFF
--- a/app/services/invoice_rebilling_initialise.service.js
+++ b/app/services/invoice_rebilling_initialise.service.js
@@ -53,6 +53,8 @@ class InvoiceRebillingInitialiseService {
       customerReference: invoice.customerReference,
       financialYear: invoice.financialYear,
       rebilledInvoiceId: invoice.id,
+      deminimisInvoice: invoice.deminimisInvoice,
+      minimumChargeInvoice: invoice.minimumChargeInvoice,
       rebilledType
     })
   }

--- a/test/services/invoice_rebilling_initialise.service.test.js
+++ b/test/services/invoice_rebilling_initialise.service.test.js
@@ -30,13 +30,6 @@ describe('Invoice Rebilling Initialise service', () => {
     expect(result.rebillInvoice.billRunId).to.equal(billRun.id)
   })
 
-  it('creates two new invoices linked to the bill run', async () => {
-    const result = await InvoiceRebillingInitialiseService.go(billRun, invoice)
-
-    expect(result.cancelInvoice.billRunId).to.equal(billRun.id)
-    expect(result.rebillInvoice.billRunId).to.equal(billRun.id)
-  })
-
   it("returns a 'response' object containing the id and type of the invoices", async () => {
     const result = await InvoiceRebillingInitialiseService.go(billRun, invoice)
 

--- a/test/services/invoice_rebilling_initialise.service.test.js
+++ b/test/services/invoice_rebilling_initialise.service.test.js
@@ -30,6 +30,18 @@ describe('Invoice Rebilling Initialise service', () => {
     expect(result.rebillInvoice.billRunId).to.equal(billRun.id)
   })
 
+  it('creates two new invoices with the same flags as the original', async () => {
+    const result = await InvoiceRebillingInitialiseService.go(billRun, invoice)
+
+    // deminimisInvoice
+    expect(result.cancelInvoice.deminimisInvoice).to.equal(invoice.deminimisInvoice)
+    expect(result.rebillInvoice.deminimisInvoice).to.equal(invoice.deminimisInvoice)
+
+    // minimumChargeInvoice
+    expect(result.cancelInvoice.minimumChargeInvoice).to.equal(invoice.minimumChargeInvoice)
+    expect(result.rebillInvoice.minimumChargeInvoice).to.equal(invoice.minimumChargeInvoice)
+  })
+
   it("returns a 'response' object containing the id and type of the invoices", async () => {
     const result = await InvoiceRebillingInitialiseService.go(billRun, invoice)
 


### PR DESCRIPTION
https://trello.com/c/rPTeXdJO

Spotted during testing that the rebilled invoices created from the original invoice don't have the same deminimis and minimum charge flags set.

This change ensures they are copied over as per the original invoice.