### PR TITLE
Link rebilled transaction to original transaction

### DIFF
--- a/app/presenters/view_transaction.presenter.js
+++ b/app/presenters/view_transaction.presenter.js
@@ -22,6 +22,7 @@ class ViewTransactionPresenter extends BasePresenter {
       periodStart: data.chargePeriodStart,
       periodEnd: data.chargePeriodEnd,
       compensationCharge: this._asBoolean(data.regimeValue17),
+      rebilledTransactionId: data.rebilledTransactionId,
       calculation: data.chargeCalculation
     }
   }

--- a/app/services/invoice_rebilling_create_transaction.service.js
+++ b/app/services/invoice_rebilling_create_transaction.service.js
@@ -47,6 +47,7 @@ class InvoiceRebillingCreateTransactionService {
       billRunId: licence.billRunId,
       invoiceId: licence.invoiceId,
       licenceId: licence.id,
+      rebilledTransactionId: transaction.id,
       chargeCredit: invert ? !transaction.chargeCredit : transaction.chargeCredit
     })
   }

--- a/app/services/view_bill_run_invoice.service.js
+++ b/app/services/view_bill_run_invoice.service.js
@@ -62,6 +62,7 @@ class ViewBillRunInvoiceService {
           'chargePeriodStart',
           'chargePeriodEnd',
           'regimeValue17',
+          'rebilledTransactionId',
           'chargeCalculation'
         )
       })

--- a/db/migrations/20210609165720_alter_transactions.js
+++ b/db/migrations/20210609165720_alter_transactions.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const tableName = 'transactions'
+
+exports.up = async function (knex) {
+  await knex
+    .schema
+    .alterTable(tableName, table => {
+      table.uuid('rebilled_transaction_id')
+    })
+}
+
+exports.down = async function (knex) {
+  await knex
+    .schema
+    .alterTable(tableName, table => {
+      table.dropColumns('rebilled_transaction_id')
+    })
+}

--- a/test/presenters/view_transaction.presenter.test.js
+++ b/test/presenters/view_transaction.presenter.test.js
@@ -25,6 +25,7 @@ describe('View Transaction Presenter', () => {
     chargePeriodStart: '2019-04-01',
     chargePeriodEnd: '2020-03-31',
     regimeValue17: 'true',
+    rebilledTransactionId: GeneralHelper.uuid4(),
     chargeCalculation: '{"__DecisionID__":"91a711c1-2dbb-47fe-ae8e-505da38432d70","WRLSChargingResponse":{"chargeValue":7.72,"decisionPoints":{"sourceFactor":10.7595,"seasonFactor":17.2152,"lossFactor":0.5164559999999999,"volumeFactor":3.5865,"abatementAdjustment":7.721017199999999,"s127Agreement":7.721017199999999,"s130Agreement":7.721017199999999,"secondPartCharge":false,"waterUndertaker":false,"eiucFactor":0,"compensationCharge":false,"eiucSourceFactor":0,"sucFactor":7.721017199999999},"messages":[],"sucFactor":14.95,"volumeFactor":3.5865,"sourceFactor":3,"seasonFactor":1.6,"lossFactor":0.03,"abatementAdjustment":"S126 x 1.0","s127Agreement":null,"s130Agreement":null,"eiucSourceFactor":0,"eiucFactor":0}}'
   }
 
@@ -43,6 +44,7 @@ describe('View Transaction Presenter', () => {
       'periodStart',
       'periodEnd',
       'compensationCharge',
+      'rebilledTransactionId',
       'calculation'
     ])
   })
@@ -61,6 +63,7 @@ describe('View Transaction Presenter', () => {
     expect(result.periodStart).to.equal(data.chargePeriodStart)
     expect(result.periodEnd).to.equal(data.chargePeriodEnd)
     expect(result.compensationCharge).to.be.true()
+    expect(result.rebilledTransactionId).to.equal(data.rebilledTransactionId)
     expect(result.calculation).to.equal(data.chargeCalculation)
   })
 })

--- a/test/services/invoice_rebilling_create_transaction.service.test.js
+++ b/test/services/invoice_rebilling_create_transaction.service.test.js
@@ -104,6 +104,10 @@ describe('Invoice Rebilling Create Transaction service', () => {
           expect(result[key]).to.not.equal(transaction[key])
         }
       })
+
+      it('records a link back to the original transaction', async () => {
+        expect(result.rebilledTransactionId).to.equal(transaction.id)
+      })
     })
 
     describe('and the tally', () => {

--- a/test/services/invoice_rebilling_create_transaction.service.test.js
+++ b/test/services/invoice_rebilling_create_transaction.service.test.js
@@ -84,7 +84,7 @@ describe('Invoice Rebilling Create Transaction service', () => {
       it('with the correct values duplicated', async () => {
       // Create a list of all keys in the transaction object and filter out the ones we don't want to check
         const transactionKeys = Object.keys(transaction)
-        const keysToSkip = ['id', 'billRunId', 'createdAt', 'updatedAt', 'createdBy', 'invoiceId', 'licenceId', 'clientId']
+        const keysToSkip = ['id', 'billRunId', 'createdAt', 'updatedAt', 'createdBy', 'invoiceId', 'licenceId', 'clientId', 'rebilledTransactionId']
         const keysToCheck = transactionKeys.filter(key => !keysToSkip.includes(key))
 
         // Iterate over the remaining keys and check that the result's value matches the original transaction's value


### PR DESCRIPTION
https://trello.com/c/qkWbpJlf

As part of the rebilling functionality, we record a link between the new rebilled invoices (`C` and `R`) and the original (`O`). We do this by recording the original invoice ID in `invoices.rebilled_invoice_id`.

We have also been asked to record a link between the rebilled transactions and the original transaction. This change adds that ability along with adding it to the `GET /invoice` response so it can be seen by client systems.