### PR TITLE
Fix - protect bill run when rebilling

### DIFF
--- a/app/services/invoice_rebilling_initialise.service.js
+++ b/app/services/invoice_rebilling_initialise.service.js
@@ -28,6 +28,7 @@ class InvoiceRebillingInitialiseService {
     let rebillInvoice
 
     await InvoiceModel.transaction(async trx => {
+      await this._setBillRunStatusToPending(billRun, trx)
       cancelInvoice = await this._createInvoice(billRun, invoice, 'C', trx)
       rebillInvoice = await this._createInvoice(billRun, invoice, 'R', trx)
     })
@@ -45,6 +46,10 @@ class InvoiceRebillingInitialiseService {
     const presenter = new InvoiceRebillingPresenter([cancelInvoice, rebillInvoice])
 
     return presenter.go()
+  }
+
+  static async _setBillRunStatusToPending (billRun, trx) {
+    await billRun.$query(trx).patch({ status: 'pending' })
   }
 
   static _createInvoice (billRun, invoice, rebilledType, trx) {

--- a/test/services/invoice_rebilling_initialise.service.test.js
+++ b/test/services/invoice_rebilling_initialise.service.test.js
@@ -42,6 +42,13 @@ describe('Invoice Rebilling Initialise service', () => {
     expect(result.rebillInvoice.minimumChargeInvoice).to.equal(invoice.minimumChargeInvoice)
   })
 
+  it("sets the bill run status to 'pending'", async () => {
+    await InvoiceRebillingInitialiseService.go(billRun, invoice)
+    const refreshedBillRun = await billRun.$query()
+
+    expect(refreshedBillRun.status).to.equal('pending')
+  })
+
   it("returns a 'response' object containing the id and type of the invoices", async () => {
     const result = await InvoiceRebillingInitialiseService.go(billRun, invoice)
 


### PR DESCRIPTION
The WRLS team have spotted an issue with the rebilling process. When the `PATCH /rebill` endpoint is hit we generate the invoices and return their ID's. The process of copying the transactions and populating the new invoices happens in the background. As far as the client system is concerned the response is complete.

The issue that's been spotted is what happens if the client system was immediately to hit the `PATCH /generate` endpoint after rebilling an invoice? Currently, disaster! As long as at least one transaction has been created the generate process will kick off and create a summary for the bill run based on what is there at the time.

So, we need a solution. This change will update the rebill process to set the bill run's status as `pending`. Whilst the status is `pending` no other actions can take place against the bill run. We've used this convention for the `/send` transaction file and customer file processes. We also intend to apply it for any new changes. In retrospect (and we'll go back and update it at some time) `pending` should be the status we use when generating a bill run.

This then ties up with our existing bill run `GET /status` endpoint; it will always tell you if the data in a bill run is complete or if events are taking place that might mean you have to wait a sec.