### PR TITLE
Refactor InvoiceRebillingService to do more

### DIFF
--- a/app/controllers/presroc/bill_runs_invoices.controller.js
+++ b/app/controllers/presroc/bill_runs_invoices.controller.js
@@ -3,8 +3,7 @@
 const {
   DeleteInvoiceService,
   FetchAndValidateBillRunInvoiceService,
-  InvoiceRebillingInitialiseService,
-  InvoiceRebillingCopyService,
+  InvoiceRebillingService,
   InvoiceRebillingValidationService,
   ViewBillRunInvoiceService
 } = require('../../services')
@@ -27,16 +26,14 @@ class BillRunsInvoicesController {
   }
 
   static async rebill (req, h) {
-    const { billRun, invoice } = req.app
+    const { billRun, invoice, notifier } = req.app
 
     // We perform validation within the controller so any errors are returned immediately
     await InvoiceRebillingValidationService.go(billRun, invoice)
-    const { cancelInvoice, rebillInvoice, response } = await InvoiceRebillingInitialiseService.go(billRun, invoice)
 
-    // We start InvoiceRebillingCopyService without await so that it runs in the background
-    InvoiceRebillingCopyService.go(invoice, cancelInvoice, rebillInvoice, req.auth.credentials.user, req.app.notifier)
+    const result = await InvoiceRebillingService.go(billRun, invoice, req.auth.credentials.user, notifier)
 
-    return h.response(response).code(201)
+    return h.response(result).code(201)
   }
 }
 

--- a/app/controllers/presroc/bill_runs_invoices.controller.js
+++ b/app/controllers/presroc/bill_runs_invoices.controller.js
@@ -31,6 +31,9 @@ class BillRunsInvoicesController {
     // We perform validation within the controller so any errors are returned immediately
     await InvoiceRebillingValidationService.go(billRun, invoice)
 
+    // We await the InvoiceRebillingService in order to generate the cancel and rebill invoice and the response back to
+    // the client system. But is also kicks off a background task to perform the actual copying of the transactions
+    // and licences from the original invoice.
     const result = await InvoiceRebillingService.go(billRun, invoice, req.auth.credentials.user, notifier)
 
     return h.response(result).code(201)

--- a/app/controllers/presroc/bill_runs_invoices.controller.js
+++ b/app/controllers/presroc/bill_runs_invoices.controller.js
@@ -4,7 +4,7 @@ const {
   DeleteInvoiceService,
   FetchAndValidateBillRunInvoiceService,
   InvoiceRebillingInitialiseService,
-  InvoiceRebillingService,
+  InvoiceRebillingCopyService,
   InvoiceRebillingValidationService,
   ViewBillRunInvoiceService
 } = require('../../services')
@@ -33,8 +33,8 @@ class BillRunsInvoicesController {
     await InvoiceRebillingValidationService.go(billRun, invoice)
     const { cancelInvoice, rebillInvoice, response } = await InvoiceRebillingInitialiseService.go(billRun, invoice)
 
-    // We start InvoiceRebillingService without await so that it runs in the background
-    InvoiceRebillingService.go(invoice, cancelInvoice, rebillInvoice, req.auth.credentials.user, req.app.notifier)
+    // We start InvoiceRebillingCopyService without await so that it runs in the background
+    InvoiceRebillingCopyService.go(invoice, cancelInvoice, rebillInvoice, req.auth.credentials.user, req.app.notifier)
 
     return h.response(response).code(201)
   }

--- a/app/services/index.js
+++ b/app/services/index.js
@@ -27,10 +27,10 @@ const GenerateBillRunService = require('./generate_bill_run.service')
 const GenerateBillRunValidationService = require('./generate_bill_run_validation.service')
 const GenerateCustomerFileService = require('./generate_customer_file.service')
 const GenerateTransactionFileService = require('./generate_transaction_file.service')
+const InvoiceRebillingCopyService = require('./invoice_rebilling_copy.service')
 const InvoiceRebillingCreateLicenceService = require('./invoice_rebilling_create_licence.service')
 const InvoiceRebillingCreateTransactionService = require('./invoice_rebilling_create_transaction.service')
 const InvoiceRebillingInitialiseService = require('./invoice_rebilling_initialise.service')
-const InvoiceRebillingService = require('./invoice_rebilling.service')
 const InvoiceRebillingValidationService = require('./invoice_rebilling_validation.service')
 const ListAuthorisedSystemsService = require('./list_authorised_systems.service')
 const ListCustomerFilesService = require('./list_customer_files.service')
@@ -93,10 +93,10 @@ module.exports = {
   GenerateBillRunValidationService,
   GenerateCustomerFileService,
   GenerateTransactionFileService,
+  InvoiceRebillingCopyService,
   InvoiceRebillingCreateLicenceService,
   InvoiceRebillingCreateTransactionService,
   InvoiceRebillingInitialiseService,
-  InvoiceRebillingService,
   InvoiceRebillingValidationService,
   ListAuthorisedSystemsService,
   ListCustomerFilesService,

--- a/app/services/index.js
+++ b/app/services/index.js
@@ -31,6 +31,7 @@ const InvoiceRebillingCopyService = require('./invoice_rebilling_copy.service')
 const InvoiceRebillingCreateLicenceService = require('./invoice_rebilling_create_licence.service')
 const InvoiceRebillingCreateTransactionService = require('./invoice_rebilling_create_transaction.service')
 const InvoiceRebillingInitialiseService = require('./invoice_rebilling_initialise.service')
+const InvoiceRebillingService = require('./invoice_rebilling.service')
 const InvoiceRebillingValidationService = require('./invoice_rebilling_validation.service')
 const ListAuthorisedSystemsService = require('./list_authorised_systems.service')
 const ListCustomerFilesService = require('./list_customer_files.service')
@@ -97,6 +98,7 @@ module.exports = {
   InvoiceRebillingCreateLicenceService,
   InvoiceRebillingCreateTransactionService,
   InvoiceRebillingInitialiseService,
+  InvoiceRebillingService,
   InvoiceRebillingValidationService,
   ListAuthorisedSystemsService,
   ListCustomerFilesService,

--- a/app/services/invoice_rebilling.service.js
+++ b/app/services/invoice_rebilling.service.js
@@ -10,6 +10,11 @@ const InvoiceRebillingCopyService = require('./invoice_rebilling_copy.service')
 
 class InvoiceRebillingService {
   /**
+   * Manages the rebilling of an invoice, including creating the 'cancel' and 'rebill' invoices, generating the response
+   * to the client system, and handling the background task to copy the details from the original invoice to the new
+   * ones.
+   *
+   * Nearly all the work is done in sub-services. We use the `InvoiceRebillingService` to marshall the whole process.
    *
    * @param {module:BillRunModel} billRun An instance of `BillRunModel` of the bill run to add the invoices to.
    * @param {module:InvoiceModel} invoice An instance of `InvoiceModel` of the invoice to be rebilled.

--- a/app/services/invoice_rebilling.service.js
+++ b/app/services/invoice_rebilling.service.js
@@ -1,0 +1,42 @@
+'use strict'
+
+/**
+ * @module InvoiceRebillingService
+ */
+
+const { InvoiceRebillingPresenter } = require('../presenters')
+const InvoiceRebillingInitialiseService = require('./invoice_rebilling_initialise.service')
+const InvoiceRebillingCopyService = require('./invoice_rebilling_copy.service')
+
+class InvoiceRebillingService {
+  /**
+   *
+   * @param {module:BillRunModel} billRun An instance of `BillRunModel` of the bill run to add the invoices to.
+   * @param {module:InvoiceModel} invoice An instance of `InvoiceModel` of the invoice to be rebilled.
+   * @param {module:AuthorisedSystemModel} authorisedSystem The authorised system making the rebilling request.
+   * @param {@module:RequestNotifierLib} notifier Instance of `RequestNotifierLib` class. We use it to log errors rather
+   * than throwing them as this service is intended to run in the background.
+   *
+   * @returns {Object} Details of the newly created 'cancel' and 'rebill' invoices
+   */
+  static async go (billRun, originalInvoice, authorisedSystem, notifier) {
+    const { cancelInvoice, rebillInvoice } = await InvoiceRebillingInitialiseService.go(billRun, originalInvoice)
+
+    try {
+      // We start InvoiceRebillingCopyService without await so that it runs in the background
+      InvoiceRebillingCopyService.go(originalInvoice, cancelInvoice, rebillInvoice, authorisedSystem)
+    } catch (error) {
+      notifier.omfg('Error rebilling invoice', { id: originalInvoice.id, error })
+    }
+
+    return this._response(cancelInvoice, rebillInvoice)
+  }
+
+  static _response (cancelInvoice, rebillInvoice) {
+    const presenter = new InvoiceRebillingPresenter([cancelInvoice, rebillInvoice])
+
+    return presenter.go()
+  }
+}
+
+module.exports = InvoiceRebillingService

--- a/app/services/invoice_rebilling_copy.service.js
+++ b/app/services/invoice_rebilling_copy.service.js
@@ -26,23 +26,17 @@ class InvoiceRebillingCopyService {
    * @param {module:InvoiceModel} cancelInvoice Instance of `InvoiceModel` for the cancelling invoice.
    * @param {module:InvoiceModel} rebillInvoice Instance of `InvoiceModel` for the rebilling invoice.
    * @param {module:AuthorisedSystemModel} authorisedSystem The authorised system making the rebilling request.
-   * @param {@module:RequestNotifierLib} notifier Instance of `RequestNotifierLib` class. We use it to log errors rather
-   * than throwing them as this service is intended to run in the background.
    */
-  static async go (invoice, cancelInvoice, rebillInvoice, authorisedSystem, notifier) {
-    try {
-      const licences = await this._licences(invoice)
+  static async go (invoice, cancelInvoice, rebillInvoice, authorisedSystem) {
+    const licences = await this._licences(invoice)
 
-      await LicenceModel.transaction(async trx => {
-        for (const licence of licences) {
-          const cancelLicence = await InvoiceRebillingCreateLicenceService.go(cancelInvoice, licence.licenceNumber, trx)
-          const rebillLicence = await InvoiceRebillingCreateLicenceService.go(rebillInvoice, licence.licenceNumber, trx)
-          await this._populateRebillingLicences(licence, cancelLicence, rebillLicence, authorisedSystem, trx)
-        }
-      })
-    } catch (error) {
-      notifier.omfg('Error rebilling invoice', { id: invoice.id, error })
-    }
+    await LicenceModel.transaction(async trx => {
+      for (const licence of licences) {
+        const cancelLicence = await InvoiceRebillingCreateLicenceService.go(cancelInvoice, licence.licenceNumber, trx)
+        const rebillLicence = await InvoiceRebillingCreateLicenceService.go(rebillInvoice, licence.licenceNumber, trx)
+        await this._populateRebillingLicences(licence, cancelLicence, rebillLicence, authorisedSystem, trx)
+      }
+    })
   }
 
   static async _populateRebillingLicences (licence, cancelLicence, rebillLicence, authorisedSystem, trx) {

--- a/app/services/invoice_rebilling_copy.service.js
+++ b/app/services/invoice_rebilling_copy.service.js
@@ -1,7 +1,7 @@
 'use strict'
 
 /**
- * @module InvoiceRebillingService
+ * @module InvoiceRebillingCopyService
  */
 
 const InvoiceRebillingCreateLicenceService = require('./invoice_rebilling_create_licence.service')
@@ -9,15 +9,18 @@ const InvoiceRebillingCreateTransactionService = require('./invoice_rebilling_cr
 
 const { LicenceModel, TransactionModel } = require('../models')
 
-class InvoiceRebillingService {
+class InvoiceRebillingCopyService {
   /**
-   * Service to rebill a given invoice onto the supplied cancel invoice and rebill invoice.
+   * Service to copy an 'original' invoice to the 'cancel' and 'rebill' invoices
    *
-   * For each licence in the invoice, it will create a corresponding licence on cancelInvoice and rebillInvoice and
-   * populate them with the transactions on the licence (flipping them from credit to debit and vice-versa as
-   * appropriate).
+   * For each licence in the `invoice`, it will create a corresponding licence on `cancelInvoice` and `rebillInvoice`
+   * and populate it with copies of the transactions from the original licence (flipping them from credit to debit and
+   * vice-versa as appropriate).
    *
-   * Note that bill run, invoice and licence tallies will be updated as part of the process.
+   * The `cancelInvoice` and `rebillInvoice` are expected to be created by the `InvoiceRebillingInitialiseService` prior
+   * to then being passed to this service.
+   *
+   * Note - The bill run, invoice and licence tallies will also be updated as part of the process.
    *
    * @param {module:InvoiceModel} invoice Instance of `InvoiceModel` for the invoice to be rebilled.
    * @param {module:InvoiceModel} cancelInvoice Instance of `InvoiceModel` for the cancelling invoice.
@@ -63,4 +66,4 @@ class InvoiceRebillingService {
   }
 }
 
-module.exports = InvoiceRebillingService
+module.exports = InvoiceRebillingCopyService

--- a/app/services/invoice_rebilling_initialise.service.js
+++ b/app/services/invoice_rebilling_initialise.service.js
@@ -5,11 +5,11 @@
  */
 
 const { InvoiceModel } = require('../models')
-const { InvoiceRebillingPresenter } = require('../presenters')
 
 class InvoiceRebillingInitialiseService {
   /**
-   * Creates two empty invoices on a given bill run for rebilling purposes: a 'cancel' invoice and a 'rebill' invoice.
+   * Creates two empty invoices on a given bill run for rebilling purposes: a 'cancel' invoice and a 'rebill' invoice
+   *
    * The cancel invoice is the invoice which will cancel out the invoice being rebilled, and the rebill invoice is the
    * one that will rebill the the customer. They can be identifed by rebillType `C` and `R` respectively. Both invoices
    * will be linked to the original invoice by rebilledInvoiceId, which contains the id of the original invoice.
@@ -17,11 +17,9 @@ class InvoiceRebillingInitialiseService {
    * @param {module:BillRunModel} billRun An instance of `BillRunModel` of the bill run to add the invoices to.
    * @param {module:InvoiceModel} invoice An instance of `InvoiceModel` of the invoice to be rebilled.
    *
-   * @returns {Object} An `object` containing `cancelInvoice`, `rebillInvoice` and `response`.
+   * @returns {Object} An `object` containing `cancelInvoice` and `rebillInvoice`.
    * @returns {module:InvoiceModel} `object.cancelInvoice` The cancel invoice.
    * @returns {module:InvoiceModel} `object.rebillInvoice` The rebill invoice.
-   * @returns {Object} `object.response` The response to be passed back from the API. This service is intended to be
-   * called from within a controller so this allows the controller to send the response directly to the caller.
    */
   static async go (billRun, invoice) {
     let cancelInvoice
@@ -32,19 +30,10 @@ class InvoiceRebillingInitialiseService {
       rebillInvoice = await this._createInvoice(billRun, invoice, 'R', trx)
     })
 
-    const response = this._response(cancelInvoice, rebillInvoice)
-
     return {
       cancelInvoice,
-      rebillInvoice,
-      response
+      rebillInvoice
     }
-  }
-
-  static _response (cancelInvoice, rebillInvoice) {
-    const presenter = new InvoiceRebillingPresenter([cancelInvoice, rebillInvoice])
-
-    return presenter.go()
   }
 
   static _createInvoice (billRun, invoice, rebilledType, trx) {

--- a/app/services/invoice_rebilling_initialise.service.js
+++ b/app/services/invoice_rebilling_initialise.service.js
@@ -26,6 +26,7 @@ class InvoiceRebillingInitialiseService {
     let rebillInvoice
 
     await InvoiceModel.transaction(async trx => {
+      await this._setBillRunStatusToPending(billRun, trx)
       cancelInvoice = await this._createInvoice(billRun, invoice, 'C', trx)
       rebillInvoice = await this._createInvoice(billRun, invoice, 'R', trx)
     })
@@ -34,6 +35,10 @@ class InvoiceRebillingInitialiseService {
       cancelInvoice,
       rebillInvoice
     }
+  }
+
+  static async _setBillRunStatusToPending (billRun, trx) {
+    await billRun.$query(trx).patch({ status: 'pending' })
   }
 
   static _createInvoice (billRun, invoice, rebilledType, trx) {

--- a/test/controllers/presroc/bill_runs_invoices.controller.test.js
+++ b/test/controllers/presroc/bill_runs_invoices.controller.test.js
@@ -29,7 +29,7 @@ const {
   DeleteInvoiceService,
   FetchAndValidateBillRunInvoiceService,
   InvoiceRebillingInitialiseService,
-  InvoiceRebillingService,
+  InvoiceRebillingCopyService,
   InvoiceRebillingValidationService
 } = require('../../../app/services')
 
@@ -241,7 +241,7 @@ describe('Presroc Invoices controller', () => {
           rebillInvoice,
           response: { msg: 'REBILL_OK' }
         })
-      rebillStub = Sinon.stub(InvoiceRebillingService, 'go')
+      rebillStub = Sinon.stub(InvoiceRebillingCopyService, 'go')
 
       response = await server.inject(options(authToken, billRun.id, invoice.id))
     })

--- a/test/controllers/presroc/bill_runs_invoices.controller.test.js
+++ b/test/controllers/presroc/bill_runs_invoices.controller.test.js
@@ -28,8 +28,7 @@ const Boom = require('@hapi/boom')
 const {
   DeleteInvoiceService,
   FetchAndValidateBillRunInvoiceService,
-  InvoiceRebillingInitialiseService,
-  InvoiceRebillingCopyService,
+  InvoiceRebillingService,
   InvoiceRebillingValidationService
 } = require('../../../app/services')
 
@@ -210,7 +209,6 @@ describe('Presroc Invoices controller', () => {
     let cancelInvoice
     let rebillInvoice
     let validationStub
-    let initialiseStub
     let rebillStub
     let response
 
@@ -231,25 +229,16 @@ describe('Presroc Invoices controller', () => {
         .returns(AuthorisationHelper.decodeToken(authToken))
       await AuthorisedSystemHelper.addAdminSystem(null, 'admin', 'active', regime)
 
-      cancelInvoice = { id: GeneralHelper.uuid4() }
-      rebillInvoice = { id: GeneralHelper.uuid4() }
+      cancelInvoice = { id: GeneralHelper.uuid4(), rebilledType: 'C' }
+      rebillInvoice = { id: GeneralHelper.uuid4(), rebilledType: 'R' }
 
       validationStub = Sinon.stub(InvoiceRebillingValidationService, 'go')
-      initialiseStub = Sinon.stub(InvoiceRebillingInitialiseService, 'go')
+      rebillStub = Sinon.stub(InvoiceRebillingService, 'go')
         .returns({
-          cancelInvoice,
-          rebillInvoice,
-          response: { msg: 'REBILL_OK' }
+          invoices: [cancelInvoice, rebillInvoice]
         })
-      rebillStub = Sinon.stub(InvoiceRebillingCopyService, 'go')
 
       response = await server.inject(options(authToken, billRun.id, invoice.id))
-    })
-
-    afterEach(async () => {
-      validationStub.restore()
-      initialiseStub.restore()
-      rebillStub.restore()
     })
 
     it('calls InvoiceRebillingValidationService with the specified bill run and invoice', async () => {
@@ -260,27 +249,19 @@ describe('Presroc Invoices controller', () => {
       expect(validationStub.getCall(0).args[1].id).to.equal(invoice.id)
     })
 
-    it('calls InvoiceRebillingInitialiseService with the specified bill run and invoice', async () => {
-      expect(initialiseStub.calledOnce).to.be.true()
-      expect(initialiseStub.getCall(0).args[0]).to.be.an.instanceof(BillRunModel)
-      expect(initialiseStub.getCall(0).args[0].id).to.equal(billRun.id)
-      expect(initialiseStub.getCall(0).args[1]).to.be.an.instanceof(InvoiceModel)
-      expect(initialiseStub.getCall(0).args[1].id).to.equal(invoice.id)
-    })
-
-    it('calls InvoiceRebillingService with the specified invoice and the initialised invoices', async () => {
+    it('calls InvoiceRebillingService with the specified bill run and invoice', async () => {
       expect(rebillStub.calledOnce).to.be.true()
-      expect(rebillStub.getCall(0).args[0]).to.be.an.instanceof(InvoiceModel)
-      expect(rebillStub.getCall(0).args[0].id).to.equal(invoice.id)
-      expect(rebillStub.getCall(0).args[1].id).to.equal(cancelInvoice.id)
-      expect(rebillStub.getCall(0).args[2].id).to.equal(rebillInvoice.id)
+      expect(rebillStub.getCall(0).args[0]).to.be.an.instanceof(BillRunModel)
+      expect(rebillStub.getCall(0).args[0].id).to.equal(billRun.id)
+      expect(rebillStub.getCall(0).args[1]).to.be.an.instanceof(InvoiceModel)
+      expect(rebillStub.getCall(0).args[1].id).to.equal(invoice.id)
     })
 
-    it('returns the expected 201 code and response from InvoiceRebillingInitialiseService', async () => {
+    it('returns the expected 201 code and response from InvoiceRebillingService', async () => {
       const responsePayload = JSON.parse(response.payload)
 
       expect(response.statusCode).to.equal(201)
-      expect(responsePayload.msg).to.equal('REBILL_OK')
+      expect(responsePayload.invoices).length(2)
     })
   })
 })

--- a/test/services/invoice_rebilling.service.test.js
+++ b/test/services/invoice_rebilling.service.test.js
@@ -1,0 +1,136 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const {
+  AuthorisedSystemHelper,
+  BillRunHelper,
+  DatabaseHelper,
+  GeneralHelper,
+  RegimeHelper,
+  InvoiceHelper
+} = require('../support/helpers')
+
+// Things we need to stub
+const { InvoiceRebillingCopyService, InvoiceRebillingInitialiseService } = require('../../app/services')
+
+// Thing under test
+const { InvoiceRebillingService } = require('../../app/services')
+
+describe('Invoice Rebilling service', () => {
+  let authorisedSystem
+  let invoice
+  let billRun
+  let notifierFake
+  let cancelInvoice
+  let rebillInvoice
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+
+    const regime = await RegimeHelper.addRegime('wrls', 'WRLS')
+    authorisedSystem = await AuthorisedSystemHelper.addSystem('1234546789', 'system1', [regime])
+
+    const billedBillRun = await BillRunHelper.addBillRun(authorisedSystem.id, regime.id, 'A', 'billed')
+    invoice = await InvoiceHelper.addInvoice(billedBillRun.id, 'CUSTOMER', '2021')
+
+    billRun = await BillRunHelper.addBillRun(authorisedSystem.id, regime.id)
+
+    // Create a fake function to stand in place of Notifier.omfg()
+    notifierFake = { omfg: Sinon.fake() }
+
+    cancelInvoice = { id: GeneralHelper.uuid4(), rebilledType: 'C' }
+    rebillInvoice = { id: GeneralHelper.uuid4(), rebilledType: 'R' }
+  })
+
+  afterEach(async () => {
+    Sinon.restore()
+  })
+
+  describe('When rebilling is successful', () => {
+    let initialiseStub
+
+    beforeEach(async () => {
+      initialiseStub = Sinon.stub(InvoiceRebillingInitialiseService, 'go')
+        .returns({ cancelInvoice, rebillInvoice })
+
+      Sinon.stub(InvoiceRebillingCopyService, 'go')
+    })
+
+    it("creates the new 'cancel' and 'rebill' invoices by calling 'InvoiceRebillingInitialiseService'", async () => {
+      const result = await InvoiceRebillingService.go(billRun, invoice, authorisedSystem, notifierFake)
+
+      const returnedCancelObject = result.invoices.find(element => element.rebilledType === 'C')
+      const returnedRebillObject = result.invoices.find(element => element.rebilledType === 'R')
+
+      expect(initialiseStub.calledOnce).to.be.true()
+      expect(returnedCancelObject.id).to.equal(cancelInvoice.id)
+      expect(returnedRebillObject.id).to.equal(rebillInvoice.id)
+    })
+
+    it('returns a response containing the id and type of the rebilled invoices', async () => {
+      const result = await InvoiceRebillingService.go(billRun, invoice, authorisedSystem, notifierFake)
+
+      const returnedCancelObject = result.invoices.find(element => element.rebilledType === 'C')
+      const returnedRebillObject = result.invoices.find(element => element.rebilledType === 'R')
+
+      expect(returnedCancelObject.id).to.equal(cancelInvoice.id)
+      expect(returnedCancelObject.rebilledType).to.equal(cancelInvoice.rebilledType)
+
+      expect(returnedRebillObject.id).to.equal(rebillInvoice.id)
+      expect(returnedRebillObject.rebilledType).to.equal(rebillInvoice.rebilledType)
+    })
+  })
+
+  describe('If an error occurs', () => {
+    describe('when initialising the rebilling invoices', () => {
+      beforeEach(async () => {
+        Sinon.stub(InvoiceRebillingInitialiseService, 'go').throws()
+      })
+
+      it('does not call the notifier', async () => {
+        await expect(
+          InvoiceRebillingService.go(billRun, invoice, authorisedSystem, notifierFake)
+        ).to.reject()
+
+        expect(notifierFake.omfg.callCount).to.equal(0)
+      })
+
+      it('does not return a result', async () => {
+        const err = await expect(
+          InvoiceRebillingService.go(billRun, invoice, authorisedSystem, notifierFake)
+        ).to.reject()
+
+        expect(err).to.be.an.error()
+      })
+    })
+
+    describe('when copying the invoice', () => {
+      beforeEach(async () => {
+        Sinon.stub(InvoiceRebillingInitialiseService, 'go')
+          .returns({ cancelInvoice, rebillInvoice })
+        Sinon.stub(InvoiceRebillingCopyService, 'go').throws()
+      })
+
+      it('calls the notifier', async () => {
+        await InvoiceRebillingService.go(billRun, invoice, authorisedSystem, notifierFake)
+
+        expect(notifierFake.omfg.callCount).to.equal(1)
+        expect(notifierFake.omfg.firstArg).to.equal('Error rebilling invoice')
+      })
+
+      it('still returns a response for the client system', async () => {
+        const result = await InvoiceRebillingService.go(billRun, invoice, authorisedSystem, notifierFake)
+
+        expect(result.invoices).length(2)
+      })
+    })
+  })
+})

--- a/test/services/invoice_rebilling_copy.service.test.js
+++ b/test/services/invoice_rebilling_copy.service.test.js
@@ -22,9 +22,9 @@ const {
 const { LicenceModel, TransactionModel } = require('../../app/models')
 
 // Thing under test
-const { InvoiceRebillingService } = require('../../app/services')
+const { InvoiceRebillingCopyService } = require('../../app/services')
 
-describe('Invoice Rebilling service', () => {
+describe('Invoice Rebilling Copy service', () => {
   let currentBillRun
   let newBillRun
   let authorisedSystem
@@ -56,7 +56,7 @@ describe('Invoice Rebilling service', () => {
       cancelInvoice = await addRebillInvoice(newBillRun.id, 'CUSTOMER_REFERENCE', 2020, invoice.id, 'C')
       rebillInvoice = await addRebillInvoice(newBillRun.id, 'CUSTOMER_REFERENCE', 2020, invoice.id, 'R')
 
-      await InvoiceRebillingService.go(invoice, cancelInvoice, rebillInvoice, authorisedSystem, notifierFake)
+      await InvoiceRebillingCopyService.go(invoice, cancelInvoice, rebillInvoice, authorisedSystem, notifierFake)
     })
 
     describe('cancel licences', () => {
@@ -116,8 +116,8 @@ describe('Invoice Rebilling service', () => {
 
   describe('When an error occurs', () => {
     it('calls the notifier', async () => {
-      Sinon.stub(InvoiceRebillingService, '_licences').throws()
-      await InvoiceRebillingService.go(
+      Sinon.stub(InvoiceRebillingCopyService, '_licences').throws()
+      await InvoiceRebillingCopyService.go(
         { id: GeneralHelper.uuid4() }, cancelInvoice, rebillInvoice, authorisedSystem, notifierFake
       )
 

--- a/test/services/invoice_rebilling_initialise.service.test.js
+++ b/test/services/invoice_rebilling_initialise.service.test.js
@@ -41,14 +41,4 @@ describe('Invoice Rebilling Initialise service', () => {
     expect(result.cancelInvoice.minimumChargeInvoice).to.equal(invoice.minimumChargeInvoice)
     expect(result.rebillInvoice.minimumChargeInvoice).to.equal(invoice.minimumChargeInvoice)
   })
-
-  it("returns a 'response' object containing the id and type of the invoices", async () => {
-    const result = await InvoiceRebillingInitialiseService.go(billRun, invoice)
-
-    const returnedCancelObject = result.response.invoices.find(element => element.rebilledType === 'C')
-    const returnedRebillObject = result.response.invoices.find(element => element.rebilledType === 'R')
-
-    expect(result.cancelInvoice.id).to.equal(returnedCancelObject.id)
-    expect(result.rebillInvoice.id).to.equal(returnedRebillObject.id)
-  })
 })

--- a/test/services/invoice_rebilling_initialise.service.test.js
+++ b/test/services/invoice_rebilling_initialise.service.test.js
@@ -41,4 +41,11 @@ describe('Invoice Rebilling Initialise service', () => {
     expect(result.cancelInvoice.minimumChargeInvoice).to.equal(invoice.minimumChargeInvoice)
     expect(result.rebillInvoice.minimumChargeInvoice).to.equal(invoice.minimumChargeInvoice)
   })
+
+  it("sets the bill run status to 'pending'", async () => {
+    await InvoiceRebillingInitialiseService.go(billRun, invoice)
+    const refreshedBillRun = await billRun.$query()
+
+    expect(refreshedBillRun.status).to.equal('pending')
+  })
 })


### PR DESCRIPTION
https://trello.com/c/A91YBKNC

As part of adding the fix to [protect bill run when rebilling](https://github.com/DEFRA/sroc-charging-module-api/pull/461) we've realised we need to do more work in the controller.

Specifically, we need to manage the status of the bill run, setting it to `pending` when the process starts and resetting it afterwards. We're already doing more than we would typically do in a controller handler for rebilling. So, it's time to do a spot of refactoring.

The first step involves updating `InvoiceRebillingService` to manage more of the process by moving the `InvoiceRebillingInitialiseService` into it. As part of that, we want to move what it currently does into its own service. `InvoiceRebillingService` can then become responsible for managing the process and in a future change, dealing with the status of the bill run.