### PR TITLE
Fix broken Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,11 +4,11 @@
 !config
 !db
 !entrypoint.sh
+!index.js
 !keys
 !knexfile.application.js
 !knexfile.js
 !package-lock.json
 !package.json
-!server.js
 !test/support/**
 !tmp/.keep

--- a/.dockerignore
+++ b/.dockerignore
@@ -11,4 +11,3 @@
 !package-lock.json
 !package.json
 !test/support/**
-!tmp/.keep


### PR DESCRIPTION
In [PR #467](https://github.com/DEFRA/sroc-charging-module-api/pull/467) the key change was to remove hpal-debug support. Our previous design for the `server.js` and it being the 'startup' file was directed by us trying to enable support for hpal-debug.

With it being dropped we also took the opportunity to update the project to more closely match the examples and documentation Hapi provides. We are going for the principle of least surprise for new devs to the team.

What we forgot to do was update our Docker ignore file to reflect the change in files, which then broke the Docker image if you tried to run it.

This fixes the issue.