### PR TITLE
Fix - Rebilling for same customer causes error

### DIFF
--- a/app/models/invoice.model.js
+++ b/app/models/invoice.model.js
@@ -8,6 +8,10 @@ const { Model } = require('objection')
 const BaseUpsertModel = require('./base_upsert.model')
 
 const DEMINIMIS_LIMIT = 500
+// This is the value used for new invoices. Reason? To allow us to accept multiple rebill invoices with the same
+// customer reference and financial year in the same bill run. It ensures the invoices table constraint works for new
+// invoices, but when we rebill and actually have a rebill ID, the constraint doesn't trigger.
+// Note - it has to be a valid UUID so we wanted a value that was clearly set rather than generated.
 const REBILL_ID_PLACEHOLDER = '99999999-9999-9999-9999-999999999999'
 
 class InvoiceModel extends BaseUpsertModel {
@@ -121,7 +125,9 @@ class InvoiceModel extends BaseUpsertModel {
   /**
    * Returns an object that contains the minimum (base) properties and values needed when inserting a new invoice
    *
-   * If rebilledType is passed through in the transaction then we use it; otherwise, we set it to 'O'
+   * If `rebilledType` is passed through in the transaction then we use it; otherwise, we set it to 'O'. If
+   * `rebilledInvoiceId` is passed through we also use it. Else we set it to `REBILL_ID_PLACEHOLDER` (currently
+   * 99999999-9999-9999-9999-999999999999).
    *
    * See `BaseUpsertModel._baseOnInsertObject()` for more details
    *

--- a/app/models/invoice.model.js
+++ b/app/models/invoice.model.js
@@ -134,7 +134,8 @@ class InvoiceModel extends BaseUpsertModel {
       billRunId: transaction.billRunId,
       customerReference: transaction.customerReference,
       financialYear: transaction.chargeFinancialYear,
-      rebilledType: transaction.rebilledType ?? 'O'
+      rebilledType: transaction.rebilledType ?? 'O',
+      rebilledInvoiceId: transaction.rebilledInvoiceId ?? transaction.billRunId
     }
   }
 
@@ -144,7 +145,7 @@ class InvoiceModel extends BaseUpsertModel {
    * @returns {string[]} an array of the constraint field names
    */
   static _onConflictContraints () {
-    return ['bill_run_id', 'customer_reference', 'financial_year', 'rebilled_type']
+    return ['bill_run_id', 'customer_reference', 'financial_year', 'rebilled_type', 'rebilled_invoice_id']
   }
 
   /**

--- a/app/models/invoice.model.js
+++ b/app/models/invoice.model.js
@@ -8,6 +8,7 @@ const { Model } = require('objection')
 const BaseUpsertModel = require('./base_upsert.model')
 
 const DEMINIMIS_LIMIT = 500
+const REBILL_ID_PLACEHOLDER = '99999999-9999-9999-9999-999999999999'
 
 class InvoiceModel extends BaseUpsertModel {
   static get tableName () {
@@ -135,7 +136,7 @@ class InvoiceModel extends BaseUpsertModel {
       customerReference: transaction.customerReference,
       financialYear: transaction.chargeFinancialYear,
       rebilledType: transaction.rebilledType ?? 'O',
-      rebilledInvoiceId: transaction.rebilledInvoiceId ?? transaction.billRunId
+      rebilledInvoiceId: transaction.rebilledInvoiceId ?? REBILL_ID_PLACEHOLDER
     }
   }
 

--- a/app/services/invoice_rebilling_copy.service.js
+++ b/app/services/invoice_rebilling_copy.service.js
@@ -34,17 +34,17 @@ class InvoiceRebillingCopyService {
       for (const licence of licences) {
         const cancelLicence = await InvoiceRebillingCreateLicenceService.go(cancelInvoice, licence.licenceNumber, trx)
         const rebillLicence = await InvoiceRebillingCreateLicenceService.go(rebillInvoice, licence.licenceNumber, trx)
-        await this._populateRebillingLicences(licence, cancelLicence, rebillLicence, authorisedSystem, trx)
+        await this._populateRebillingLicences(invoice, licence, cancelLicence, rebillLicence, authorisedSystem, trx)
       }
     })
   }
 
-  static async _populateRebillingLicences (licence, cancelLicence, rebillLicence, authorisedSystem, trx) {
+  static async _populateRebillingLicences (invoice, licence, cancelLicence, rebillLicence, authorisedSystem, trx) {
     const transactions = await this._transactions(licence, trx)
 
     for (const transaction of transactions) {
-      await InvoiceRebillingCreateTransactionService.go(transaction, rebillLicence, authorisedSystem, trx)
-      await InvoiceRebillingCreateTransactionService.go(transaction, cancelLicence, authorisedSystem, trx, true)
+      await InvoiceRebillingCreateTransactionService.go(transaction, rebillLicence, invoice, authorisedSystem, trx)
+      await InvoiceRebillingCreateTransactionService.go(transaction, cancelLicence, invoice, authorisedSystem, trx, true)
     }
   }
 

--- a/app/services/invoice_rebilling_create_transaction.service.js
+++ b/app/services/invoice_rebilling_create_transaction.service.js
@@ -20,11 +20,11 @@ class InvoiceRebillingCreateTransactionService {
    * @param {Boolean} [invert] Whether the transaction type should be inverted.
    * @returns {module:TransactionModel} The newly-created transaction.
    */
-  static async go (transaction, licence, authorisedSystem, trx = null, invert = false) {
+  static async go (transaction, licence, rebilledInvoice, authorisedSystem, trx = null, invert = false) {
     const preparedTransaction = await this._prepareTransaction(transaction, licence, authorisedSystem, invert)
     const rebilledType = this._rebilledType(invert)
 
-    return this._create(preparedTransaction, rebilledType, trx)
+    return this._create(preparedTransaction, rebilledType, rebilledInvoice.id, trx)
   }
 
   /**
@@ -63,9 +63,9 @@ class InvoiceRebillingCreateTransactionService {
   /**
    * Creates a record in the db for the provided transaction and returns it
    */
-  static async _create (transaction, rebilledType, trx) {
+  static async _create (transaction, rebilledType, rebilledInvoiceId, trx) {
     await BillRunModel.patchTally(transaction, trx)
-    await InvoiceModel.updateTally({ ...transaction, rebilledType }, trx)
+    await InvoiceModel.updateTally({ ...transaction, rebilledType, rebilledInvoiceId }, trx)
     await LicenceModel.updateTally(transaction, trx)
 
     const newTransaction = await transaction.$query(trx)

--- a/app/services/invoice_rebilling_create_transaction.service.js
+++ b/app/services/invoice_rebilling_create_transaction.service.js
@@ -14,6 +14,7 @@ class InvoiceRebillingCreateTransactionService {
    *
    * @param {module:TransactionModel} transaction The transaction to be duplicated.
    * @param {module:LicenceModel} licence The licence the transaction should be created on.
+   * @param {module:InvoiceModel} rebilledInvoice The rebill invoice the transaction was copied from.
    * @param {module:AuthorisedSystemModel} authorisedSystem The authorised system making the rebilling request (which
    * will therefore be set as the authorised system for the transaction).
    * @param {Object} [trx] Optional DB transaction this is being performed as part of.
@@ -65,6 +66,8 @@ class InvoiceRebillingCreateTransactionService {
    */
   static async _create (transaction, rebilledType, rebilledInvoiceId, trx) {
     await BillRunModel.patchTally(transaction, trx)
+    // rebilledType and rebilledInvoiceId are fields on the invoice not the transaction which is why we add them
+    // dynamically when calling `InvoiceModel.updateTally()`
     await InvoiceModel.updateTally({ ...transaction, rebilledType, rebilledInvoiceId }, trx)
     await LicenceModel.updateTally(transaction, trx)
 

--- a/db/migrations/20210706135346_alter_invoices.js
+++ b/db/migrations/20210706135346_alter_invoices.js
@@ -22,6 +22,12 @@ const tableName = 'invoices'
  * rather than the DB (as a column default).
  */
 exports.up = async function (knex) {
+  // Update any existing invoice records with our placeholder value so they will behave and have the same data as any
+  // new invoices we create
+  await knex('invoices')
+    .where({ rebilled_type: 'O' })
+    .update({ rebilled_invoice_id: '99999999-9999-9999-9999-999999999999' })
+
   await knex
     .schema
     .alterTable(tableName, table => {
@@ -37,4 +43,9 @@ exports.down = async function (knex) {
       table.dropUnique(['bill_run_id', 'customer_reference', 'financial_year', 'rebilled_type', 'rebilled_invoice_id'])
       table.unique(['bill_run_id', 'customer_reference', 'financial_year', 'rebilled_type'])
     })
+
+  // Reset all the rebilled_invoice_id fields to null
+  await knex('invoices')
+    .where({ rebilled_type: 'O' })
+    .update({ rebilled_invoice_id: null })
 }

--- a/db/migrations/20210706135346_alter_invoices.js
+++ b/db/migrations/20210706135346_alter_invoices.js
@@ -1,0 +1,21 @@
+'use strict'
+
+const tableName = 'invoices'
+
+exports.up = async function (knex) {
+  await knex
+    .schema
+    .alterTable(tableName, table => {
+      table.dropUnique(['bill_run_id', 'customer_reference', 'financial_year', 'rebilled_type'])
+      table.unique(['bill_run_id', 'customer_reference', 'financial_year', 'rebilled_type', 'rebilled_invoice_id'])
+    })
+}
+
+exports.down = async function (knex) {
+  await knex
+    .schema
+    .alterTable(tableName, table => {
+      table.dropUnique(['bill_run_id', 'customer_reference', 'financial_year', 'rebilled_type', 'rebilled_invoice_id'])
+      table.unique(['bill_run_id', 'customer_reference', 'financial_year', 'rebilled_type'])
+    })
+}

--- a/db/migrations/20210706135346_alter_invoices.js
+++ b/db/migrations/20210706135346_alter_invoices.js
@@ -2,6 +2,25 @@
 
 const tableName = 'invoices'
 
+/**
+ * Added to allow multiple invoices with the same customer reference and financial year to be rebilled within the same
+ * bill run.
+ *
+ * Scenario: Customer T12345 gets invoiced twice in 2020 on 2 separate bill runs (so 2 different invoices). Both went to
+ * the wrong address so they need to be rebilled on a new, 3rd bill run.
+ *
+ * Prior to this change a unique constraint error would be thrown because we'd be attempting to add two invoices with
+ * the same rebill type, customer ref., financial year and bill run ID. Adding `rebilled_invoice_id` to the constraint
+ * means the DB no longer sees them as a duplicate.
+ *
+ * For reference because it's relevant, this is an issue for new (rebill type 'O') invoices. We have no rebill invoice
+ * ID to set. If we leave the field `null` it breaks the constraint in a different way, in that it creates a new invoice
+ * for _every_ transaction added. We rely on the constraint firing in this scenario so that our 'ON CONFLICT' query
+ * triggers and the existing invoice is updated (see the Tally services and functions).
+ *
+ * So, for new invoices the value defaults to '99999999-9999-9999-9999-999999999999'. This is done in the invoice model
+ * rather than the DB (as a column default).
+ */
 exports.up = async function (knex) {
   await knex
     .schema

--- a/test/services/invoice_rebilling_create_transaction.service.test.js
+++ b/test/services/invoice_rebilling_create_transaction.service.test.js
@@ -68,6 +68,26 @@ describe('Invoice Rebilling Create Transaction service', () => {
     })
   })
 
+  describe('when the transaction has a matching customer ref. and financial year to an existing rebill invoice', () => {
+    beforeEach(async () => {
+      await addRebillInvoice(rebillBillRun.id, 'TH230000222', 2021, GeneralHelper.uuid4(), 'R')
+      const invoice = await addRebillInvoice(rebillBillRun.id, 'TH230000222', 2021, originalInvoice.id, 'R')
+      const licence = await LicenceHelper.addLicence(rebillBillRun.id, 'TONY/TF9222/37', invoice.id)
+      transaction = await TransactionHelper.addTransaction(originalBillRun.id, { chargeFinancialYear: 2021 })
+
+      result = await InvoiceRebillingCreateTransactionService.go(
+        transaction,
+        licence,
+        originalInvoice,
+        rebillAuthorisedSystem
+      )
+    })
+
+    it('still can create the new rebilling transaction (the DB unique constraint does not block it)', () => {
+      expect(result.id).to.exist()
+    })
+  })
+
   describe('when the transaction type is not to be inverted', () => {
     let licence
 

--- a/test/services/invoice_rebilling_initialise.service.test.js
+++ b/test/services/invoice_rebilling_initialise.service.test.js
@@ -49,4 +49,22 @@ describe('Invoice Rebilling Initialise service', () => {
 
     expect(refreshedBillRun.status).to.equal('pending')
   })
+
+  describe('when a second invoice for the same customer ref, and financial year is being rebilled', () => {
+    let secondOriginalInvoice
+    beforeEach(async () => {
+      // Initialised the first rebilling invoices
+      await InvoiceRebillingInitialiseService.go(rebillBillRun, originalInvoice)
+
+      const secondOriginalBillRun = await BillRunHelper.addBillRun(GeneralHelper.uuid4(), GeneralHelper.uuid4())
+      secondOriginalInvoice = await InvoiceHelper.addInvoice(secondOriginalBillRun.id, 'CUSTOMER', '2021')
+    })
+
+    it('still creates two new invoices linked to the bill run for the second invoice', async () => {
+      const result = await InvoiceRebillingInitialiseService.go(rebillBillRun, secondOriginalInvoice)
+
+      expect(result.cancelInvoice.billRunId).to.equal(rebillBillRun.id)
+      expect(result.rebillInvoice.billRunId).to.equal(rebillBillRun.id)
+    })
+  })
 })

--- a/test/services/invoice_rebilling_initialise.service.test.js
+++ b/test/services/invoice_rebilling_initialise.service.test.js
@@ -14,37 +14,38 @@ const { BillRunHelper, DatabaseHelper, GeneralHelper, InvoiceHelper } = require(
 const { InvoiceRebillingInitialiseService } = require('../../app/services')
 
 describe('Invoice Rebilling Initialise service', () => {
-  let billRun
-  let invoice
+  let originalInvoice
+  let rebillBillRun
 
   beforeEach(async () => {
     await DatabaseHelper.clean()
-    billRun = await BillRunHelper.addBillRun(GeneralHelper.uuid4(), GeneralHelper.uuid4())
-    invoice = await InvoiceHelper.addInvoice(billRun.id, 'CUSTOMER', '2021')
+    const originalBillRun = await BillRunHelper.addBillRun(GeneralHelper.uuid4(), GeneralHelper.uuid4())
+    originalInvoice = await InvoiceHelper.addInvoice(originalBillRun.id, 'CUSTOMER', '2021')
+    rebillBillRun = await BillRunHelper.addBillRun(GeneralHelper.uuid4(), GeneralHelper.uuid4())
   })
 
   it('creates two new invoices linked to the bill run', async () => {
-    const result = await InvoiceRebillingInitialiseService.go(billRun, invoice)
+    const result = await InvoiceRebillingInitialiseService.go(rebillBillRun, originalInvoice)
 
-    expect(result.cancelInvoice.billRunId).to.equal(billRun.id)
-    expect(result.rebillInvoice.billRunId).to.equal(billRun.id)
+    expect(result.cancelInvoice.billRunId).to.equal(rebillBillRun.id)
+    expect(result.rebillInvoice.billRunId).to.equal(rebillBillRun.id)
   })
 
   it('creates two new invoices with the same flags as the original', async () => {
-    const result = await InvoiceRebillingInitialiseService.go(billRun, invoice)
+    const result = await InvoiceRebillingInitialiseService.go(rebillBillRun, originalInvoice)
 
     // deminimisInvoice
-    expect(result.cancelInvoice.deminimisInvoice).to.equal(invoice.deminimisInvoice)
-    expect(result.rebillInvoice.deminimisInvoice).to.equal(invoice.deminimisInvoice)
+    expect(result.cancelInvoice.deminimisInvoice).to.equal(originalInvoice.deminimisInvoice)
+    expect(result.rebillInvoice.deminimisInvoice).to.equal(originalInvoice.deminimisInvoice)
 
     // minimumChargeInvoice
-    expect(result.cancelInvoice.minimumChargeInvoice).to.equal(invoice.minimumChargeInvoice)
-    expect(result.rebillInvoice.minimumChargeInvoice).to.equal(invoice.minimumChargeInvoice)
+    expect(result.cancelInvoice.minimumChargeInvoice).to.equal(originalInvoice.minimumChargeInvoice)
+    expect(result.rebillInvoice.minimumChargeInvoice).to.equal(originalInvoice.minimumChargeInvoice)
   })
 
   it("sets the bill run status to 'pending'", async () => {
-    await InvoiceRebillingInitialiseService.go(billRun, invoice)
-    const refreshedBillRun = await billRun.$query()
+    await InvoiceRebillingInitialiseService.go(rebillBillRun, originalInvoice)
+    const refreshedBillRun = await rebillBillRun.$query()
 
     expect(refreshedBillRun.status).to.equal('pending')
   })

--- a/test/support/helpers/invoice.helper.js
+++ b/test/support/helpers/invoice.helper.js
@@ -37,7 +37,7 @@ class InvoiceHelper {
     subjectToMinimumChargeCount = 0,
     subjectToMinimumChargeCreditValue = 0,
     subjectToMinimumChargeDebitValue = 0,
-    rebilledInvoiceId = undefined,
+    rebilledInvoiceId = '99999999-9999-9999-9999-999999999999',
     rebilledType = undefined
   ) {
     const flags = this._flags(


### PR DESCRIPTION
CMEA-64 https://eaflood.atlassian.net/browse/CMEA-64

During testing we encountered an issue we had not anticipated. If you attempt to rebill multiple invoices that happen to be for the same customer and financial year you get a DB conflict error.
    
```json
{
  "statusCode": 409,
  "error": "Conflict",
  "message": "UniqueViolationError - Key (bill_run_id, customer_reference, financial_year, rebilled_type)= (5e969d83-8f32-483f-b90b-601bdece7d37, T1234567890A, 2020, C) already exists."
}
```

The problem is the constraint we use on the `invoices` table. This is actually at the core of the logic we use when transactions are added, to determine when a new invoice record needs creating or an existing one needs adding too. When adding transactions we always attempt to add a new invoice and rely on PostgreSQL's `ON CONFLICT` functionality to tell us actually we just need to update the details of an existing invoice.

In [Create rebilling initialise service](https://github.com/DEFRA/sroc-charging-module-api/pull/395) we tweaked the constraint to take account of invoice type. This is what allows us to have 3 invoices for the same customer and financial year; as long as the types are all different. But what if a customer, who was invoiced on 2 separate bill runs, needs both rebilled in the next bill run? This could happen but our constraint is not written to handle it.

This fix updates the constraint to allow us to handle the scenario, whilst ensuring we don't affect existing behaviour.

Steps to reproduce
    
- Use `T1234567890A` and financial year `2020` for all transactions
- Create and complete bill run having added some transactions
  - Grab the Invoice ID for rebilling later
- Create and complete another bill run having added some more transactions
  - Grab the Invoice ID for rebilling later
- Create a new bill run
  - request to rebill the first invoice ID grabbed
  - request to rebill the second invoice ID grabbed (this request will error)
