### PR TITLE
Create table body presenter

### DIFF
--- a/app/presenters/index.js
+++ b/app/presenters/index.js
@@ -11,6 +11,7 @@ const CustomerFileTailPresenter = require('./customer_file_tail.presenter')
 const JsonPresenter = require('./json.presenter')
 const InvoiceRebillingPresenter = require('./invoice_rebilling.presenter')
 const RulesServicePresenter = require('./rules_service.presenter')
+const TableBodyPresenter = require('./table_body.presenter')
 const TransactionFileBodyPresenter = require('./transaction_file_body.presenter')
 const TransactionFileHeadPresenter = require('./transaction_file_head.presenter')
 const TransactionFileTailPresenter = require('./transaction_file_tail.presenter')
@@ -32,6 +33,7 @@ module.exports = {
   InvoiceRebillingPresenter,
   JsonPresenter,
   RulesServicePresenter,
+  TableBodyPresenter,
   TransactionFileBodyPresenter,
   TransactionFileHeadPresenter,
   TransactionFileTailPresenter,

--- a/app/presenters/table_body.presenter.js
+++ b/app/presenters/table_body.presenter.js
@@ -1,0 +1,45 @@
+'use strict'
+
+/**
+ * @module TableBodyPresenter
+ */
+
+const BasePresenter = require('./base.presenter')
+
+/**
+ * Formats data for the body of an exported table file.
+ *
+ * Takes a data object in the format:
+ *  { first: 'A', second: 'B', third: 'C' }
+ * and returns an object in the format:
+ *  { col01: 'A', col02: 'B', col03: 'C' }
+ */
+class TableBodyPresenter extends BasePresenter {
+  _presentation (data) {
+    return this._columnNamedData(data)
+  }
+
+  _columnNamedData (data) {
+    const returnData = {}
+    let colNumber = 1
+
+    // Iterate over the items in the data object and map eah one to an incrementingly-named key eg. col01, col02, col03
+    for (const column in data) {
+      const returnColumnName = this._formatKey(colNumber)
+      returnData[returnColumnName] = data[column]
+      colNumber += 1
+    }
+
+    return returnData
+  }
+
+  /**
+   * Accepts a column number eg. 4 and returns a string in the format `col04` ie. zero-padded to 2 digits
+   */
+  _formatKey (col) {
+    const paddedNumber = col.toString().padStart(2, '0')
+    return `col${paddedNumber}`
+  }
+}
+
+module.exports = TableBodyPresenter

--- a/test/presenters/table_body.presenter.test.js
+++ b/test/presenters/table_body.presenter.test.js
@@ -12,7 +12,7 @@ const { PresenterHelper } = require('../support/helpers')
 // Thing under test
 const { TableBodyPresenter } = require('../../app/presenters')
 
-describe.only('Table Body Presenter', () => {
+describe('Table Body Presenter', () => {
   const data = {
     firstColumn: 'FIRST_COLUMN',
     secondColumn: 'SECOND_COLUMN',

--- a/test/presenters/table_body.presenter.test.js
+++ b/test/presenters/table_body.presenter.test.js
@@ -1,0 +1,43 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it } = exports.lab = Lab.script()
+const { expect } = Code
+
+const { PresenterHelper } = require('../support/helpers')
+
+// Thing under test
+const { TableBodyPresenter } = require('../../app/presenters')
+
+describe.only('Table Body Presenter', () => {
+  const data = {
+    firstColumn: 'FIRST_COLUMN',
+    secondColumn: 'SECOND_COLUMN',
+    thirdColumn: 'THIRD_COLUMN',
+    fourthColumn: 'FOURTH_COLUMN',
+    fifthColumn: 'FIFTH_COLUMN'
+  }
+
+  it('returns the required columns', () => {
+    const presenter = new TableBodyPresenter(data)
+    const result = presenter.go()
+
+    const expectedFields = PresenterHelper.generateNumberedColumns(5)
+
+    expect(result).to.only.include(expectedFields)
+  })
+
+  it('returns the correct values for each field', () => {
+    const presenter = new TableBodyPresenter(data)
+    const result = presenter.go()
+
+    expect(result.col01).to.equal(data.firstColumn)
+    expect(result.col02).to.equal(data.secondColumn)
+    expect(result.col03).to.equal(data.thirdColumn)
+    expect(result.col04).to.equal(data.fourthColumn)
+    expect(result.col05).to.equal(data.fifthColumn)
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/projects/CMEA/boards/907?selectedIssue=CMEA-1

Similar to how we generate transaction and customer files, we will be piping the contents of a db table row by row through a presenter which formats the row into sequentially-numbered columns, and then through a presenter which formats the row as CSV, and finally the row will be piped into a file.

We start developing this process by creating the table body presenter. Note that we may end up reusing this for the table head; if we do then we will rename the presenter accordingly.