### PR TITLE
Create TransformTableToFile service

### DIFF
--- a/app/presenters/index.js
+++ b/app/presenters/index.js
@@ -11,7 +11,7 @@ const CustomerFileTailPresenter = require('./customer_file_tail.presenter')
 const JsonPresenter = require('./json.presenter')
 const InvoiceRebillingPresenter = require('./invoice_rebilling.presenter')
 const RulesServicePresenter = require('./rules_service.presenter')
-const TableBodyPresenter = require('./table_body.presenter')
+const TableFilePresenter = require('./table_file.presenter')
 const TransactionFileBodyPresenter = require('./transaction_file_body.presenter')
 const TransactionFileHeadPresenter = require('./transaction_file_head.presenter')
 const TransactionFileTailPresenter = require('./transaction_file_tail.presenter')
@@ -33,7 +33,7 @@ module.exports = {
   InvoiceRebillingPresenter,
   JsonPresenter,
   RulesServicePresenter,
-  TableBodyPresenter,
+  TableFilePresenter,
   TransactionFileBodyPresenter,
   TransactionFileHeadPresenter,
   TransactionFileTailPresenter,

--- a/app/presenters/table_file.presenter.js
+++ b/app/presenters/table_file.presenter.js
@@ -1,20 +1,20 @@
 'use strict'
 
 /**
- * @module TableBodyPresenter
+ * @module TableFilePresenter
  */
 
 const BasePresenter = require('./base.presenter')
 
 /**
- * Formats data for the body of an exported table file.
+ * Formats data for an exported table file.
  *
  * Takes a data object in the format:
  *  { first: 'A', second: 'B', third: 'C' }
  * and returns an object in the format:
  *  { col01: 'A', col02: 'B', col03: 'C' }
  */
-class TableBodyPresenter extends BasePresenter {
+class TableFilePresenter extends BasePresenter {
   _presentation (data) {
     return this._columnNamedData(data)
   }
@@ -42,4 +42,4 @@ class TableBodyPresenter extends BasePresenter {
   }
 }
 
-module.exports = TableBodyPresenter
+module.exports = TableFilePresenter

--- a/app/services/index.js
+++ b/app/services/index.js
@@ -61,6 +61,7 @@ const StreamTransformCSVService = require('./streams/stream_transform_csv.servic
 const StreamTransformUsingPresenterService = require('./streams/stream_transform_using_presenter.service')
 const StreamWritableFileService = require('./streams/stream_writable_file.service')
 const TransformRecordsToFileService = require('./transform_records_to_file.service')
+const TransformTableToFileService = require('./transform_table_to_file.service')
 const UpdateAuthorisedSystemService = require('./update_authorised_system.service')
 const ValidateBillRunLicenceService = require('./validate_bill_run_licence.service')
 const ViewBillRunInvoiceService = require('./view_bill_run_invoice.service')
@@ -128,6 +129,7 @@ module.exports = {
   StreamTransformUsingPresenterService,
   StreamWritableFileService,
   TransformRecordsToFileService,
+  TransformTableToFileService,
   UpdateAuthorisedSystemService,
   ValidateBillRunLicenceService,
   ViewBillRunInvoiceService,

--- a/app/services/streams/stream_transform_using_presenter.service.js
+++ b/app/services/streams/stream_transform_using_presenter.service.js
@@ -15,34 +15,42 @@ const { Transform } = require('stream')
  * transform the data, then an array is created from the resulting values, ensuring the values are first sorted in
  * alphabetical order of key, on the basis that the presenter will have its items named 'col01', 'col02' etc.
  *
- * While we should in theory receive the data from the presenter in the correct order, we sort it to ensure this is
- * the case as the order we store the data in the array is critical to producing the resulting file correctly.
+ * While we should in theory receive the data from the presenter in the correct order, we sort it to ensure this is the
+ * case as the order we store the data in the array is critical to producing the resulting file correctly.
  *
- * We are also able to pass an object containing additional data which will be added to each record before it's
- * passed to the presenter. For example, the bill run's file reference is required for each row of a transaction file
- * but this isn't present in the transaction records we pull from the db. We therefore pass it in when writing these
- * records so that it's available to us.
+ * We are also able to pass an object containing additional data which will be added to each record before it's passed
+ * to the presenter. For example, the bill run's file reference is required for each row of a transaction file but this
+ * isn't present in the transaction records we pull from the db. We therefore pass it in when writing these records so
+ * that it's available to us.
  *
  * To ensure that rows in a file are numbered correctly, we optionally accept indexStart which is the number that the
  * index will start at. Say for example we have written the header and body of a file, with the rows numbered 1-19. When
  * this service is called to write the tail, an indexStart value of 20 will be passed in, ensuring that the tail row has
- * the correct number 20.
+ * the correct number 20. Not all files require the index number; therefore, the index will only be passed to the
+ * presenter if it is specified when calling this service. This avoids situations where the presenter acts on all the
+ * data it receives where passing in the index number would cause it to be acted on unnecessarily; eg if exporting an
+ * entire db table, the index would be added to the end of each row which would not be desired.
  *
  * @param {module:Presenter} Presenter Presenter to be used to transform data.
  * @param {object} [additionalData] Optional data object which will be combined with the incoming data before being
  * transformed.
  * @param {integer} [indexStart] The start value for the index. Used to ensure that we use the correct consecutive
- * numbering for each row of the data file. Defaults to 0.
+ * numbering for each row of the data file. If not specified then the index will not be added.
  * @returns {TransformStream} A stream of data.
  */
 class StreamTransformUsingPresenterService {
-  static go (Presenter, additionalData = {}, indexStart = 0) {
+  static go (Presenter, additionalData = {}, indexStart = null) {
     let index = indexStart
 
     return new Transform({
       objectMode: true,
       transform: function (currentRow, _encoding, callback) {
-        const presenter = new Presenter({ ...currentRow, ...additionalData, index })
+        const presenter = new Presenter({
+          ...currentRow,
+          ...additionalData,
+          // Include index only if indexStart was specified
+          ...(indexStart !== null) && { index }
+        })
         const dataObject = presenter.go()
 
         // Object.keys() gives us an array of keys in the object. We then sort it, and use map to create a new array by
@@ -52,7 +60,9 @@ class StreamTransformUsingPresenterService {
           .sort()
           .map(key => dataObject[key])
 
-        index++
+        if (indexStart !== null) {
+          index++
+        }
 
         callback(null, sortedArray)
       }

--- a/app/services/transform_table_to_file.service.js
+++ b/app/services/transform_table_to_file.service.js
@@ -9,7 +9,7 @@ const { pipeline } = require('stream')
 const util = require('util')
 const { temporaryFilePath } = require('../../config/server.config')
 
-const { TableBodyPresenter } = require('../presenters')
+const { TableFilePresenter } = require('../presenters')
 
 const StreamReadableDataService = require('./streams/stream_readable_data.service')
 const StreamReadableRecordsService = require('./streams/stream_readable_records.service')
@@ -24,10 +24,9 @@ class TransformTableToFileService {
    *
    * The file comprises 2 parts:
    *
-   * The bulk of the file is comprised of the body. Each line of the body is a database record selected by the passed-in
-   * query.
-   *
    * The head is a single line at the top. It takes its data from the columnNames array.
+   *
+   * The body comprises the rest of the file. Each line is a database record selected by the passed-in query.
    *
    * @param {module:QueryBuilder} query The Objection query which will be run and the results passed to `bodyPresenter`
    * @param {array} columnNames The names of the columns to be saved to in the head row.
@@ -37,8 +36,8 @@ class TransformTableToFileService {
   static async go (query, columnNames, filename) {
     const filenameWithPath = this._filenameWithPath(filename)
 
-    await this._writeHead(columnNames, TableBodyPresenter, filenameWithPath)
-    await this._writeBody(query, TableBodyPresenter, filenameWithPath)
+    await this._writeHead(columnNames, TableFilePresenter, filenameWithPath)
+    await this._writeBody(query, TableFilePresenter, filenameWithPath)
 
     return filenameWithPath
   }

--- a/app/services/transform_table_to_file.service.js
+++ b/app/services/transform_table_to_file.service.js
@@ -1,0 +1,139 @@
+'use strict'
+
+/**
+ * @module TransformTableToFileService
+ */
+
+const path = require('path')
+const { pipeline } = require('stream')
+const util = require('util')
+const { temporaryFilePath } = require('../../config/server.config')
+
+const { TableBodyPresenter } = require('../presenters')
+
+const StreamReadableDataService = require('./streams/stream_readable_data.service')
+const StreamReadableRecordsService = require('./streams/stream_readable_records.service')
+const StreamTransformCSVService = require('./streams/stream_transform_csv.service')
+const StreamTransformUsingPresenterService = require('./streams/stream_transform_using_presenter.service')
+const StreamWritableFileService = require('./streams/stream_writable_file.service')
+
+class TransformTableToFileService {
+  /**
+   * Takes an Objection QueryBuilder object and passes its results through the provided presenters in order to generate
+   * a file.
+   *
+   * The file comprises 2 parts:
+   *
+   * The bulk of the file is comprised of the body. Each line of the body is a database record selected by the passed-in
+   * query.
+   *
+   * The head is a single line at the top. It takes its data from the columnNames array.
+   *
+   * @param {module:QueryBuilder} query The Objection query which will be run and the results passed to `bodyPresenter`
+   * @param {array} columnNames The names of the columns to be saved to in the head row.
+   * @param {string} filename The filename to be saved to
+   * @returns {string} The full path and filename of the generated file
+   */
+  static async go (query, columnNames, filename) {
+    const filenameWithPath = this._filenameWithPath(filename)
+
+    await this._writeHead(columnNames, TableBodyPresenter, filenameWithPath)
+    await this._writeBody(query, TableBodyPresenter, filenameWithPath)
+
+    return filenameWithPath
+  }
+
+  static _filenameWithPath (name) {
+    // We use path.normalize to remove any double forward slashes that occur when assembling the path
+    return path.normalize(
+      path.format({
+        dir: temporaryFilePath,
+        name
+      })
+    )
+  }
+
+  /**
+   * Transforms a stream of data and writes it to a file in CSV format. Intended to be used to write a "section" of a
+   * file, ie. head, body or tail.
+   *
+   * @param {ReadableStream} inputStream The stream of data to be written.
+   * @param {module:Presenter} presenter The presenter to use to transform the data.
+   * @param {string} filenameWithPath The filename and path to be written to.
+   * @param {boolean} append Whether data should be appended to the file.
+   * @param {object} additionalData Any additional data to be added to the presenter
+   * @returns {integer} The number of records written.
+   */
+  static async _writeSection (inputStream, presenter, filenameWithPath, append, additionalData) {
+    const promisifiedPipeline = this._promisifiedPipeline()
+
+    await promisifiedPipeline(
+      inputStream,
+      this._presenterTransformStream(presenter, additionalData),
+      this._csvTransformStream(),
+      this._writeToFileStream(filenameWithPath, append)
+    )
+  }
+
+  /**
+   * Write the file head, passing the supplied data to the supplied presenter. Overwrites the content of the file if
+   * it exists.
+   */
+  static async _writeHead (data, presenter, filenameWithPath) {
+    await this._writeSection(this._dataStream(data), presenter, filenameWithPath, false, null)
+  }
+
+  /**
+   * Write the file body, using the supplied query to read records from the database and passing them to the supplied
+   * presenter, along with additionalData. Appends the data if the file already exists, or creates it if not.
+   */
+  static async _writeBody (query, presenter, filenameWithPath, additionalData) {
+    await this._writeSection(this._recordStream(query), presenter, filenameWithPath, true, { ...additionalData })
+  }
+
+  /**
+   * Wrap stream.pipeline in a promise so we can easily 'await' it.
+   */
+  static _promisifiedPipeline () {
+    return util.promisify(pipeline)
+  }
+
+  /**
+   * Readable stream which simply outputs the data passed to it.
+   */
+  static _dataStream (data) {
+    return StreamReadableDataService.go(data)
+  }
+
+  /**
+   * Readble stream which outputs the records returned by the passed-in Objection QueryBuilder object.
+   */
+  static _recordStream (query) {
+    return StreamReadableRecordsService.go(query)
+  }
+
+  /**
+   * Transform stream which processes an object supplied to it using the supplied Presenter, and optionally combining
+   * each chunk of data it receives with additionalData, which allows us to eg. use bill run-level data when handling
+   * transaction records.
+   */
+  static _presenterTransformStream (Presenter, additionalData, lineCount) {
+    return StreamTransformUsingPresenterService.go(Presenter, additionalData, lineCount)
+  }
+
+  /**
+   * Transform stream which returns a comma-separated row of data, terminating in a newline.
+   */
+  static _csvTransformStream () {
+    return StreamTransformCSVService.go()
+  }
+
+  /**
+   * Writable stream that writes to a given file.
+   */
+  static _writeToFileStream (filenameWithPath, append) {
+    return StreamWritableFileService.go(filenameWithPath, append)
+  }
+}
+
+module.exports = TransformTableToFileService

--- a/test/presenters/table_file.presenter.test.js
+++ b/test/presenters/table_file.presenter.test.js
@@ -10,7 +10,7 @@ const { expect } = Code
 const { PresenterHelper } = require('../support/helpers')
 
 // Thing under test
-const { TableBodyPresenter } = require('../../app/presenters')
+const { TableFilePresenter } = require('../../app/presenters')
 
 describe('Table Body Presenter', () => {
   const data = {
@@ -22,7 +22,7 @@ describe('Table Body Presenter', () => {
   }
 
   it('returns the required columns', () => {
-    const presenter = new TableBodyPresenter(data)
+    const presenter = new TableFilePresenter(data)
     const result = presenter.go()
 
     const expectedFields = PresenterHelper.generateNumberedColumns(5)
@@ -31,7 +31,7 @@ describe('Table Body Presenter', () => {
   })
 
   it('returns the correct values for each field', () => {
-    const presenter = new TableBodyPresenter(data)
+    const presenter = new TableFilePresenter(data)
     const result = presenter.go()
 
     expect(result.col01).to.equal(data.firstColumn)

--- a/test/services/streams/stream_transform_using_presenter.service.test.js
+++ b/test/services/streams/stream_transform_using_presenter.service.test.js
@@ -64,15 +64,8 @@ describe('Stream Transform CSV service', () => {
       expect(result[3]).to.equal('EXTRA')
     })
 
-    it('passes in the index starting at 0', async () => {
-      const transformStream = StreamTransformUsingPresenterService.go(testPresenter)
-      const [result] = await StreamHelper.testTransformStream(transformStream, testData)
-
-      expect(result[4]).to.equal(0)
-    })
-
     it('increments the index', async () => {
-      const transformStream = StreamTransformUsingPresenterService.go(testPresenter)
+      const transformStream = StreamTransformUsingPresenterService.go(testPresenter, null, 0)
       const resultArray = await StreamHelper.testTransformStream(transformStream, testData, 3)
 
       expect(resultArray[0][4]).to.equal(0)
@@ -87,6 +80,15 @@ describe('Stream Transform CSV service', () => {
       expect(resultArray[0][4]).to.equal(10)
       expect(resultArray[1][4]).to.equal(11)
       expect(resultArray[2][4]).to.equal(12)
+    })
+
+    it('does not include the index if no value is passed', async () => {
+      const transformStream = StreamTransformUsingPresenterService.go(testPresenter)
+      const resultArray = await StreamHelper.testTransformStream(transformStream, testData, 3)
+
+      expect(resultArray[0][4]).to.be.undefined()
+      expect(resultArray[1][4]).to.be.undefined()
+      expect(resultArray[2][4]).to.be.undefined()
     })
   })
 })

--- a/test/services/transform_table_to_file.service.test.js
+++ b/test/services/transform_table_to_file.service.test.js
@@ -1,0 +1,85 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { afterEach, beforeEach, describe, it } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const {
+  BillRunHelper,
+  DatabaseHelper,
+  GeneralHelper,
+  TransactionHelper
+} = require('../support/helpers')
+
+const { TransactionModel } = require('../../app/models')
+
+const fs = require('fs')
+const path = require('path')
+
+const { temporaryFilePath } = require('../../config/server.config')
+
+// Thing under test
+const { TransformTableToFileService } = require('../../app/services')
+
+describe('Transform Table To File service', () => {
+  let billRun
+  let transaction
+
+  const filename = 'test.dat'
+
+  // We use path.normalize to remove any double forward slashes that occur when assembling the path
+  const filenameWithPath = path.normalize(path.format({ dir: temporaryFilePath, name: filename }))
+
+  const columnNames = ['COL_A', 'COL_B', 'COL_C']
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+
+    billRun = await BillRunHelper.addBillRun(GeneralHelper.uuid4(), GeneralHelper.uuid4())
+    billRun.fileReference = filename
+
+    transaction = await TransactionHelper.addTransaction(billRun.id)
+  })
+
+  afterEach(async () => {
+    Sinon.restore()
+  })
+
+  describe.only('When writing a file succeeds', () => {
+    it('creates a file with expected content', async () => {
+      const query = TransactionModel.query().select('id', 'region', 'customerReference')
+
+      await TransformTableToFileService.go(
+        query,
+        columnNames,
+        filename
+      )
+
+      const expectedResult = [
+        '"COL_A","COL_B","COL_C"\n',
+        `"${transaction.id}","${transaction.region}","${transaction.customerReference}"\n`
+      ].join('')
+
+      const file = await fs.readFileSync(filenameWithPath, 'utf-8')
+
+      expect(file).to.equal(expectedResult)
+    })
+
+    it('returns the filename and path', async () => {
+      const query = TransactionModel.query().select('id', 'region', 'customerReference')
+
+      const returnedFilenameWithPath = await TransformTableToFileService.go(
+        query,
+        columnNames,
+        filename
+      )
+
+      expect(returnedFilenameWithPath).to.equal(filenameWithPath)
+    })
+  })
+})

--- a/test/services/transform_table_to_file.service.test.js
+++ b/test/services/transform_table_to_file.service.test.js
@@ -50,7 +50,7 @@ describe('Transform Table To File service', () => {
     Sinon.restore()
   })
 
-  describe.only('When writing a file succeeds', () => {
+  describe('When writing a file succeeds', () => {
     it('creates a file with expected content', async () => {
       const query = TransactionModel.query().select('id', 'region', 'customerReference')
 


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/projects/CMEA/boards/907?selectedIssue=CMEA-1

We want to take a database table and pipe its contents to a CSV file. We have [a presenter which will format the body of the table](https://github.com/DEFRA/sroc-charging-module-api/pull/476); the next stage is to create the service which will use this to transform a query into a CSV file.

This change introduces `TransformTableToFileService`, which adapts the existing `TransformRecordsToFileService`. We will later be looking at refactoring in order to share common functions; but for now we have this as an entirely separate service.

We make a small change to `StreamTransformUsingPresenterService` to allow us to reuse it here -- it does everything we need except it also adds in the index number needed for producing customer and transaction files. This has the effect of adding the index value to our output CSV (as the table file presenter simply passes on all the data it receives). We therefore modify `StreamTransformUsingPresenterService` so that if no starting index value is passed to it, the index is not added to the output.