### PR TITLE
Create table export service

### DIFF
--- a/app/services/export_table.service.js
+++ b/app/services/export_table.service.js
@@ -1,0 +1,53 @@
+'use strict'
+
+/**
+ * @module ExportTableService
+ */
+
+const TransformTableToFileService = require('./transform_table_to_file.service')
+
+const { db } = require('../../db')
+
+class ExportTableService {
+  /**
+   * Writes the content of a database table to a file in CSV format.
+   *
+   * We use `TransformRecordsToFileService` to do this, passing in the following parameters:
+   * - A knex QueryBuilder object which will select everything in the table when the query is executed;
+   * - The column names, obtained using the knex columnInfo() method;
+   * - The filename, which is the table name with `.dat` appended.
+   *
+   * `TransformTableToFileService` returns the path and filename of the exported file, which we pass back to the service
+   * that called us.
+   *
+   * @param {string} table The name of the table to be exported
+   * @returns {string} The full path and filename of the exported file
+   */
+  static async go (table) {
+    return TransformTableToFileService.go(
+      this._query(table),
+      await this._columnNames(table),
+      this._filename(table)
+    )
+  }
+
+  static _query (table) {
+    return db
+      .from(table)
+      .select('*')
+  }
+
+  static async _columnNames (table) {
+    const columnInfo = await db
+      .from(table)
+      .columnInfo()
+
+    return Object.keys(columnInfo)
+  }
+
+  static _filename (table) {
+    return `${table}.dat`
+  }
+}
+
+module.exports = ExportTableService

--- a/app/services/index.js
+++ b/app/services/index.js
@@ -21,6 +21,7 @@ const DeleteBillRunService = require('./delete_bill_run.service')
 const DeleteFileService = require('./delete_file.service')
 const DeleteInvoiceService = require('./delete_invoice.service')
 const DeleteLicenceService = require('./delete_licence.service')
+const ExportTableService = require('./export_table.service')
 const FetchAndValidateBillRunInvoiceService = require('./fetch_and_validate_bill_run_invoice.service')
 const FilterRoutesService = require('./plugins/filter_routes.service')
 const GenerateBillRunService = require('./generate_bill_run.service')
@@ -89,6 +90,7 @@ module.exports = {
   DeleteFileService,
   DeleteInvoiceService,
   DeleteLicenceService,
+  ExportTableService,
   FetchAndValidateBillRunInvoiceService,
   FilterRoutesService,
   GenerateBillRunService,

--- a/test/services/export_table.service.test.js
+++ b/test/services/export_table.service.test.js
@@ -1,0 +1,101 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { afterEach, beforeEach, describe, it } = exports.lab = Lab.script()
+const { expect } = Code
+
+const fs = require('fs')
+const path = require('path')
+
+// Test helpers
+const { DatabaseHelper, RegimeHelper } = require('../support/helpers')
+
+const { temporaryFilePath } = require('../../config/server.config')
+
+const { CreateCustomerDetailsService } = require('../../app/services')
+
+const { CustomerFileModel, CustomerModel } = require('../../app/models')
+
+// Thing under test
+const { ExportTableService } = require('../../app/services')
+
+describe('Export Table service', () => {
+  const table = 'customers'
+  const filename = table.concat('.dat')
+  const filenameWithPath = path.join(temporaryFilePath, filename)
+
+  let regime
+  let customer
+  let customerRecord
+
+  const payload = {
+    region: 'A',
+    customerReference: 'AB12345678',
+    customerName: 'CUSTOMER_NAME',
+    addressLine1: 'ADDRESS_LINE_1',
+    addressLine2: 'ADDRESS_LINE_2',
+    addressLine3: 'ADDRESS_LINE_3',
+    addressLine4: 'ADDRESS_LINE_4',
+    addressLine5: 'ADDRESS_LINE_5',
+    addressLine6: 'ADDRESS_LINE_6',
+    postcode: 'POSTCODE'
+  }
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+
+    regime = await RegimeHelper.addRegime('wrls', 'WRLS')
+    customer = await CreateCustomerDetailsService.go(payload, regime)
+
+    // We insert a customer file record so that customerFileId is set
+    const { id: customerFileId } = await CustomerFileModel.query().insert({
+      regimeId: regime.id,
+      region: payload.region,
+      fileReference: table
+    })
+    await customer.$query().patch({ customerFileId })
+
+    // We separately pull out the customer record so we can compare the exported file against the exact db contents
+    // including the createdAt and updatedAt fields
+    customerRecord = await CustomerModel.query().findById(customer.id)
+  })
+
+  afterEach(async () => {
+    Sinon.restore()
+  })
+
+  it('creates a file with the correct content', async () => {
+    const returnedFilenameWithPath = await ExportTableService.go(table)
+
+    const file = fs.readFileSync(returnedFilenameWithPath, 'utf-8')
+    const expectedContent = _expectedContent()
+
+    expect(file).to.equal(expectedContent)
+  })
+
+  it('returns the filename and path', async () => {
+    const returnedFilenameWithPath = await ExportTableService.go('customers')
+
+    expect(returnedFilenameWithPath).to.equal(filenameWithPath)
+  })
+
+  function _expectedContent () {
+    // The head line of the file is comprised of the customerRecord object keys in CSV form
+    const head = _contentLine(Object.keys(customerRecord))
+
+    // The body line of the file is comprised of the customerRecord object values in CSV form
+    const body = _contentLine(Object.values(customerRecord))
+
+    return head.concat(body)
+  }
+
+  function _contentLine (contentArray) {
+    return contentArray.map(item => `"${item}"`)
+      .join(',')
+      .concat('\n')
+  }
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/projects/CMEA/boards/907?selectedIssue=CMEA-1

We have `TransformTableToFileService` which can output a table to a file; we now need a service which accepts a table name and generates the required parameters (selecting query, column names, and output filename) which it then uses to call `TransformTableToFileService`.

A note on testing: it creates a customer change along with a customer file (so the customer change record can be populated with the file id) then exports the table and compares the customer change db record to the exported file. I would have preferred to completely mock the db calls to control exactly what data is fed to `TransformTableToFileService` but ran into difficulties with this. This therefore may be something to revisit in future.