### PR TITLE
Include licence no. for min. charge in trans file

### DIFF
--- a/app/presenters/transaction_file_body.presenter.js
+++ b/app/presenters/transaction_file_body.presenter.js
@@ -44,7 +44,7 @@ class TransactionFileBodyPresenter extends BasePresenter {
       col23: data.lineDescription,
       col24: 'A',
       col25: '',
-      col26: this._blankIfCompensationChargeOrMinimumCharge(data.lineAttr1, data),
+      col26: this._blankIfCompensationCharge(data.lineAttr1, data),
       col27: this._blankIfCompensationChargeOrMinimumCharge(data.lineAttr2, data),
       col28: this._blankIfCompensationChargeOrMinimumCharge(data.lineAttr3, data),
       col29: this._blankIfCompensationChargeOrMinimumCharge(data.lineAttr4, data),
@@ -80,6 +80,13 @@ class TransactionFileBodyPresenter extends BasePresenter {
     // We don't expect to store anything other than lower case but we change case just to be safe. We use optional
     // chaining as regimeValue17 is null for minimum charge transactions.
     return data.regimeValue17?.toLowerCase() === 'true'
+  }
+
+  /**
+   * Returns an empty string if this is a compensation charge
+   */
+  _blankIfCompensationCharge (value, data) {
+    return this._compensationCharge(data) ? '' : value
   }
 
   /**

--- a/test/presenters/transaction_file_body.presenter.test.js
+++ b/test/presenters/transaction_file_body.presenter.test.js
@@ -174,7 +174,7 @@ describe('Transaction File Body Presenter', () => {
 
     const result = presenter.go()
 
-    expect(result.col26).to.equal('')
+    expect(result.col26).to.equal(data.lineAttr1)
     expect(result.col27).to.equal('')
     expect(result.col28).to.equal('')
     expect(result.col29).to.equal('')


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/CMEA-12

The WRLS team on behalf of their users have told us that licence no. needs to be included in the transaction file we generate. This is so that the customer can work out how the minimum charge was calculated for each individual licence on an invoice.

Prior to this change, there was a requirement to not include licence no. if the transaction was subject to minimum charge or a compensation charge. This change updates the logic to ensures it's only blank when the transaction is a compensation charge.