### PR TITLE
Reject requests with inverted quotation marks

### DIFF
--- a/app/plugins/invalid_characters.plugin.js
+++ b/app/plugins/invalid_characters.plugin.js
@@ -11,7 +11,7 @@ const Boom = require('@hapi/boom')
 const invalidCharacters = obj => {
   const jsonObj = JSON.stringify(obj)
 
-  if (jsonObj.match(/[?£\u2014\u2264\u2265]/)) {
+  if (jsonObj.match(/[?£\u2014\u2264\u2265\u201C\u201D]/)) {
     return true
   }
 

--- a/app/plugins/invalid_characters.plugin.js
+++ b/app/plugins/invalid_characters.plugin.js
@@ -3,9 +3,18 @@
 const Boom = require('@hapi/boom')
 
 /**
- * Converts an object to a JSON string and then tests if it contains any of the following characters: ? £ ≤ ≥
+ * Converts an object to a JSON string and then tests if it contains any of the following characters:
+ *
+ * - {@link https://unicode-table.com/en/00A3| £ Pound Sign}
+ * - {@link https://unicode-table.com/en/003F| ? Question Mark}
+ * - {@link https://unicode-table.com/en/2014| — Em dash}
+ * - {@link https://unicode-table.com/en/2264| ≤ Less-Than or Equal To}
+ * - {@link https://unicode-table.com/en/2265| ≥ Greater-Than or Equal To}
+ * - {@link https://unicode-table.com/en/201C| “ Left Double Quotation Mark}
+ * - {@link https://unicode-table.com/en/201D| ” Right Double Quotation Mark}
  *
  * @param {Object} obj The object you wish to check for invalid characters
+ *
  * @returns {boolean} `true` if the object contains an invalid character, else `false`
  */
 const invalidCharacters = obj => {
@@ -27,7 +36,7 @@ const InvalidCharactersPlugin = {
       }
 
       if (invalidCharacters(request.payload)) {
-        throw Boom.badData('We cannot accept any request that contains the following characters: ? £ ≤ ≥ “ ”')
+        throw Boom.badData('We cannot accept any request that contains the following characters: ? £ — ≤ ≥ “ ”')
       }
 
       return h.continue

--- a/app/plugins/invalid_characters.plugin.js
+++ b/app/plugins/invalid_characters.plugin.js
@@ -27,7 +27,7 @@ const InvalidCharactersPlugin = {
       }
 
       if (invalidCharacters(request.payload)) {
-        throw Boom.badData('We cannot accept any request that contains the following characters: ? £ ≤ ≥')
+        throw Boom.badData('We cannot accept any request that contains the following characters: ? £ ≤ ≥ “ ”')
       }
 
       return h.continue

--- a/test/features/invalid_characters.test.js
+++ b/test/features/invalid_characters.test.js
@@ -55,7 +55,7 @@ describe('Reject requests with invalid characters', () => {
         const responsePayload = JSON.parse(response.payload)
 
         expect(response.statusCode).to.equal(422)
-        expect(responsePayload.message).to.equal('We cannot accept any request that contains the following characters: ? £ ≤ ≥')
+        expect(responsePayload.message).to.equal('We cannot accept any request that contains the following characters: ? £ ≤ ≥ “ ”')
       })
     })
 
@@ -70,7 +70,7 @@ describe('Reject requests with invalid characters', () => {
         const responsePayload = JSON.parse(response.payload)
 
         expect(response.statusCode).to.equal(422)
-        expect(responsePayload.message).to.equal('We cannot accept any request that contains the following characters: ? £ ≤ ≥')
+        expect(responsePayload.message).to.equal('We cannot accept any request that contains the following characters: ? £ ≤ ≥ “ ”')
       })
     })
   })

--- a/test/features/invalid_characters.test.js
+++ b/test/features/invalid_characters.test.js
@@ -44,17 +44,34 @@ describe('Reject requests with invalid characters', () => {
   })
 
   describe('When a payload does include an invalid character', () => {
-    it('rejects the request with the appropriate error message', async () => {
-      const requestPayload = {
-        reference: 'BESESAME001',
-        customerName: 'Bert & Ernie Ltd?'
-      }
+    describe('for example a question mark', () => {
+      it('rejects the request with the appropriate error message', async () => {
+        const requestPayload = {
+          reference: 'BESESAME001',
+          customerName: 'Bert & Ernie Ltd?'
+        }
 
-      const response = await server.inject(options(requestPayload))
-      const responsePayload = JSON.parse(response.payload)
+        const response = await server.inject(options(requestPayload))
+        const responsePayload = JSON.parse(response.payload)
 
-      expect(response.statusCode).to.equal(422)
-      expect(responsePayload.message).to.equal('We cannot accept any request that contains the following characters: ? £ ≤ ≥')
+        expect(response.statusCode).to.equal(422)
+        expect(responsePayload.message).to.equal('We cannot accept any request that contains the following characters: ? £ ≤ ≥')
+      })
+    })
+
+    describe('for example a double (inverted) quotation mark', () => {
+      it('rejects the request with the appropriate error message', async () => {
+        const requestPayload = {
+          reference: 'BESESAME001',
+          customerName: 'Bert & “Ernie” Ltd'
+        }
+
+        const response = await server.inject(options(requestPayload))
+        const responsePayload = JSON.parse(response.payload)
+
+        expect(response.statusCode).to.equal(422)
+        expect(responsePayload.message).to.equal('We cannot accept any request that contains the following characters: ? £ ≤ ≥')
+      })
     })
   })
 })

--- a/test/features/invalid_characters.test.js
+++ b/test/features/invalid_characters.test.js
@@ -55,7 +55,9 @@ describe('Reject requests with invalid characters', () => {
         const responsePayload = JSON.parse(response.payload)
 
         expect(response.statusCode).to.equal(422)
-        expect(responsePayload.message).to.equal('We cannot accept any request that contains the following characters: ? £ ≤ ≥ “ ”')
+        expect(responsePayload.message)
+          .to
+          .equal('We cannot accept any request that contains the following characters: ? £ — ≤ ≥ “ ”')
       })
     })
 
@@ -70,7 +72,9 @@ describe('Reject requests with invalid characters', () => {
         const responsePayload = JSON.parse(response.payload)
 
         expect(response.statusCode).to.equal(422)
-        expect(responsePayload.message).to.equal('We cannot accept any request that contains the following characters: ? £ ≤ ≥ “ ”')
+        expect(responsePayload.message)
+          .to
+          .equal('We cannot accept any request that contains the following characters: ? £ — ≤ ≥ “ ”')
       })
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/CMEA-11

During initial business acceptance testing of the WRLS system and its integration with the CM API found a transaction file that was rejected by SOP.

This was tracked down to the line description containing 'inverted quotation marks'. It wasn't possible to get an exact example. But based on the description (and Google!) we have interpreted this as

- **“** [Left Double Quotation Mark](https://unicode-table.com/en/201C/) `U+201C`
- **”** [Right Double Quotation Mark](https://unicode-table.com/en/201D/) `U+201D`

This change adds these to our `InvalidCharactersPlugin` which will mean any `POST` request that contains them anywhere in its content will be rejected.