### PR TITLE
Remove invalid min. charge model tests

### DIFF
--- a/test/models/invoice.model.test.js
+++ b/test/models/invoice.model.test.js
@@ -308,5 +308,13 @@ describe('Invoice Model', () => {
 
       expect(result).to.be.true()
     })
+
+    it('returns `false` if this is not a minimum charge invoice', async () => {
+      const invoice = await InvoiceHelper.addInvoice(billRun.id, 'MIN0000001', 2020, 0, 0, 1, 2499, 0, 0, 0, 0)
+
+      const result = invoice.$minimumChargeInvoice()
+
+      expect(result).to.be.false()
+    })
   })
 })

--- a/test/models/invoice.model.test.js
+++ b/test/models/invoice.model.test.js
@@ -308,25 +308,5 @@ describe('Invoice Model', () => {
 
       expect(result).to.be.true()
     })
-
-    describe('returns `false` if this is not a deminimis invoice', () => {
-      it('because the value is above the deminimis limit', async () => {
-        const invoice = await InvoiceHelper.addInvoice(billRun.id, 'NMN0000001', 2021, 0, 0, 1, 5000)
-
-        const result = invoice.$deminimisInvoice()
-
-        expect(result).to.be.false()
-      })
-
-      it('because rebilledType is not `O`', async () => {
-        const invoice = await InvoiceHelper.addInvoice(
-          billRun.id, 'DEM0000001', 2021, 1, 750, 1, 1000, 0, 0, 0, 0, GeneralHelper.uuid4(), 'R'
-        )
-
-        const result = invoice.$deminimisInvoice()
-
-        expect(result).to.be.false()
-      })
-    })
   })
 })


### PR DESCRIPTION
Whilst working on another PR we spotted a couple of tests for the invoice model which are invalid/irrelevant. We think they are just the result of a copy and paste that never got cleaned up.

This change removes them.