### PR TITLE
Test helpers cascade changes upwards

### DIFF
--- a/test/controllers/presroc/bill_runs_invoices.controller.test.js
+++ b/test/controllers/presroc/bill_runs_invoices.controller.test.js
@@ -48,7 +48,7 @@ describe('Presroc Invoices controller', () => {
     const regime = await RegimeHelper.addRegime('wrls', 'WRLS')
     await AuthorisedSystemHelper.addSystem('clientId', 'system1', [regime])
 
-    invoice = await NewInvoiceHelper.add()
+    invoice = await NewInvoiceHelper.create()
   })
 
   afterEach(async () => {
@@ -151,7 +151,7 @@ describe('Presroc Invoices controller', () => {
 
     describe('When the request is valid', () => {
       it('returns success status 200', async () => {
-        const transaction = await NewTransactionHelper.add()
+        const transaction = await NewTransactionHelper.create()
 
         const response = await server.inject(options(authToken, transaction.billRunId, transaction.invoiceId))
         const responsePayload = JSON.parse(response.payload)
@@ -178,7 +178,7 @@ describe('Presroc Invoices controller', () => {
 
       describe('because it is not linked to the bill run', () => {
         it('throws an error', async () => {
-          const newTransaction = await NewTransactionHelper.add()
+          const newTransaction = await NewTransactionHelper.create()
 
           const response = await server.inject(options(authToken, invoice.billRunId, newTransaction.invoiceId))
           const responsePayload = JSON.parse(response.payload)

--- a/test/services/validate_bill_run_licence.service.test.js
+++ b/test/services/validate_bill_run_licence.service.test.js
@@ -32,7 +32,7 @@ describe('Validate Bill Run Licence service', () => {
 
   describe('When a valid bill run ID is supplied', () => {
     beforeEach(async () => {
-      licence = await NewLicenceHelper.add()
+      licence = await NewLicenceHelper.create()
       billRun = await BillRunModel.query().findById(licence.billRunId)
     })
 
@@ -49,7 +49,7 @@ describe('Validate Bill Run Licence service', () => {
         let otherBillRun
 
         beforeEach(async () => {
-          otherBillRun = await NewBillRunHelper.add()
+          otherBillRun = await NewBillRunHelper.create()
         })
 
         it('throws an error', async () => {
@@ -66,11 +66,11 @@ describe('Validate Bill Run Licence service', () => {
         let rebillingLicence
 
         beforeEach(async () => {
-          invoice = await NewInvoiceHelper.add(billRun, {
+          invoice = await NewInvoiceHelper.create(billRun, {
             rebilledInvoiceId: GeneralHelper.uuid4(),
             rebilledType: 'R'
           })
-          rebillingLicence = await NewLicenceHelper.add(invoice)
+          rebillingLicence = await NewLicenceHelper.create(invoice)
         })
 
         it('throws an error', async () => {

--- a/test/support/helpers/new_bill_run.helper.js
+++ b/test/support/helpers/new_bill_run.helper.js
@@ -18,7 +18,7 @@ class NewBillRunHelper {
    *
    * @returns {module:BillRunModel} The newly created instance of `BillRunModel`.
    */
-  static async add (authorisedSystemId, regimeId, overrides = {}) {
+  static async create (authorisedSystemId, regimeId, overrides = {}) {
     let regime
 
     if (!regimeId) {

--- a/test/support/helpers/new_bill_run.helper.js
+++ b/test/support/helpers/new_bill_run.helper.js
@@ -49,6 +49,26 @@ class NewBillRunHelper {
   }
 
   /**
+   * Updates a bill run
+   *
+   * @param {module:BillRunModel} billRun The bill run to be updated.
+   * @param {object} updates JSON object of values to be updated. Each value in the object will be added to the existing
+   *  value in the bill run.
+   *
+   * @returns {module:BillRunModel} The newly updated instance of `BillRunModel`.
+   */
+  static async update (billRun, updates = {}) {
+    const patch = {}
+
+    for (const key in updates) {
+      patch[key] = billRun[key] + updates[key]
+    }
+
+    return billRun.$query()
+      .patchAndFetch(patch)
+  }
+
+  /**
    * Mock generate a bill run
    *
    * We do not _actually_ generate a bill run with this helper. We simply update the bill run record to reflect what a

--- a/test/support/helpers/new_bill_run.helper.js
+++ b/test/support/helpers/new_bill_run.helper.js
@@ -53,7 +53,7 @@ class NewBillRunHelper {
    *
    * @param {module:BillRunModel} billRun The bill run to be updated.
    * @param {object} updates JSON object of values to be updated. Each value in the object will be added to the existing
-   *  value in the bill run.
+   *  value in the bill run if it is a number; if it isn't a number then the existing value will be replaced.
    *
    * @returns {module:BillRunModel} The newly updated instance of `BillRunModel`.
    */
@@ -61,7 +61,12 @@ class NewBillRunHelper {
     const patch = {}
 
     for (const key in updates) {
-      patch[key] = billRun[key] + updates[key]
+      // If the value is a number then we add it to the existing number; otherwise we replace the existing value
+      if (typeof updates[key] === 'number') {
+        patch[key] = billRun[key] + updates[key]
+      } else {
+        patch[key] = updates[key]
+      }
     }
 
     return billRun.$query()

--- a/test/support/helpers/new_invoice.helper.js
+++ b/test/support/helpers/new_invoice.helper.js
@@ -14,9 +14,9 @@ class NewInvoiceHelper {
    *
    * @returns {module:InvoiceModel} The newly created instance of `InvoiceModel`.
    */
-  static async add (billRun, overrides = {}) {
+  static async create (billRun, overrides = {}) {
     if (!billRun) {
-      billRun = await NewBillRunHelper.add()
+      billRun = await NewBillRunHelper.create()
     }
 
     const invoiceValues = {

--- a/test/support/helpers/new_invoice.helper.js
+++ b/test/support/helpers/new_invoice.helper.js
@@ -104,7 +104,7 @@ class NewInvoiceHelper {
    *
    * @param {module:InvoiceModel} invoice The invoice to be updated.
    * @param {object} updates JSON object of values to be updated. Each value in the object will be added to the existing
-   *  value in the invoice.
+   *  value in the invoice if it is a number; if it isn't a number then the existing value will be replaced.
    *
    * @returns {module:InvoiceModel} The newly updated instance of `InvoiceModel`.
    */
@@ -112,7 +112,12 @@ class NewInvoiceHelper {
     const patch = {}
 
     for (const key in updates) {
-      patch[key] = invoice[key] + updates[key]
+      // If the value is a number then we add it to the existing number; otherwise we replace the existing value
+      if (typeof updates[key] === 'number') {
+        patch[key] = invoice[key] + updates[key]
+      } else {
+        patch[key] = updates[key]
+      }
     }
 
     return invoice.$query()

--- a/test/support/helpers/new_invoice.helper.js
+++ b/test/support/helpers/new_invoice.helper.js
@@ -25,13 +25,18 @@ class NewInvoiceHelper {
     }
     const flags = this._flags(invoiceValues)
 
-    return InvoiceModel.query()
+    const invoice = await InvoiceModel.query()
       .insert({
         billRunId: billRun.id,
         ...invoiceValues,
         ...flags
       })
       .returning('*')
+
+    const updatePatch = this._updatePatch(invoice)
+    await NewBillRunHelper.update(billRun, updatePatch)
+
+    return invoice
   }
 
   static _defaultInvoice () {
@@ -79,6 +84,19 @@ class NewInvoiceHelper {
     }
 
     return flags
+  }
+
+  static _updatePatch (invoice) {
+    return {
+      creditLineCount: invoice.creditLineCount,
+      creditLineValue: invoice.creditLineValue,
+      debitLineCount: invoice.debitLineCount,
+      debitLineValue: invoice.debitLineValue,
+      zeroLineCount: invoice.zeroLineCount,
+      subjectToMinimumChargeCount: invoice.subjectToMinimumChargeCount,
+      subjectToMinimumChargeCreditValue: invoice.subjectToMinimumChargeCreditValue,
+      subjectToMinimumChargeDebitValue: invoice.subjectToMinimumChargeDebitValue
+    }
   }
 
   /**

--- a/test/support/helpers/new_invoice.helper.js
+++ b/test/support/helpers/new_invoice.helper.js
@@ -80,6 +80,26 @@ class NewInvoiceHelper {
 
     return flags
   }
+
+  /**
+   * Updates an invoice
+   *
+   * @param {module:InvoiceModel} invoice The invoice to be updated.
+   * @param {object} updates JSON object of values to be updated. Each value in the object will be added to the existing
+   *  value in the invoice.
+   *
+   * @returns {module:InvoiceModel} The newly updated instance of `InvoiceModel`.
+   */
+  static async update (invoice, updates = {}) {
+    const patch = {}
+
+    for (const key in updates) {
+      patch[key] = invoice[key] + updates[key]
+    }
+
+    return invoice.$query()
+      .patchAndFetch(patch)
+  }
 }
 
 module.exports = NewInvoiceHelper

--- a/test/support/helpers/new_invoice.helper.js
+++ b/test/support/helpers/new_invoice.helper.js
@@ -104,24 +104,36 @@ class NewInvoiceHelper {
    *
    * @param {module:InvoiceModel} invoice The invoice to be updated.
    * @param {object} updates JSON object of values to be updated. Each value in the object will be added to the existing
-   *  value in the invoice if it is a number; if it isn't a number then the existing value will be replaced.
+   *  value in the bill run if it is a number (unless it's an exception such as financialYear); if it isn't a number
+   *  then the existing value will be replaced.
    *
    * @returns {module:InvoiceModel} The newly updated instance of `InvoiceModel`.
    */
-  static async update (invoice, updates = {}) {
+  static async update (entity, updates = {}) {
     const patch = {}
 
-    for (const key in updates) {
-      // If the value is a number then we add it to the existing number; otherwise we replace the existing value
-      if (typeof updates[key] === 'number') {
-        patch[key] = invoice[key] + updates[key]
+    for (const [key, value] of Object.entries(updates)) {
+      // If the field is "addable" then we add it to the existing number; otherwise we replace the existing value.
+      if (this._addable(key, value)) {
+        patch[key] = entity[key] + value
       } else {
-        patch[key] = updates[key]
+        patch[key] = value
       }
     }
 
-    return invoice.$query()
+    return entity.$query()
       .patchAndFetch(patch)
+  }
+
+  /**
+   * When updating an entity we either add or replace values. In general, we add anything that's a number (eg. counts
+   * and values) and replace anything that isn't. However some numbers are an exception and we do want them to be
+   * replaced. This function returns true if the passed key/value pair are suitable for adding and false if they aren't.
+   */
+  static _addable (key, value) {
+    const isNumber = typeof value === 'number'
+    const exception = ['billRunNumber', 'financialYear'].includes(key)
+    return isNumber && !exception
   }
 }
 

--- a/test/support/helpers/new_licence.helper.js
+++ b/test/support/helpers/new_licence.helper.js
@@ -70,7 +70,7 @@ class NewLicenceHelper {
    *
    * @param {module:LicenceModel} licence The licence to be updated.
    * @param {object} updates JSON object of values to be updated. Each value in the object will be added to the existing
-   *  value in the licence.
+   *  value in the licence if it is a number; if it isn't a number then the existing value will be replaced.
    *
    * @returns {module:LicenceModel} The newly updated instance of `LicenceModel`.
    */
@@ -78,7 +78,12 @@ class NewLicenceHelper {
     const patch = {}
 
     for (const key in updates) {
-      patch[key] = licence[key] + updates[key]
+      // If the value is a number then we add it to the existing number; otherwise we replace the existing value
+      if (typeof updates[key] === 'number') {
+        patch[key] = licence[key] + updates[key]
+      } else {
+        patch[key] = updates[key]
+      }
     }
 
     return licence.$query()

--- a/test/support/helpers/new_licence.helper.js
+++ b/test/support/helpers/new_licence.helper.js
@@ -74,20 +74,31 @@ class NewLicenceHelper {
    *
    * @returns {module:LicenceModel} The newly updated instance of `LicenceModel`.
    */
-  static async update (licence, updates = {}) {
+  static async update (entity, updates = {}) {
     const patch = {}
 
-    for (const key in updates) {
-      // If the value is a number then we add it to the existing number; otherwise we replace the existing value
-      if (typeof updates[key] === 'number') {
-        patch[key] = licence[key] + updates[key]
+    for (const [key, value] of Object.entries(updates)) {
+      // If the field is "addable" then we add it to the existing number; otherwise we replace the existing value.
+      if (this._addable(key, value)) {
+        patch[key] = entity[key] + value
       } else {
-        patch[key] = updates[key]
+        patch[key] = value
       }
     }
 
-    return licence.$query()
+    return entity.$query()
       .patchAndFetch(patch)
+  }
+
+  /**
+   * When updating an entity we either add or replace values. In general, we add anything that's a number (eg. counts
+   * and values) and replace anything that isn't. However some numbers are an exception and we do want them to be
+   * replaced. This function returns true if the passed key/value pair are suitable for adding and false if they aren't.
+   */
+  static _addable (key, value) {
+    const isNumber = typeof value === 'number'
+    const exception = ['billRunNumber', 'financialYear'].includes(key)
+    return isNumber && !exception
   }
 }
 

--- a/test/support/helpers/new_licence.helper.js
+++ b/test/support/helpers/new_licence.helper.js
@@ -24,13 +24,18 @@ class NewLicenceHelper {
       ...overrides
     }
 
-    return LicenceModel.query()
+    const licence = await LicenceModel.query()
       .insert({
         invoiceId: invoice.id,
         billRunId: invoice.billRunId,
         ...licenceValues
       })
       .returning('*')
+
+    const updatePatch = this._updatePatch(licence)
+    await NewInvoiceHelper.update(invoice, updatePatch)
+
+    return licence
   }
 
   static _defaultLicence () {
@@ -44,6 +49,19 @@ class NewLicenceHelper {
       subjectToMinimumChargeCount: 0,
       subjectToMinimumChargeCreditValue: 0,
       subjectToMinimumChargeDebitValue: 0
+    }
+  }
+
+  static _updatePatch (licence) {
+    return {
+      creditLineCount: licence.creditLineCount,
+      creditLineValue: licence.creditLineValue,
+      debitLineCount: licence.debitLineCount,
+      debitLineValue: licence.debitLineValue,
+      zeroLineCount: licence.zeroLineCount,
+      subjectToMinimumChargeCount: licence.subjectToMinimumChargeCount,
+      subjectToMinimumChargeCreditValue: licence.subjectToMinimumChargeCreditValue,
+      subjectToMinimumChargeDebitValue: licence.subjectToMinimumChargeDebitValue
     }
   }
 

--- a/test/support/helpers/new_licence.helper.js
+++ b/test/support/helpers/new_licence.helper.js
@@ -14,9 +14,9 @@ class NewLicenceHelper {
    *
    * @returns {module:LicenceModel} The newly created instance of `LicenceModel`.
    */
-  static async add (invoice, overrides) {
+  static async create (invoice, overrides) {
     if (!invoice) {
-      invoice = await NewInvoiceHelper.add()
+      invoice = await NewInvoiceHelper.create()
     }
 
     const licenceValues = {

--- a/test/support/helpers/new_licence.helper.js
+++ b/test/support/helpers/new_licence.helper.js
@@ -14,7 +14,6 @@ class NewLicenceHelper {
    *
    * @returns {module:LicenceModel} The newly created instance of `LicenceModel`.
    */
-
   static async add (invoice, overrides) {
     if (!invoice) {
       invoice = await NewInvoiceHelper.add()
@@ -46,6 +45,26 @@ class NewLicenceHelper {
       subjectToMinimumChargeCreditValue: 0,
       subjectToMinimumChargeDebitValue: 0
     }
+  }
+
+  /**
+   * Updates a licence
+   *
+   * @param {module:LicenceModel} licence The licence to be updated.
+   * @param {object} updates JSON object of values to be updated. Each value in the object will be added to the existing
+   *  value in the licence.
+   *
+   * @returns {module:LicenceModel} The newly updated instance of `LicenceModel`.
+   */
+  static async update (licence, updates = {}) {
+    const patch = {}
+
+    for (const key in updates) {
+      patch[key] = licence[key] + updates[key]
+    }
+
+    return licence.$query()
+      .patchAndFetch(patch)
   }
 }
 

--- a/test/support/helpers/new_transaction.helper.js
+++ b/test/support/helpers/new_transaction.helper.js
@@ -23,9 +23,9 @@ class NewTransactionHelper {
    *
    * @returns {module:TransactionModel} The newly created instance of `TransactionModel`.
    */
-  static async add (licence, overrides = {}) {
+  static async create (licence, overrides = {}) {
     if (!licence) {
-      licence = await NewLicenceHelper.add()
+      licence = await NewLicenceHelper.create()
     }
 
     const transaction = await TransactionModel.query()

--- a/test/support/test/helpers/new_bill_run.helper.test.js
+++ b/test/support/test/helpers/new_bill_run.helper.test.js
@@ -22,7 +22,7 @@ describe('New Bill Run helper', () => {
 
   describe('#update method', () => {
     beforeEach(async () => {
-      billRun = await NewBillRunHelper.add()
+      billRun = await NewBillRunHelper.add(null, null, { billRunNumber: 50000 })
     })
 
     it('adds supplied numbers to the existing bill run values', async () => {
@@ -35,12 +35,20 @@ describe('New Bill Run helper', () => {
       expect(result.invoiceValue).to.equal(5000)
     })
 
-    it('replaces existing bill run strings ', async () => {
+    it('replaces existing bill run strings', async () => {
       const result = await NewBillRunHelper.update(billRun, {
         status: 'generated'
       })
 
       expect(result.status).to.equal('generated')
+    })
+
+    it('replaces bill run number', async () => {
+      const result = await NewBillRunHelper.update(billRun, {
+        billRunNumber: 10000
+      })
+
+      expect(result.billRunNumber).to.equal(10000)
     })
   })
 })

--- a/test/support/test/helpers/new_bill_run.helper.test.js
+++ b/test/support/test/helpers/new_bill_run.helper.test.js
@@ -22,7 +22,7 @@ describe('New Bill Run helper', () => {
 
   describe('#update method', () => {
     beforeEach(async () => {
-      billRun = await NewBillRunHelper.add(null, null, { billRunNumber: 50000 })
+      billRun = await NewBillRunHelper.create(null, null, { billRunNumber: 50000 })
     })
 
     it('adds supplied numbers to the existing bill run values', async () => {

--- a/test/support/test/helpers/new_bill_run.helper.test.js
+++ b/test/support/test/helpers/new_bill_run.helper.test.js
@@ -25,7 +25,7 @@ describe('New Bill Run helper', () => {
       billRun = await NewBillRunHelper.add()
     })
 
-    it('adds supplied values to the existing bill run', async () => {
+    it('adds supplied numbers to the existing bill run values', async () => {
       const result = await NewBillRunHelper.update(billRun, {
         invoiceCount: 5,
         invoiceValue: 5000
@@ -33,6 +33,14 @@ describe('New Bill Run helper', () => {
 
       expect(result.invoiceCount).to.equal(5)
       expect(result.invoiceValue).to.equal(5000)
+    })
+
+    it('replaces existing bill run strings ', async () => {
+      const result = await NewBillRunHelper.update(billRun, {
+        status: 'generated'
+      })
+
+      expect(result.status).to.equal('generated')
     })
   })
 })

--- a/test/support/test/helpers/new_bill_run.helper.test.js
+++ b/test/support/test/helpers/new_bill_run.helper.test.js
@@ -1,0 +1,38 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const { DatabaseHelper } = require('../../helpers')
+
+// Thing under test
+const { NewBillRunHelper } = require('../../helpers')
+
+describe('New Bill Run helper', () => {
+  let billRun
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+  })
+
+  describe('#update method', () => {
+    beforeEach(async () => {
+      billRun = await NewBillRunHelper.add()
+    })
+
+    it('adds supplied values to the existing bill run', async () => {
+      const result = await NewBillRunHelper.update(billRun, {
+        invoiceCount: 5,
+        invoiceValue: 5000
+      })
+
+      expect(result.invoiceCount).to.equal(5)
+      expect(result.invoiceValue).to.equal(5000)
+    })
+  })
+})

--- a/test/support/test/helpers/new_invoice.helper.test.js
+++ b/test/support/test/helpers/new_invoice.helper.test.js
@@ -22,17 +22,24 @@ describe('New Invoice helper', () => {
 
     invoice = await NewInvoiceHelper.add(null, {
       debitLineCount: 5,
-      subjectToMinimumChargeDebitValue: 5000,
-      financialYear: 2021
+      debitLineValue: 250,
+      financialYear: 2021,
+      deminimisInvoice: false,
+      zeroValueInvoice: true
     })
   })
 
   describe('#add method', () => {
+    it('sets flags as requested', async () => {
+      expect(invoice.deminimisInvoice).to.be.false()
+      expect(invoice.zeroValueInvoice).to.be.true()
+    })
+
     it('updates the parent bill run', async () => {
       const result = await BillRunModel.query().findById(invoice.billRunId)
 
       expect(result.debitLineCount).to.equal(5)
-      expect(result.subjectToMinimumChargeDebitValue).to.equal(5000)
+      expect(result.debitLineValue).to.equal(250)
     })
   })
 
@@ -40,11 +47,11 @@ describe('New Invoice helper', () => {
     it('adds supplied numbers to the existing invoice values', async () => {
       const result = await NewInvoiceHelper.update(invoice, {
         debitLineCount: 1,
-        subjectToMinimumChargeDebitValue: 1000
+        debitLineValue: 1000
       })
 
       expect(result.debitLineCount).to.equal(6)
-      expect(result.subjectToMinimumChargeDebitValue).to.equal(6000)
+      expect(result.debitLineValue).to.equal(1250)
     })
 
     it('replaces existing invoice strings and booleans', async () => {
@@ -63,6 +70,15 @@ describe('New Invoice helper', () => {
       })
 
       expect(result.financialYear).to.equal(3000)
+    })
+  })
+
+  describe('#refreshFlags method', () => {
+    it('sets flags based on current counts and values', async () => {
+      const result = await NewInvoiceHelper.refreshFlags(invoice)
+
+      expect(result.deminimisInvoice).to.be.true()
+      expect(result.zeroValueInvoice).to.be.false()
     })
   })
 })

--- a/test/support/test/helpers/new_invoice.helper.test.js
+++ b/test/support/test/helpers/new_invoice.helper.test.js
@@ -22,7 +22,8 @@ describe('New Invoice helper', () => {
 
     invoice = await NewInvoiceHelper.add(null, {
       debitLineCount: 5,
-      subjectToMinimumChargeDebitValue: 5000
+      subjectToMinimumChargeDebitValue: 5000,
+      financialYear: 2021
     })
   })
 
@@ -54,6 +55,14 @@ describe('New Invoice helper', () => {
 
       expect(result.customerReference).to.equal('NEW_REF')
       expect(result.deminimisInvoice).to.be.true()
+    })
+
+    it('replaces financial year', async () => {
+      const result = await NewInvoiceHelper.update(invoice, {
+        financialYear: 3000
+      })
+
+      expect(result.financialYear).to.equal(3000)
     })
   })
 })

--- a/test/support/test/helpers/new_invoice.helper.test.js
+++ b/test/support/test/helpers/new_invoice.helper.test.js
@@ -1,0 +1,38 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const { DatabaseHelper } = require('../../helpers')
+
+// Thing under test
+const { NewInvoiceHelper } = require('../../helpers')
+
+describe('New Invoice helper', () => {
+  let invoice
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+  })
+
+  describe('#update method', () => {
+    beforeEach(async () => {
+      invoice = await NewInvoiceHelper.add()
+    })
+
+    it('adds supplied values to the existing invoice', async () => {
+      const result = await NewInvoiceHelper.update(invoice, {
+        debitLineCount: 5,
+        subjectToMinimumChargeDebitValue: 5000
+      })
+
+      expect(result.debitLineCount).to.equal(5)
+      expect(result.subjectToMinimumChargeDebitValue).to.equal(5000)
+    })
+  })
+})

--- a/test/support/test/helpers/new_invoice.helper.test.js
+++ b/test/support/test/helpers/new_invoice.helper.test.js
@@ -12,17 +12,39 @@ const { DatabaseHelper } = require('../../helpers')
 
 // Thing under test
 const { NewInvoiceHelper } = require('../../helpers')
+const { BillRunModel } = require('../../../../app/models')
 
 describe('New Invoice helper', () => {
-  let invoice
-
   beforeEach(async () => {
     await DatabaseHelper.clean()
   })
 
-  describe('#update method', () => {
+  describe('#add method', () => {
+    let invoice
+
     beforeEach(async () => {
-      invoice = await NewInvoiceHelper.add()
+      invoice = await NewInvoiceHelper.add(null, {
+        debitLineCount: 5,
+        subjectToMinimumChargeDebitValue: 5000
+      })
+    })
+
+    it('updates the parent bill run', async () => {
+      const billRun = await BillRunModel.query().findById(invoice.billRunId)
+
+      expect(billRun.debitLineCount).to.equal(5)
+      expect(billRun.subjectToMinimumChargeDebitValue).to.equal(5000)
+    })
+  })
+
+  describe('#update method', () => {
+    let invoice
+
+    beforeEach(async () => {
+      invoice = await NewInvoiceHelper.add(null, {
+        debitLineCount: 1,
+        subjectToMinimumChargeDebitValue: 1000
+      })
     })
 
     it('adds supplied values to the existing invoice', async () => {
@@ -31,8 +53,8 @@ describe('New Invoice helper', () => {
         subjectToMinimumChargeDebitValue: 5000
       })
 
-      expect(result.debitLineCount).to.equal(5)
-      expect(result.subjectToMinimumChargeDebitValue).to.equal(5000)
+      expect(result.debitLineCount).to.equal(6)
+      expect(result.subjectToMinimumChargeDebitValue).to.equal(6000)
     })
   })
 })

--- a/test/support/test/helpers/new_invoice.helper.test.js
+++ b/test/support/test/helpers/new_invoice.helper.test.js
@@ -20,7 +20,7 @@ describe('New Invoice helper', () => {
   beforeEach(async () => {
     await DatabaseHelper.clean()
 
-    invoice = await NewInvoiceHelper.add(null, {
+    invoice = await NewInvoiceHelper.create(null, {
       debitLineCount: 5,
       debitLineValue: 250,
       financialYear: 2021,
@@ -29,7 +29,7 @@ describe('New Invoice helper', () => {
     })
   })
 
-  describe('#add method', () => {
+  describe('#create method', () => {
     it('sets flags as requested', async () => {
       expect(invoice.deminimisInvoice).to.be.false()
       expect(invoice.zeroValueInvoice).to.be.true()

--- a/test/support/test/helpers/new_invoice.helper.test.js
+++ b/test/support/test/helpers/new_invoice.helper.test.js
@@ -9,48 +9,37 @@ const { expect } = Code
 
 // Test helpers
 const { DatabaseHelper } = require('../../helpers')
+const { BillRunModel } = require('../../../../app/models')
 
 // Thing under test
 const { NewInvoiceHelper } = require('../../helpers')
-const { BillRunModel } = require('../../../../app/models')
 
 describe('New Invoice helper', () => {
+  let invoice
+
   beforeEach(async () => {
     await DatabaseHelper.clean()
+
+    invoice = await NewInvoiceHelper.add(null, {
+      debitLineCount: 5,
+      subjectToMinimumChargeDebitValue: 5000
+    })
   })
 
   describe('#add method', () => {
-    let invoice
-
-    beforeEach(async () => {
-      invoice = await NewInvoiceHelper.add(null, {
-        debitLineCount: 5,
-        subjectToMinimumChargeDebitValue: 5000
-      })
-    })
-
     it('updates the parent bill run', async () => {
-      const billRun = await BillRunModel.query().findById(invoice.billRunId)
+      const result = await BillRunModel.query().findById(invoice.billRunId)
 
-      expect(billRun.debitLineCount).to.equal(5)
-      expect(billRun.subjectToMinimumChargeDebitValue).to.equal(5000)
+      expect(result.debitLineCount).to.equal(5)
+      expect(result.subjectToMinimumChargeDebitValue).to.equal(5000)
     })
   })
 
   describe('#update method', () => {
-    let invoice
-
-    beforeEach(async () => {
-      invoice = await NewInvoiceHelper.add(null, {
-        debitLineCount: 1,
-        subjectToMinimumChargeDebitValue: 1000
-      })
-    })
-
     it('adds supplied values to the existing invoice', async () => {
       const result = await NewInvoiceHelper.update(invoice, {
-        debitLineCount: 5,
-        subjectToMinimumChargeDebitValue: 5000
+        debitLineCount: 1,
+        subjectToMinimumChargeDebitValue: 1000
       })
 
       expect(result.debitLineCount).to.equal(6)

--- a/test/support/test/helpers/new_invoice.helper.test.js
+++ b/test/support/test/helpers/new_invoice.helper.test.js
@@ -36,7 +36,7 @@ describe('New Invoice helper', () => {
   })
 
   describe('#update method', () => {
-    it('adds supplied values to the existing invoice', async () => {
+    it('adds supplied numbers to the existing invoice values', async () => {
       const result = await NewInvoiceHelper.update(invoice, {
         debitLineCount: 1,
         subjectToMinimumChargeDebitValue: 1000
@@ -44,6 +44,16 @@ describe('New Invoice helper', () => {
 
       expect(result.debitLineCount).to.equal(6)
       expect(result.subjectToMinimumChargeDebitValue).to.equal(6000)
+    })
+
+    it('replaces existing invoice strings and booleans', async () => {
+      const result = await NewInvoiceHelper.update(invoice, {
+        customerReference: 'NEW_REF',
+        deminimisInvoice: true
+      })
+
+      expect(result.customerReference).to.equal('NEW_REF')
+      expect(result.deminimisInvoice).to.be.true()
     })
   })
 })

--- a/test/support/test/helpers/new_licence.helper.test.js
+++ b/test/support/test/helpers/new_licence.helper.test.js
@@ -1,0 +1,38 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const { DatabaseHelper } = require('../../helpers')
+
+// Thing under test
+const { NewLicenceHelper } = require('../../helpers')
+
+describe('New Invoice helper', () => {
+  let licence
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+  })
+
+  describe('#update method', () => {
+    beforeEach(async () => {
+      licence = await NewLicenceHelper.add()
+    })
+
+    it('adds supplied values to the existing licence', async () => {
+      const result = await NewLicenceHelper.update(licence, {
+        debitLineCount: 5,
+        subjectToMinimumChargeDebitValue: 5000
+      })
+
+      expect(result.debitLineCount).to.equal(5)
+      expect(result.subjectToMinimumChargeDebitValue).to.equal(5000)
+    })
+  })
+})

--- a/test/support/test/helpers/new_licence.helper.test.js
+++ b/test/support/test/helpers/new_licence.helper.test.js
@@ -36,7 +36,7 @@ describe('New Licence helper', () => {
   })
 
   describe('#update method', () => {
-    it('adds supplied values to the existing licence', async () => {
+    it('adds supplied numbers to the existing licence values', async () => {
       const result = await NewLicenceHelper.update(licence, {
         debitLineCount: 1,
         subjectToMinimumChargeDebitValue: 1000
@@ -44,6 +44,14 @@ describe('New Licence helper', () => {
 
       expect(result.debitLineCount).to.equal(6)
       expect(result.subjectToMinimumChargeDebitValue).to.equal(6000)
+    })
+
+    it('replaces existing licence strings', async () => {
+      const result = await NewLicenceHelper.update(licence, {
+        licenceNumber: 'NEW_REF'
+      })
+
+      expect(result.licenceNumber).to.equal('NEW_REF')
     })
   })
 })

--- a/test/support/test/helpers/new_licence.helper.test.js
+++ b/test/support/test/helpers/new_licence.helper.test.js
@@ -9,30 +9,41 @@ const { expect } = Code
 
 // Test helpers
 const { DatabaseHelper } = require('../../helpers')
+const { InvoiceModel } = require('../../../../app/models')
 
 // Thing under test
 const { NewLicenceHelper } = require('../../helpers')
 
-describe('New Invoice helper', () => {
+describe.only('New Licence helper', () => {
   let licence
 
   beforeEach(async () => {
     await DatabaseHelper.clean()
+
+    licence = await NewLicenceHelper.add(null, {
+      debitLineCount: 5,
+      subjectToMinimumChargeDebitValue: 5000
+    })
   })
 
-  describe('#update method', () => {
-    beforeEach(async () => {
-      licence = await NewLicenceHelper.add()
-    })
-
-    it('adds supplied values to the existing licence', async () => {
-      const result = await NewLicenceHelper.update(licence, {
-        debitLineCount: 5,
-        subjectToMinimumChargeDebitValue: 5000
-      })
+  describe('#add method', () => {
+    it('updates the parent invoice', async () => {
+      const result = await InvoiceModel.query().findById(licence.invoiceId)
 
       expect(result.debitLineCount).to.equal(5)
       expect(result.subjectToMinimumChargeDebitValue).to.equal(5000)
+    })
+  })
+
+  describe('#update method', () => {
+    it('adds supplied values to the existing licence', async () => {
+      const result = await NewLicenceHelper.update(licence, {
+        debitLineCount: 1,
+        subjectToMinimumChargeDebitValue: 1000
+      })
+
+      expect(result.debitLineCount).to.equal(6)
+      expect(result.subjectToMinimumChargeDebitValue).to.equal(6000)
     })
   })
 })

--- a/test/support/test/helpers/new_licence.helper.test.js
+++ b/test/support/test/helpers/new_licence.helper.test.js
@@ -14,7 +14,7 @@ const { InvoiceModel } = require('../../../../app/models')
 // Thing under test
 const { NewLicenceHelper } = require('../../helpers')
 
-describe.only('New Licence helper', () => {
+describe('New Licence helper', () => {
   let licence
 
   beforeEach(async () => {

--- a/test/support/test/helpers/new_licence.helper.test.js
+++ b/test/support/test/helpers/new_licence.helper.test.js
@@ -20,13 +20,13 @@ describe('New Licence helper', () => {
   beforeEach(async () => {
     await DatabaseHelper.clean()
 
-    licence = await NewLicenceHelper.add(null, {
+    licence = await NewLicenceHelper.create(null, {
       debitLineCount: 5,
       subjectToMinimumChargeDebitValue: 5000
     })
   })
 
-  describe('#add method', () => {
+  describe('#create method', () => {
     it('updates the parent invoice', async () => {
       const result = await InvoiceModel.query().findById(licence.invoiceId)
 

--- a/test/support/test/helpers/new_transaction.helper.test.js
+++ b/test/support/test/helpers/new_transaction.helper.test.js
@@ -20,10 +20,10 @@ describe('New Transaction helper', () => {
   beforeEach(async () => {
     await DatabaseHelper.clean()
 
-    transaction = await NewTransactionHelper.add()
+    transaction = await NewTransactionHelper.create()
   })
 
-  describe('#add method', () => {
+  describe('#create method', () => {
     it('updates the parent licence', async () => {
       const result = await LicenceModel.query().findById(transaction.licenceId)
 

--- a/test/support/test/helpers/new_transaction.helper.test.js
+++ b/test/support/test/helpers/new_transaction.helper.test.js
@@ -1,0 +1,34 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const { DatabaseHelper } = require('../../helpers')
+const { LicenceModel } = require('../../../../app/models')
+
+// Thing under test
+const { NewTransactionHelper } = require('../../helpers')
+
+describe('New Transaction helper', () => {
+  let transaction
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+
+    transaction = await NewTransactionHelper.add()
+  })
+
+  describe('#add method', () => {
+    it('updates the parent licence', async () => {
+      const result = await LicenceModel.query().findById(transaction.licenceId)
+
+      expect(result.debitLineCount).to.equal(1)
+      expect(result.debitLineValue).to.equal(transaction.chargeValue)
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/projects/CMEA/boards/907?selectedIssue=CMEA-4

The new test helpers we have created will allow us to greatly streamline our tests. For example, if we want to test a transaction in isolation then we only need to create the transaction and everything else (bill run, invoice, licence, even authorised system and regime) will be handled for us.

However, if we do this then the bill run, invoice and licence will all be blank, which does not reflect the reality of what happens when we create things. We are therefore adding an `update` method to their helpers which will allow us to pass in an object of values to be added to the existing values. This is then used by the `add` method to cascade changes upwards, so if a transaction is created with certain values then these values will be added to the licence, invoice and bill run.

We also introduce test helper tests as part of this change. These are purely intended for us to test and demonstrate that the functionality works; as we start to update the existing tests to use the new helpers, we can ultimately delete the tests when we are satisfied that they are sufficiently tested through use.