### PR TITLE
Test helpers pass all changes up

### DIFF
--- a/test/support/helpers/new_bill_run.helper.js
+++ b/test/support/helpers/new_bill_run.helper.js
@@ -51,26 +51,26 @@ class NewBillRunHelper {
   /**
    * Updates a bill run
    *
-   * @param {module:BillRunModel} entity The bill run to be updated.
+   * @param {module:BillRunModel} billRun The bill run to be updated.
    * @param {object} updates JSON object of values to be updated. Each value in the object will be added to the existing
    *  value in the bill run if it is a number (unless it's an exception such as billRunNumber); if it isn't a number
    *  then the existing value will be replaced.
    *
    * @returns {module:BillRunModel} The newly updated instance of `BillRunModel`.
    */
-  static async update (entity, updates = {}) {
+  static async update (billRun, updates = {}) {
     const patch = {}
 
     for (const [key, value] of Object.entries(updates)) {
       // If the field is "addable" then we add it to the existing number; otherwise we replace the existing value.
       if (this._addable(key, value)) {
-        patch[key] = entity[key] + value
+        patch[key] = billRun[key] + value
       } else {
         patch[key] = value
       }
     }
 
-    return entity.$query()
+    return billRun.$query()
       .patchAndFetch(patch)
   }
 

--- a/test/support/helpers/new_invoice.helper.js
+++ b/test/support/helpers/new_invoice.helper.js
@@ -78,19 +78,19 @@ class NewInvoiceHelper {
    *
    * @returns {module:InvoiceModel} The newly updated instance of `InvoiceModel`.
    */
-  static async update (entity, updates = {}) {
+  static async update (invoice, updates = {}) {
     const patch = {}
 
     for (const [key, value] of Object.entries(updates)) {
       // If the field is "addable" then we add it to the existing number; otherwise we replace the existing value.
       if (this._addable(key, value)) {
-        patch[key] = entity[key] + value
+        patch[key] = invoice[key] + value
       } else {
         patch[key] = value
       }
     }
 
-    return entity.$query()
+    return invoice.$query()
       .patchAndFetch(patch)
   }
 

--- a/test/support/helpers/new_licence.helper.js
+++ b/test/support/helpers/new_licence.helper.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { LicenceModel } = require('../../../app/models')
+const { InvoiceModel, LicenceModel } = require('../../../app/models')
 
 const NewInvoiceHelper = require('./new_invoice.helper')
 
@@ -32,8 +32,7 @@ class NewLicenceHelper {
       })
       .returning('*')
 
-    const updatePatch = this._updatePatch(licence)
-    await NewInvoiceHelper.update(invoice, updatePatch)
+    await this._updateInvoice(invoice, licence)
 
     return licence
   }
@@ -50,6 +49,11 @@ class NewLicenceHelper {
       subjectToMinimumChargeCreditValue: 0,
       subjectToMinimumChargeDebitValue: 0
     }
+  }
+
+  static async _updateInvoice (invoice, objectToUpdateFrom) {
+    const updatePatch = this._updatePatch(objectToUpdateFrom)
+    await NewInvoiceHelper.update(invoice, updatePatch)
   }
 
   static _updatePatch (licence) {
@@ -86,8 +90,13 @@ class NewLicenceHelper {
       }
     }
 
-    return licence.$query()
+    const updatedInvoice = await licence.$query()
       .patchAndFetch(patch)
+
+    const invoice = await InvoiceModel.query().findById(licence.invoiceId)
+    await this._updateInvoice(invoice, updates)
+
+    return updatedInvoice
   }
 
   /**

--- a/test/support/helpers/new_licence.helper.js
+++ b/test/support/helpers/new_licence.helper.js
@@ -74,19 +74,19 @@ class NewLicenceHelper {
    *
    * @returns {module:LicenceModel} The newly updated instance of `LicenceModel`.
    */
-  static async update (entity, updates = {}) {
+  static async update (licence, updates = {}) {
     const patch = {}
 
     for (const [key, value] of Object.entries(updates)) {
       // If the field is "addable" then we add it to the existing number; otherwise we replace the existing value.
       if (this._addable(key, value)) {
-        patch[key] = entity[key] + value
+        patch[key] = licence[key] + value
       } else {
         patch[key] = value
       }
     }
 
-    return entity.$query()
+    return licence.$query()
       .patchAndFetch(patch)
   }
 

--- a/test/support/test/helpers/new_invoice.helper.test.js
+++ b/test/support/test/helpers/new_invoice.helper.test.js
@@ -71,6 +71,17 @@ describe('New Invoice helper', () => {
 
       expect(result.financialYear).to.equal(3000)
     })
+
+    it('updates values at bill run level', async () => {
+      await NewInvoiceHelper.update(invoice, {
+        debitLineCount: 1,
+        debitLineValue: 1000
+      })
+      const result = await BillRunModel.query().findById(invoice.billRunId)
+
+      expect(result.debitLineCount).to.equal(6)
+      expect(result.debitLineValue).to.equal(1250)
+    })
   })
 
   describe('#refreshFlags method', () => {

--- a/test/support/test/helpers/new_invoice.helper.test.js
+++ b/test/support/test/helpers/new_invoice.helper.test.js
@@ -72,7 +72,7 @@ describe('New Invoice helper', () => {
       expect(result.financialYear).to.equal(3000)
     })
 
-    it('updates values at bill run level', async () => {
+    it('updates values at the bill run level', async () => {
       await NewInvoiceHelper.update(invoice, {
         debitLineCount: 1,
         debitLineValue: 1000

--- a/test/support/test/helpers/new_licence.helper.test.js
+++ b/test/support/test/helpers/new_licence.helper.test.js
@@ -9,7 +9,7 @@ const { expect } = Code
 
 // Test helpers
 const { DatabaseHelper } = require('../../helpers')
-const { InvoiceModel } = require('../../../../app/models')
+const { BillRunModel, InvoiceModel } = require('../../../../app/models')
 
 // Thing under test
 const { NewLicenceHelper } = require('../../helpers')
@@ -52,6 +52,20 @@ describe('New Licence helper', () => {
       })
 
       expect(result.licenceNumber).to.equal('NEW_REF')
+    })
+
+    it('updates values at the invoice and bill run levels', async () => {
+      await NewLicenceHelper.update(licence, {
+        debitLineCount: 1,
+        subjectToMinimumChargeDebitValue: 1000
+      })
+      const invoice = await InvoiceModel.query().findById(licence.invoiceId)
+      const billRun = await BillRunModel.query().findById(licence.billRunId)
+
+      expect(invoice.debitLineCount).to.equal(6)
+      expect(invoice.subjectToMinimumChargeDebitValue).to.equal(6000)
+      expect(billRun.debitLineCount).to.equal(6)
+      expect(billRun.subjectToMinimumChargeDebitValue).to.equal(6000)
     })
   })
 })

--- a/test/support/test/helpers/new_transaction.helper.test.js
+++ b/test/support/test/helpers/new_transaction.helper.test.js
@@ -9,7 +9,7 @@ const { expect } = Code
 
 // Test helpers
 const { DatabaseHelper } = require('../../helpers')
-const { LicenceModel } = require('../../../../app/models')
+const { BillRunModel, InvoiceModel, LicenceModel } = require('../../../../app/models')
 
 // Thing under test
 const { NewTransactionHelper } = require('../../helpers')
@@ -29,6 +29,16 @@ describe('New Transaction helper', () => {
 
       expect(result.debitLineCount).to.equal(1)
       expect(result.debitLineValue).to.equal(transaction.chargeValue)
+    })
+
+    it('updates values at the invoice and bill run level', async () => {
+      const invoice = await InvoiceModel.query().findById(transaction.invoiceId)
+      const billRun = await BillRunModel.query().findById(transaction.billRunId)
+
+      expect(invoice.debitLineCount).to.equal(1)
+      expect(invoice.debitLineValue).to.equal(transaction.chargeValue)
+      expect(billRun.debitLineCount).to.equal(1)
+      expect(billRun.debitLineValue).to.equal(transaction.chargeValue)
     })
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/projects/CMEA/boards/907?selectedIssue=CMEA-4

While running through our new test helpers we noticed one small issue; although changes cascaded up to the next level (eg. from transaction to licence), they did not propagate any further than that. We quickly realised that although our `add` methods would call the `update` method of the parent, the `update` methods were not calling _their_ parents. This change resolves this.