### PR TITLE
Enable delete licence in production

### DIFF
--- a/app/routes/bill_run_licence.routes.js
+++ b/app/routes/bill_run_licence.routes.js
@@ -6,12 +6,7 @@ const routes = [
   {
     method: 'DELETE',
     path: '/v2/{regimeId}/bill-runs/{billRunId}/licences/{licenceId}',
-    handler: PresrocBillRunsLicencesController.delete,
-    options: {
-      app: {
-        excludeFromProd: true
-      }
-    }
+    handler: PresrocBillRunsLicencesController.delete
   }
 ]
 


### PR DESCRIPTION
https://trello.com/c/q3yaHhS7

The delete licence functionality has been checked and approved which means we are happy to make it available for use in `production`. This removes the routes filter that prevents the endpoint from being available in production.