### PR TITLE
Add data export task

### DIFF
--- a/app/tasks/data_export.task.js
+++ b/app/tasks/data_export.task.js
@@ -1,0 +1,27 @@
+'use strict'
+
+/**
+ * @module DataExportTask
+ */
+
+const { ReportingExportService } = require('../services')
+
+class DataExportTask {
+  /**
+   * Trigger export of all relevant data tables to CSV and then upload them to S3
+   *
+   * Intended to be called as a scheduled task from Jenkins using a package.json script and via `TaskRunner`.
+   *
+   * @param {@module:BaseNotifierLib} notifier Instance of a `Notifier` class. Expected to be an instance of
+   * `TaskNotifierLib` but anything that implements `BaseNotifierLib` is supported.
+   */
+  static async go (notifier) {
+    notifier.omg('Starting data export task')
+
+    await ReportingExportService.go(notifier)
+
+    notifier.omg('Finished data export task')
+  }
+}
+
+module.exports = DataExportTask

--- a/app/tasks/data_export.task.js
+++ b/app/tasks/data_export.task.js
@@ -4,7 +4,7 @@
  * @module DataExportTask
  */
 
-const { ReportingExportService } = require('../services')
+const { DataExportService } = require('../services')
 
 class DataExportTask {
   /**
@@ -18,7 +18,7 @@ class DataExportTask {
   static async go (notifier) {
     notifier.omg('Starting data export task')
 
-    await ReportingExportService.go(notifier)
+    await DataExportService.go(notifier)
 
     notifier.omg('Finished data export task')
   }

--- a/app/tasks/index.js
+++ b/app/tasks/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const CustomerFilesTask = require('./customer_files.task')
+const DataExportTask = require('./data_export.task')
 const TaskRunner = require('./task_runner')
 
 // This determines if the module has been run directly, for example, as a script entry in `package.json` or just
@@ -11,5 +12,6 @@ if (require.main === module) {
 
 module.exports = {
   CustomerFilesTask,
+  DataExportTask,
   TaskRunner
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "reset-test-db": "npm run clean-test-db && npm run rollback-test-db && npm run migrate-test-db",
     "nuke-db": "node db/drop.database.js && npm run create-db",
     "nuke-test-db": "NODE_ENV=test node db/drop.database.js && npm run create-test-db",
-    "customer-files-task": "node app/tasks/index.js CustomerFilesTask"
+    "customer-files-task": "node app/tasks/index.js CustomerFilesTask",
+    "data-export-task": "node app/tasks/index.js DataExportTask"
   },
   "repository": {
     "type": "git",

--- a/test/tasks/data_export.task.test.js
+++ b/test/tasks/data_export.task.test.js
@@ -1,0 +1,38 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Thing under test
+const { DataExportTask } = require('../../app/tasks')
+
+// Things we need to stub
+const { ReportingExportService } = require('../../app/services')
+
+describe('Customer Files Task', () => {
+  let notifierFake
+  let serviceStub
+
+  beforeEach(async () => {
+    notifierFake = { omg: Sinon.fake(), omfg: Sinon.fake() }
+
+    serviceStub = Sinon.stub(ReportingExportService, 'go')
+  })
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe('When the task is run', () => {
+    it("calls the 'ReportingExportService'", async () => {
+      await DataExportTask.go(notifierFake)
+
+      expect(serviceStub.calledOnce).to.be.true()
+    })
+  })
+})

--- a/test/tasks/data_export.task.test.js
+++ b/test/tasks/data_export.task.test.js
@@ -12,7 +12,7 @@ const { expect } = Code
 const { DataExportTask } = require('../../app/tasks')
 
 // Things we need to stub
-const { ReportingExportService } = require('../../app/services')
+const { DataExportService } = require('../../app/services')
 
 describe('Customer Files Task', () => {
   let notifierFake
@@ -21,7 +21,7 @@ describe('Customer Files Task', () => {
   beforeEach(async () => {
     notifierFake = { omg: Sinon.fake(), omfg: Sinon.fake() }
 
-    serviceStub = Sinon.stub(ReportingExportService, 'go')
+    serviceStub = Sinon.stub(DataExportService, 'go')
   })
 
   afterEach(() => {
@@ -29,7 +29,7 @@ describe('Customer Files Task', () => {
   })
 
   describe('When the task is run', () => {
-    it("calls the 'ReportingExportService'", async () => {
+    it("calls the 'DataExportService'", async () => {
       await DataExportTask.go(notifierFake)
 
       expect(serviceStub.calledOnce).to.be.true()


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/CMEA-68

For the customer changes export process we have a `task` which we call from a scheduled Jenkins job to kick off the process. This covers adding the same thing, only for the data export process that is currently [being developed](https://github.com/DEFRA/sroc-charging-module-api/pull/501).