### PR TITLE
Specify full key when sending to S3 bucket

### DIFF
--- a/app/services/send_customer_file.service.js
+++ b/app/services/send_customer_file.service.js
@@ -128,7 +128,7 @@ class SendCustomerFileService {
     const filename = path.basename(generatedFile)
 
     // The key is the remote path and filename in the S3 bucket, eg. 'wrls/customer/nalac50001.dat'
-    const key = path.join(regime.slug, 'customer', filename)
+    const key = path.join('export', regime.slug, 'customer', filename)
 
     await SendFileToS3Service.go(generatedFile, key)
 

--- a/app/services/send_customer_file.service.js
+++ b/app/services/send_customer_file.service.js
@@ -127,7 +127,7 @@ class SendCustomerFileService {
     const generatedFile = await GenerateCustomerFileService.go(customerFile)
     const filename = path.basename(generatedFile)
 
-    // The key is the remote path and filename in the S3 bucket, eg. 'wrls/customer/nalac50001.dat'
+    // The key is the remote path and filename in the S3 bucket, eg. 'export/wrls/customer/nalac50001.dat'
     const key = path.join('export', regime.slug, 'customer', filename)
 
     await SendFileToS3Service.go(generatedFile, key)

--- a/app/services/send_file_to_s3.service.js
+++ b/app/services/send_file_to_s3.service.js
@@ -9,7 +9,6 @@ const { temporaryFilePath } = ServerConfig
 
 const { S3Client, PutObjectCommand } = require('@aws-sdk/client-s3')
 const fs = require('fs')
-const path = require('path')
 
 class SendFileToS3Service {
   /**
@@ -17,18 +16,15 @@ class SendFileToS3Service {
    *
    * @param {string} localFilenameWithPath The name and path of the file to be sent to S3.
    * @param {string} key The key is the path and filename the file will have in the bucket. For example,
-   * 'wrls/transaction/nalai50001.dat'. Note that we prepend this with 'export'.
+   * 'export/wrls/transaction/nalai50001.dat'.
    * @param {boolean} [copyToArchive] Whether the file is also be sent to the archive bucket. Defaults to `true`.
   */
 
   static async go (localFilenameWithPath, key, copyToArchive = true) {
-    // We always upload into the top-level export folder so prepend the key we've been given with 'export/'
-    const exportKey = path.join('export', key)
-
-    await this._sendFile(this._uploadBucket(), exportKey, localFilenameWithPath)
+    await this._sendFile(this._uploadBucket(), key, localFilenameWithPath)
 
     if (copyToArchive) {
-      await this._sendFile(this._archiveBucket(), exportKey, localFilenameWithPath)
+      await this._sendFile(this._archiveBucket(), key, localFilenameWithPath)
     }
   }
 

--- a/app/services/send_transaction_file.service.js
+++ b/app/services/send_transaction_file.service.js
@@ -72,7 +72,7 @@ class SendTransactionFileService {
     const generatedFile = await GenerateTransactionFileService.go(billRun, filename)
 
     // The key is the remote path and filename in the S3 bucket, eg. 'wrls/transaction/nalai50001.dat'
-    const key = path.join(regime.slug, 'transaction', filename)
+    const key = path.join('export', regime.slug, 'transaction', filename)
 
     await SendFileToS3Service.go(generatedFile, key)
 

--- a/app/services/send_transaction_file.service.js
+++ b/app/services/send_transaction_file.service.js
@@ -71,7 +71,7 @@ class SendTransactionFileService {
     const filename = this._filename(billRun.fileReference)
     const generatedFile = await GenerateTransactionFileService.go(billRun, filename)
 
-    // The key is the remote path and filename in the S3 bucket, eg. 'wrls/transaction/nalai50001.dat'
+    // The key is the remote path and filename in the S3 bucket, eg. 'export/wrls/transaction/nalai50001.dat'
     const key = path.join('export', regime.slug, 'transaction', filename)
 
     await SendFileToS3Service.go(generatedFile, key)

--- a/test/services/send_customer_file.service.test.js
+++ b/test/services/send_customer_file.service.test.js
@@ -93,7 +93,7 @@ describe('Send Customer File service', () => {
         it('sends the customer file', async () => {
           expect(sendStub.calledOnce).to.be.true()
           expect(sendStub.getCall(0).firstArg).to.equal('nalac50001.dat')
-          expect(sendStub.getCall(0).args[1]).to.equal(`${regime.slug}/customer/nalac50001.dat`)
+          expect(sendStub.getCall(0).args[1]).to.equal(`export/${regime.slug}/customer/nalac50001.dat`)
         })
 
         it('moves the customers to the exported customers table', async () => {
@@ -175,9 +175,9 @@ describe('Send Customer File service', () => {
         it('sends the customer file', async () => {
           expect(sendStub.calledTwice).to.be.true()
           expect(sendStub.getCall(0).args[0]).to.equal('nalac50001.dat')
-          expect(sendStub.getCall(0).args[1]).to.equal(`${regime.slug}/customer/nalac50001.dat`)
+          expect(sendStub.getCall(0).args[1]).to.equal(`export/${regime.slug}/customer/nalac50001.dat`)
           expect(sendStub.getCall(1).args[0]).to.equal('nalwc50001.dat')
-          expect(sendStub.getCall(1).args[1]).to.equal(`${regime.slug}/customer/nalwc50001.dat`)
+          expect(sendStub.getCall(1).args[1]).to.equal(`export/${regime.slug}/customer/nalwc50001.dat`)
         })
 
         it('moves the customers to the exported customers table', async () => {
@@ -250,9 +250,9 @@ describe('Send Customer File service', () => {
         it('sends all required customer files', async () => {
           expect(sendStub.calledTwice).to.be.true()
           expect(sendStub.getCall(0).args[0]).to.equal('nalac50001.dat')
-          expect(sendStub.getCall(0).args[1]).to.equal(`${regime.slug}/customer/nalac50001.dat`)
+          expect(sendStub.getCall(0).args[1]).to.equal(`export/${regime.slug}/customer/nalac50001.dat`)
           expect(sendStub.getCall(1).args[0]).to.equal('nalwc50001.dat')
-          expect(sendStub.getCall(1).args[1]).to.equal(`${regime.slug}/customer/nalwc50001.dat`)
+          expect(sendStub.getCall(1).args[1]).to.equal(`export/${regime.slug}/customer/nalwc50001.dat`)
         })
 
         it('moves the customers to the exported customers table', async () => {

--- a/test/services/send_file_to_s3.service.test.js
+++ b/test/services/send_file_to_s3.service.test.js
@@ -54,11 +54,9 @@ describe('Send File To S3 service', () => {
   })
 
   describe('When a valid file is specified', () => {
-    beforeEach(async () => {
-      await SendFileToS3Service.go(filenameWithPath, key, false)
-    })
-
     it('uploads the file to the S3 bucket', async () => {
+      await SendFileToS3Service.go(filenameWithPath, key, false)
+
       // Test that the S3 client was called once
       expect(s3Stub.calledOnce).to.be.true()
 
@@ -71,12 +69,16 @@ describe('Send File To S3 service', () => {
     })
 
     it('specifies the correct key to upload it to', async () => {
+      await SendFileToS3Service.go(filenameWithPath, key, false)
+
       const calledCommand = s3Stub.getCall(0).firstArg
 
       expect(calledCommand.input.Key).to.equal(key)
     })
 
     it("also uploads the file to the archive S3 bucket when copyToArchive is 'true'", async () => {
+      await SendFileToS3Service.go(filenameWithPath, key, true)
+
       // Test that the S3 client was called twice
       expect(s3Stub.calledTwice).to.be.true()
 

--- a/test/services/send_file_to_s3.service.test.js
+++ b/test/services/send_file_to_s3.service.test.js
@@ -54,9 +54,11 @@ describe('Send File To S3 service', () => {
   })
 
   describe('When a valid file is specified', () => {
-    it('uploads the file to the S3 bucket', async () => {
+    beforeEach(async () => {
       await SendFileToS3Service.go(filenameWithPath, key, false)
+    })
 
+    it('uploads the file to the S3 bucket', async () => {
       // Test that the S3 client was called once
       expect(s3Stub.calledOnce).to.be.true()
 
@@ -68,9 +70,13 @@ describe('Send File To S3 service', () => {
       expect(calledCommand.input.Bucket).to.equal('TEST_BUCKET')
     })
 
-    it("also uploads the file to the archive S3 bucket when copyToArchive is 'true'", async () => {
-      await SendFileToS3Service.go(filenameWithPath, key, true)
+    it('specifies the correct key to upload it to', async () => {
+      const calledCommand = s3Stub.getCall(0).firstArg
 
+      expect(calledCommand.input.Key).to.equal(key)
+    })
+
+    it("also uploads the file to the archive S3 bucket when copyToArchive is 'true'", async () => {
       // Test that the S3 client was called twice
       expect(s3Stub.calledTwice).to.be.true()
 

--- a/test/services/send_transaction_file.service.test.js
+++ b/test/services/send_transaction_file.service.test.js
@@ -70,7 +70,7 @@ describe('Send Transaction File service', () => {
 
         expect(sendStub.calledOnce).to.be.true()
         expect(sendStub.getCall(0).firstArg).to.equal('stubFilename')
-        expect(sendStub.getCall(0).args[1]).to.equal(`${regime.slug}/transaction/${billRun.fileReference}.dat`)
+        expect(sendStub.getCall(0).args[1]).to.equal(`export/${regime.slug}/transaction/${billRun.fileReference}.dat`)
       })
 
       it("sets the bill run status to 'billed'", async () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/projects/CMEA/boards/907?selectedIssue=CMEA-67

As part of creating the `DataExportService`, we need to be able to specify that we are creating a file whose key starts with `csv/`. During the creation of the original `SendFileToS3Service`, the customer and transaction files were all being given keys starting with `export/` so we built the service to automatically preface keys with this.

This change therefore changes `SendFileToS3Service` to no longer preface keys with `export/`, and updates the services using it (`SendCustomerFileService` and `SendTransactionFileService`) to add it instead. This will therefore enable `DataExportService` to add `csv/` as desired.