### PR TITLE
Create data export endpoint

### DIFF
--- a/app/controllers/admin/test/test_data_export.controller.js
+++ b/app/controllers/admin/test/test_data_export.controller.js
@@ -1,0 +1,14 @@
+'use strict'
+
+const { DataExportService } = require('../../../services')
+
+class TestDataExportController {
+  static async export (req, h) {
+    const result = await DataExportService.go(req.app.notifier)
+    const statusCode = result ? 200 : 400
+
+    return h.response().code(statusCode)
+  }
+}
+
+module.exports = TestDataExportController

--- a/app/controllers/admin/test/test_data_export.controller.js
+++ b/app/controllers/admin/test/test_data_export.controller.js
@@ -5,7 +5,7 @@ const { DataExportService } = require('../../../services')
 class TestDataExportController {
   static async export (req, h) {
     const result = await DataExportService.go(req.app.notifier)
-    const statusCode = result ? 200 : 400
+    const statusCode = result ? 204 : 400
 
     return h.response().code(statusCode)
   }

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -17,6 +17,7 @@ const PresrocCustomerDetailsController = require('./presroc/customer_details.con
 const RegimesController = require('./admin/regimes.controller')
 const TestBillRunsController = require('./admin/test/test_bill_runs.controller')
 const TestCustomerFilesController = require('./admin/test/test_customer_files.controller')
+const TestDataExportController = require('./admin/test/test_data_export.controller')
 const TestTransactionsController = require('./admin/test/test_transactions.controller')
 
 module.exports = {
@@ -36,5 +37,6 @@ module.exports = {
   RootController,
   TestBillRunsController,
   TestCustomerFilesController,
+  TestDataExportController,
   TestTransactionsController
 }

--- a/app/routes/test.routes.js
+++ b/app/routes/test.routes.js
@@ -3,6 +3,7 @@
 const {
   TestBillRunsController,
   TestCustomerFilesController,
+  TestDataExportController,
   TestTransactionsController
 } = require('../controllers')
 
@@ -46,6 +47,17 @@ const routes = [
     handler: TestCustomerFilesController.show,
     options: {
       description: 'Used by the delivery team to show a customer file and its exported customers.',
+      auth: {
+        scope: ['admin']
+      }
+    }
+  },
+  {
+    method: 'PATCH',
+    path: '/admin/test/data-export',
+    handler: TestDataExportController.export,
+    options: {
+      description: 'Used by the delivery team to generate and send export files for testing.',
       auth: {
         scope: ['admin']
       }

--- a/app/services/data_export.service.js
+++ b/app/services/data_export.service.js
@@ -1,7 +1,7 @@
 'use strict'
 
 /**
- * @module ReportingExportService
+ * @module DataExportService
  */
 
 const path = require('path')

--- a/test/controllers/admin/test/test_data_export.controller.test.js
+++ b/test/controllers/admin/test/test_data_export.controller.test.js
@@ -45,7 +45,7 @@ describe('Test data export controller', () => {
     Sinon.restore()
   })
 
-  describe('Show transaction: PATCH /admin/test/data-export', () => {
+  describe('Test data export: PATCH /admin/test/data-export', () => {
     let response
     let dataExportStub
 

--- a/test/controllers/admin/test/test_data_export.controller.test.js
+++ b/test/controllers/admin/test/test_data_export.controller.test.js
@@ -63,8 +63,8 @@ describe('Test data export controller', () => {
         response = await server.inject(options(authToken))
       })
 
-      it('returns a 200 response', async () => {
-        expect(response.statusCode).to.equal(200)
+      it('returns a 204 response', async () => {
+        expect(response.statusCode).to.equal(204)
       })
 
       it('calls the DataExportService', async () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/projects/CMEA/boards/907?selectedIssue=CMEA-56

This change creates the `PATCH /admin/test/data-export` endpoint which can be used to manually trigger the data export process for testing purposes. The controller checks the response from `DataExportService` to see if it succeeds or fails and returns a `204` or `400` response accordingly.