### PR TITLE
Add logging to `DataExportService`

### DIFF
--- a/app/services/data_export.service.js
+++ b/app/services/data_export.service.js
@@ -65,6 +65,7 @@ class DataExportService {
 
       for (table of tables) {
         const file = await ExportTableService.go(table)
+        notifier.omg(`Exported table ${table} to ${file}`)
         files.push(file)
       }
 
@@ -91,6 +92,7 @@ class DataExportService {
       try {
         const key = this._determineKey(file)
         await SendFileToS3Service.go(file, key, false)
+        notifier.omg(`Sent file ${file}`)
       } catch (error) {
         notifier.omfg(
           `Error sending file ${file}`,

--- a/test/services/data_export.service.test.js
+++ b/test/services/data_export.service.test.js
@@ -24,8 +24,8 @@ describe('Data Export service', () => {
     exportTableStub = Sinon.stub(ExportTableService, 'go').callsFake(table => `${table}.csv`)
     sendFileStub = Sinon.stub(SendFileToS3Service, 'go')
 
-    // Create a fake function to stand in place of Notifier.omfg()
-    notifierFake = { omfg: Sinon.fake() }
+    // Create fake functions to stand in place of Notifier.omg() and .omfg()
+    notifierFake = { omg: Sinon.fake(), omfg: Sinon.fake() }
   })
 
   afterEach(() => {
@@ -83,6 +83,22 @@ describe('Data Export service', () => {
         'csv/regimes.csv',
         'csv/transactions.csv'
       ])
+    })
+
+    it('logs each exported table', async () => {
+      const exportedCalls = notifierFake.omg
+        .getCalls()
+        .filter(call => call.firstArg.startsWith('Exported table'))
+
+      expect(exportedCalls.length).to.equal(8)
+    })
+
+    it('logs each sent file', async () => {
+      const sentCalls = notifierFake.omg
+        .getCalls()
+        .filter(call => call.firstArg.startsWith('Sent file'))
+
+      expect(sentCalls.length).to.equal(8)
     })
 
     it('returns true', async () => {


### PR DESCRIPTION
After seeing that [`DataExportTask`](https://github.com/DEFRA/sroc-charging-module-api/pull/505) logs its start and end, we realised it would probably be useful if `DataExportService` also did some logging. We have therefore added log messages when each table is successfully exported to a file, and when each file is successfully sent to S3.