### PR TITLE
Delete `REMOVE_TMP_FILES` environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,7 +50,6 @@ LOG_IN_TEST=false
 
 # Temp file config
 TMPDIR=/tmp/
-REMOVE_TMP_FILES=true
 
 # AWS S3 config
 AWS_REGION=eu-west-1

--- a/app/services/files/customers/send_customer_file.service.js
+++ b/app/services/files/customers/send_customer_file.service.js
@@ -6,9 +6,6 @@
 
 const path = require('path')
 
-const { ServerConfig } = require('../../../../config')
-const { removeTemporaryFiles } = ServerConfig
-
 const { CustomerFileModel } = require('../../../models')
 
 const DeleteFileService = require('../delete_file.service')
@@ -95,9 +92,7 @@ class SendCustomerFileService {
 
         await this._setExportedStatusAndDate(customerFile)
 
-        if (this._removeTemporaryFiles()) {
-          await DeleteFileService.go(generatedFile)
-        }
+        await DeleteFileService.go(generatedFile)
 
         notifier.omg('Completed sending customer file', { regime: regime.slug, region, generatedFile })
       } catch (error) {
@@ -133,13 +128,6 @@ class SendCustomerFileService {
     await SendFileToS3Service.go(generatedFile, key)
 
     return generatedFile
-  }
-
-  /**
-   * Returns the state of the `removeTemporaryFiles` config setting. Kept in a separate method for ease of testing.
-   */
-  static _removeTemporaryFiles () {
-    return removeTemporaryFiles
   }
 }
 

--- a/app/services/files/customers/send_customer_file.service.js
+++ b/app/services/files/customers/send_customer_file.service.js
@@ -30,8 +30,7 @@ class SendCustomerFileService {
    * - Calls GenerateCustomerFileService to generate the customer file
    * - Calls SendFileToS3Service to send the customer file to the S3 bucket
    * - Deletes the linked customer change records
-   * - Sets the `customer_file`s record status to `exported` and `exportedDate` to the current date;
-   * - Deletes the file if `ServerConfig.removeTemporaryFiles` is set to `true`.
+   * - Sets the `customer_file`s record status to `exported` and `exportedDate` to the current date.
    *
    * @param {module:RegimeModel} regime The regime that the customer file is to be generated for.
    * @param {array} regions An arry of regions we want to send a customer file for.

--- a/app/services/files/transactions/send_transaction_file.service.js
+++ b/app/services/files/transactions/send_transaction_file.service.js
@@ -17,7 +17,6 @@ class SendTransactionFileService {
    * - Checks that a transaction file is required;
    * - Calls GenerateTransactionFileService to generate the transaction file;
    * - Calls SendFileToS3Service to send the transaction file to the S3 bucket;
-   * - Deletes the file if ServerConfig.removeTemporaryFiles is set to `true`;
    * - Sets the bill run status to 'billed' if everything was successful.
    *
    * @param {module:RegimeModel} regime The regime that the bill run belongs to. The regime slug will form part of the

--- a/app/services/files/transactions/send_transaction_file.service.js
+++ b/app/services/files/transactions/send_transaction_file.service.js
@@ -6,9 +6,6 @@
 
 const path = require('path')
 
-const { ServerConfig } = require('../../../../config')
-const { removeTemporaryFiles } = ServerConfig
-
 const GenerateTransactionFileService = require('./generate_transaction_file.service')
 const SendFileToS3Service = require('../send_file_to_s3.service')
 const DeleteFileService = require('../delete_file.service')
@@ -46,9 +43,7 @@ class SendTransactionFileService {
       await this._setBilledStatus(billRun)
 
       // We delete the file last of all to ensure we still set the bill run status, even if deletion fails.
-      if (this._removeTemporaryFiles()) {
-        await DeleteFileService.go(generatedFile)
-      }
+      await DeleteFileService.go(generatedFile)
     } catch (error) {
       notifier.omfg('Error sending transaction file', { generatedFile, error })
     }
@@ -81,10 +76,6 @@ class SendTransactionFileService {
 
   static _filename (fileReference) {
     return `${fileReference}.dat`
-  }
-
-  static _removeTemporaryFiles () {
-    return removeTemporaryFiles
   }
 
   static async _setBillingNotRequiredStatus (billRun) {

--- a/config/server.config.js
+++ b/config/server.config.js
@@ -20,8 +20,7 @@ const config = {
       stripTrailingSlash: true
     }
   },
-  temporaryFilePath: process.env.TMPDIR || '/tmp/',
-  removeTemporaryFiles: process.env.REMOVE_TMP_FILES || true
+  temporaryFilePath: process.env.TMPDIR || '/tmp/'
 }
 
 module.exports = config

--- a/test/services/files/customers/send_customer_file.service.test.js
+++ b/test/services/files/customers/send_customer_file.service.test.js
@@ -5,7 +5,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, before, beforeEach, afterEach } = exports.lab = Lab.script()
+const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
@@ -68,10 +68,10 @@ describe('Send Customer File service', () => {
       await CreateCustomerDetailsService.go({ ...payload, region: 'A', customerReference: 'AA12345678' }, regime)
       await CreateCustomerDetailsService.go({ ...payload, region: 'W', customerReference: 'WA87654321' }, regime)
 
-      deleteStub = Sinon.stub(DeleteFileService, 'go').returns(true)
+      deleteStub = Sinon.stub(DeleteFileService, 'go')
       generateStub = Sinon.stub(GenerateCustomerFileService, 'go').callsFake(file => `${file.fileReference}.dat`)
-      sendStub = Sinon.stub(SendFileToS3Service, 'go').returns(true)
-      moveStub = Sinon.stub(MoveCustomerDetailsToExportedTableService, 'go').returns(true)
+      sendStub = Sinon.stub(SendFileToS3Service, 'go')
+      moveStub = Sinon.stub(MoveCustomerDetailsToExportedTableService, 'go')
       Sinon.stub(NextCustomerFileReferenceService, 'go').callsFake((_, region) => `nal${region.toLowerCase()}c50001`)
     })
 
@@ -105,24 +105,8 @@ describe('Send Customer File service', () => {
           expect(args[2]).to.equal(customerFile.id)
         })
 
-        describe('and when removeTemporary files is set to `true`', () => {
-          before(async () => {
-            Sinon.stub(SendCustomerFileService, '_removeTemporaryFiles').returns(true)
-          })
-
-          it('deletes the file', async () => {
-            expect(deleteStub.calledOnce).to.equal(true)
-          })
-        })
-
-        describe('and when removeTemporary files is set to `false`', () => {
-          before(async () => {
-            Sinon.stub(SendCustomerFileService, '_removeTemporaryFiles').returns(false)
-          })
-
-          it("doesn't delete the file", async () => {
-            expect(deleteStub.called).to.equal(false)
-          })
+        it('deletes the file', async () => {
+          expect(deleteStub.calledOnce).to.equal(true)
         })
 
         describe("on the matching 'customer_files' record", () => {
@@ -193,24 +177,8 @@ describe('Send Customer File service', () => {
           expect(secondArgs[2]).to.equal(customerFiles[1].id)
         })
 
-        describe('and when removeTemporary files is set to `true`', () => {
-          before(async () => {
-            Sinon.stub(SendCustomerFileService, '_removeTemporaryFiles').returns(true)
-          })
-
-          it('deletes the file', async () => {
-            expect(deleteStub.calledTwice).to.equal(true)
-          })
-        })
-
-        describe('and when removeTemporary files is set to `false`', () => {
-          before(async () => {
-            Sinon.stub(SendCustomerFileService, '_removeTemporaryFiles').returns(false)
-          })
-
-          it("doesn't delete the file", async () => {
-            expect(deleteStub.called).to.equal(false)
-          })
+        it('deletes the file', async () => {
+          expect(deleteStub.calledTwice).to.equal(true)
         })
 
         describe("on the matching 'customer_files' records", () => {
@@ -268,24 +236,8 @@ describe('Send Customer File service', () => {
           expect(secondArgs[2]).to.equal(customerFiles[1].id)
         })
 
-        describe('and when removeTemporary files is set to `true`', () => {
-          before(async () => {
-            Sinon.stub(SendCustomerFileService, '_removeTemporaryFiles').returns(true)
-          })
-
-          it('deletes the file', async () => {
-            expect(deleteStub.calledTwice).to.equal(true)
-          })
-        })
-
-        describe('and when removeTemporary files is set to `false`', () => {
-          before(async () => {
-            Sinon.stub(SendCustomerFileService, '_removeTemporaryFiles').returns(false)
-          })
-
-          it("doesn't delete the file", async () => {
-            expect(deleteStub.called).to.equal(false)
-          })
+        it('deletes the file', async () => {
+          expect(deleteStub.calledTwice).to.equal(true)
         })
 
         describe("on the matching 'customer_files' records", () => {

--- a/test/services/files/transactions/send_transaction_file.service.test.js
+++ b/test/services/files/transactions/send_transaction_file.service.test.js
@@ -5,7 +5,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, before, beforeEach, afterEach } = exports.lab = Lab.script()
+const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
@@ -36,9 +36,9 @@ describe('Send Transaction File service', () => {
     regime = await RegimeHelper.addRegime('wrls', 'WRLS')
     billRun = await BillRunHelper.addBillRun(regime.id, GeneralHelper.uuid4())
 
-    deleteStub = Sinon.stub(DeleteFileService, 'go').returns(true)
+    deleteStub = Sinon.stub(DeleteFileService, 'go')
     generateStub = Sinon.stub(GenerateTransactionFileService, 'go').returns('stubFilename')
-    sendStub = Sinon.stub(SendFileToS3Service, 'go').returns(true)
+    sendStub = Sinon.stub(SendFileToS3Service, 'go')
 
     // Create a fake function to stand in place of Notifier.omfg()
     notifierFake = { omfg: Sinon.fake() }
@@ -81,28 +81,10 @@ describe('Send Transaction File service', () => {
         expect(refreshedBillRun.status).to.equal('billed')
       })
 
-      describe('and removeTemporary files is set to `true`', () => {
-        before(async () => {
-          Sinon.stub(SendTransactionFileService, '_removeTemporaryFiles').returns(true)
-        })
+      it('deletes the file', async () => {
+        await SendTransactionFileService.go(regime, billRun)
 
-        it('deletes the file', async () => {
-          await SendTransactionFileService.go(regime, billRun)
-
-          expect(deleteStub.calledOnce).to.equal(true)
-        })
-      })
-
-      describe('and removeTemporary files is set to `false`', () => {
-        before(async () => {
-          Sinon.stub(SendTransactionFileService, '_removeTemporaryFiles').returns(false)
-        })
-
-        it("doesn't delete the file", async () => {
-          await SendTransactionFileService.go(regime, billRun)
-
-          expect(deleteStub.called).to.equal(false)
-        })
+        expect(deleteStub.calledOnce).to.equal(true)
       })
     })
 


### PR DESCRIPTION
One of the [SonarCloud warnings we reviewed](https://github.com/DEFRA/sroc-charging-module-api/pull/516) related to the `REMOVE_TMP_FILES` environment variable (which controls whether customer and transaction files should be deleted after being sent to S3. We came to the conclusion that we don't actually need this environment variable -- it defaults to `true`, isn't currently set in any of our environments, and the chances of us ever needing to set it are exceedingly slim. We are therefore removing it.