### PR TITLE
Delete files in `ExportDataFilesService`

### DIFF
--- a/app/services/files/exports/export_data_files.service.js
+++ b/app/services/files/exports/export_data_files.service.js
@@ -8,6 +8,7 @@ const path = require('path')
 
 const ExportTableToFileService = require('./export_table_to_file.service')
 const SendFileToS3Service = require('../send_file_to_s3.service')
+const DeleteFileService = require('../delete_file.service')
 
 class ExportDataFilesService {
   /**
@@ -16,9 +17,10 @@ class ExportDataFilesService {
    * When called it will attempt to export the tables to CSV files. If any one of these fails to export, an error will
    * be logged using notifier, the process will stop, and the service will return `false`.
    *
-   * Once the tables are exported, it will then attempt to send them to an S3 bucket (in the /csv/ 'folder'). If any
-   * file fails to send, an error will be logged using notifier, the process will continue, and once complete the
-   * service will return `false`. If all files are sent successfully then the service will return `true`.
+   * Once the tables are exported, it will then attempt to send them to an S3 bucket (in the /csv/ 'folder'), deleting
+   * each one after it's been sent. If any file fails to send or delete, an error will be logged using notifier, the
+   * process will continue, and once complete the service will return `false`. If all files are sent and deleted
+   * successfully then the service will return `true`.
    *
    * @param {@module:RequestNotifierLib} notifier Instance of `RequestNotifierLib` class. We use it to log errors rather
    * than throwing them as this service is intended to run in the background.
@@ -82,8 +84,9 @@ class ExportDataFilesService {
   }
 
   /**
-   * Receives an array of filenames and sends the files to the S3 bucket. If sending a file fails then an error will be
-   * logged with notifier and it will continue to send the remaining files.
+   * Receives an array of filenames and sends the files to the S3 bucket, deleting each one after it's been sent. If
+   * sending/deleting a file fails then an error will be logged with notifier and it will continue to send the remaining
+   * files.
    */
   static async _sendFiles (files, notifier) {
     let success = true
@@ -92,6 +95,7 @@ class ExportDataFilesService {
       try {
         const key = this._determineKey(file)
         await SendFileToS3Service.go(file, key, false)
+        await DeleteFileService.go(file)
         notifier.omg(`Sent file ${file}`)
       } catch (error) {
         notifier.omfg(

--- a/test/services/files/exports/export_data_files.service.test.js
+++ b/test/services/files/exports/export_data_files.service.test.js
@@ -9,7 +9,11 @@ const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Things we need to stub
-const { ExportTableToFileService, SendFileToS3Service } = require('../../../../app/services')
+const {
+  DeleteFileService,
+  ExportTableToFileService,
+  SendFileToS3Service
+} = require('../../../../app/services')
 
 // Thing under test
 const { ExportDataFiles } = require('../../../../app/services')
@@ -17,12 +21,14 @@ const { ExportDataFiles } = require('../../../../app/services')
 describe('Export Data Files service', () => {
   let exportTableStub
   let sendFileStub
+  let deleteStub
   let notifierFake
   let success
 
   beforeEach(async () => {
     exportTableStub = Sinon.stub(ExportTableToFileService, 'go').callsFake(table => `${table}.csv`)
     sendFileStub = Sinon.stub(SendFileToS3Service, 'go')
+    deleteStub = Sinon.stub(DeleteFileService, 'go')
 
     // Create fake functions to stand in place of Notifier.omg() and .omfg()
     notifierFake = { omg: Sinon.fake(), omfg: Sinon.fake() }
@@ -82,6 +88,22 @@ describe('Export Data Files service', () => {
         'csv/licences.csv',
         'csv/regimes.csv',
         'csv/transactions.csv'
+      ])
+    })
+
+    it('deletes each file', async () => {
+      // firstArg of each call is the file to be deleted, so we map them to an array we can check
+      const keys = deleteStub.getCalls().map(call => call.firstArg)
+
+      expect(keys).to.only.include([
+        'authorised_systems.csv',
+        'bill_runs.csv',
+        'customer_files.csv',
+        'exported_customers.csv',
+        'invoices.csv',
+        'licences.csv',
+        'regimes.csv',
+        'transactions.csv'
       ])
     })
 


### PR DESCRIPTION
We realised that `ExportDataFilesService` wasn't deleting its temp files after sending them to S3, which is inconsistent with how we handle temp files elsewhere (`SendCustomerFileService` and `SendTransactionFileService`). We therefore update `ExportDataFilesService` to do this.