### PR TITLE
Add GitHub actions to Dependabot checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     interval: daily
   open-pull-requests-limit: 10
   versioning-strategy: lockfile-only
+- package-ecosystem: "github-actions"
+  # Workflow files stored in the default location of `.github/workflows`
+  directory: "/"
+  schedule:
+    interval: "daily"


### PR DESCRIPTION
Whilst working on [Add Docker build and push to GitHub workflows](https://github.com/DEFRA/sroc-charging-module-api/pull/522) we spotted in the README for [Docker Build-Push action](https://github.com/marketplace/actions/build-and-push-docker-images) a reference to the fact [Dependabot has native GitHub actions support](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#package-ecosystem).

With 2 workflows using a number of actions, it makes sense to us to ensure we keep up to date with the versions we use in the same way we try and keep up to date with our npm dependencies.

So, this change updates the `dependabot.yml` workflow to include daily checks for our GitHub actions.