### PR TITLE
Fix automatic push to DockerHub

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -62,7 +62,7 @@ jobs:
         run: |
           echo 'ALL_TAGS<<EOF' >> $GITHUB_ENV
           echo "${{ steps.meta.outputs.tags }}" >> $GITHUB_ENV
-          echo "${{ steps.meta.outputs.tags }}" | sed -e 's|${{ env.GHC_REGISTRY }}|docker.io|g' >> $GITHUB_ENV
+          echo "${{ steps.meta.outputs.tags }}" | sed -e 's|${{ env.GHC_REGISTRY }}/defra|docker.io/environmentagency|g' >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
 
       # Build and push Docker image with Buildx


### PR DESCRIPTION
In [Add pushing to DockerHub to Docker workflow](https://github.com/DEFRA/sroc-charging-module-api/pull/527) we updated our Docker workflow to include also pushing the images we are building to DockerHub as well as GitHub Container Registry (GHCR).

However, there is a flaw in our logic. We first generate the metadata used when building the images, including the docker tags, based on pushing to GHCR. We then use [sed](https://en.wikipedia.org/wiki/Sed) to update the tags to replace the GHCR address (`ghcr.io`) with DockerHub's (`docker.io`).

The flaw is we did not take into account the organisation. In GHCR we have permission to push packages to the [DEFRA organisation](https://github.com/DEFRA) but in DockerHub we are using [environmentagency](https://hub.docker.com/repository/docker/environmentagency/sroc-charging-module-api) as Defra has been set up and is controlled by another party.

So, our sed command needs to take this into account when updating the tags for the push to DockerHub to succeed.