### PR TITLE
Fix customer details `null` defect

### DIFF
--- a/app/services/create_customer_details.service.js
+++ b/app/services/create_customer_details.service.js
@@ -34,6 +34,8 @@ class CreateCustomerDetailsService {
 
   static _create (translator) {
     // Implements UPSERT by specifying that the new data should be merged in case of a conflict
+    // Note that we have defaulted all unspecified fields to `null` in the translator to ensure that merging will
+    // overwrite any unspecified fields with `null`
     return CustomerModel.query()
       .insert({ ...translator })
       .onConflict('customerReference')

--- a/app/services/create_customer_details.service.js
+++ b/app/services/create_customer_details.service.js
@@ -37,7 +37,7 @@ class CreateCustomerDetailsService {
     // Note that we have defaulted all unspecified fields to `null` in the translator to ensure that merging will
     // overwrite any unspecified fields with `null`
     return CustomerModel.query()
-      .insert({ ...translator })
+      .insert(translator)
       .onConflict('customerReference')
       .merge()
   }

--- a/app/translators/customer.translator.js
+++ b/app/translators/customer.translator.js
@@ -17,11 +17,13 @@ class CustomerTranslator extends BaseTranslator {
       customerReference: Joi.string().uppercase().max(12).required(),
       customerName: Joi.string().max(360).required(),
       addressLine1: Joi.string().max(240).required(),
-      addressLine2: Joi.string().max(240),
-      addressLine3: Joi.string().max(240),
-      addressLine4: Joi.string().max(240),
-      addressLine5: Joi.string().max(60),
-      addressLine6: Joi.string().max(60),
+      // We default these fields to `null` to ensure that any unspecified fields are overwritten with `null` when
+      // updating an existing record:
+      addressLine2: Joi.string().max(240).default(null),
+      addressLine3: Joi.string().max(240).default(null),
+      addressLine4: Joi.string().max(240).default(null),
+      addressLine5: Joi.string().max(60).default(null),
+      addressLine6: Joi.string().max(60).default(null),
       postcode: Joi.string().max(60).required()
     })
   }

--- a/test/services/create_customer_details.service.test.js
+++ b/test/services/create_customer_details.service.test.js
@@ -64,26 +64,6 @@ describe('Create Customer Details service', () => {
       expect(result[0].postcode).to.equal('NEW_POSTCODE')
     })
 
-    it('sets to `null` anything received as `null`', async () => {
-      await CreateCustomerDetailsService.go(payload, regime)
-      await CreateCustomerDetailsService.go({ ...payload, addressLine2: null }, regime)
-
-      const result = await CustomerModel.query()
-
-      expect(result.length).to.equal(1)
-      expect(result[0].addressLine2).to.equal(null)
-    })
-
-    it('sets to `null` anything received as `undefined`', async () => {
-      await CreateCustomerDetailsService.go(payload, regime)
-      await CreateCustomerDetailsService.go({ ...payload, addressLine2: undefined }, regime)
-
-      const result = await CustomerModel.query()
-
-      expect(result.length).to.equal(1)
-      expect(result[0].addressLine2).to.equal(null)
-    })
-
     it('sets to `null` anything not received', async () => {
       const partialPayload = payload
       delete partialPayload.addressLine2

--- a/test/services/create_customer_details.service.test.js
+++ b/test/services/create_customer_details.service.test.js
@@ -63,6 +63,39 @@ describe('Create Customer Details service', () => {
       expect(result.length).to.equal(1)
       expect(result[0].postcode).to.equal('NEW_POSTCODE')
     })
+
+    it('sets to `null` anything received as `null`', async () => {
+      await CreateCustomerDetailsService.go(payload, regime)
+      await CreateCustomerDetailsService.go({ ...payload, addressLine2: null }, regime)
+
+      const result = await CustomerModel.query()
+
+      expect(result.length).to.equal(1)
+      expect(result[0].addressLine2).to.equal(null)
+    })
+
+    it('sets to `null` anything received as `undefined`', async () => {
+      await CreateCustomerDetailsService.go(payload, regime)
+      await CreateCustomerDetailsService.go({ ...payload, addressLine2: undefined }, regime)
+
+      const result = await CustomerModel.query()
+
+      expect(result.length).to.equal(1)
+      expect(result[0].addressLine2).to.equal(null)
+    })
+
+    it('sets to `null` anything not received', async () => {
+      const partialPayload = payload
+      delete partialPayload.addressLine2
+
+      await CreateCustomerDetailsService.go(payload, regime)
+      await CreateCustomerDetailsService.go(partialPayload, regime)
+
+      const result = await CustomerModel.query()
+
+      expect(result.length).to.equal(1)
+      expect(result[0].addressLine2).to.equal(null)
+    })
   })
 
   describe('When an invalid payload is supplied', () => {

--- a/test/translators/customer.translator.test.js
+++ b/test/translators/customer.translator.test.js
@@ -44,6 +44,26 @@ describe('Customer translator', () => {
         expect(result.customerReference).to.equal('CUSTOMERREF1')
       })
     })
+
+    describe('when not passed address lines 2-6', () => {
+      it('defaults to `null`', async () => {
+        const validInput = input
+        delete validInput.addressLine2
+        delete validInput.addressLine3
+        delete validInput.addressLine4
+        delete validInput.addressLine5
+        delete validInput.addressLine6
+
+        const result = new CustomerTranslator(validInput)
+
+        expect(result).to.not.be.an.error()
+        expect(result.addressLine2).to.equal(null)
+        expect(result.addressLine3).to.equal(null)
+        expect(result.addressLine4).to.equal(null)
+        expect(result.addressLine5).to.equal(null)
+        expect(result.addressLine6).to.equal(null)
+      })
+    })
   })
 
   describe('Validation', () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/projects/CMEA/boards/907?selectedIssue=CMEA-137

WRLS reported an issue with the customer details functionality. When submitting a customer record for a customer who already has a record, we should essentially overwrite the entire existing record with the new one. However what currently happens is that we only _update_ the existing record.

Say for example we have the following customer record:

```
{
    "region": "A",
    "customerReference": "AA11AAAA",
    "customerName": "Customer Name",
    "addressLine1": "House name",
    "addressLine2": "Street name",
    "addressLine3": "Town",
    "addressLine4": "County",
    "postcode": "PO57 0DE"
}
```

We want to change the details to remove the town and county. We submit the following customer change:

```
{
    "region": "A",
    "customerReference": "AA11AAAA",
    "customerName": "Customer Name",
    "addressLine1": "House name",
    "addressLine2": "Street name",
    "addressLine3": null,
    "postcode": "PO57 0DE"
}
```

Setting `addressLine3` to `null` should set it to `null` in the database. Not including `addressLine4` in the request should also set it to `null`. However neither of these have any effect.

Observing how the the endpoint and service interact tells us the following:
* Any items not included in a request are similarly not included in the payload passed to `CreateCustomerDetailsService` (eg. `addressLine4` in the above example). This also applies to any items set to `null` in the request (eg. `addressLine3`).
* Once received by the service, we put the payload through the `CustomerTranslator`. At this stage, any items not in the payload are created with a default value of `undefined`.
* Finally, when we UPSERT the record, any items set to `undefined` are ignored so the existing value is kept.

We found that if we were to UPSERT a record containing `null` for the missing items, the existing values would be overwritten with `null`. We initially looked at doing this in `CreateCustomerDetailsService` but it would have led to a more convoluted process of translating the payload, then updating this translated payload to change fields with an `undefined` value to `null`. The simpler solution we went with was simply to change `CustomerTranslator` to default missing address fields to `null`.

We have added a test to `CreateCustomerDetailsService` to confirm that a missing address lines is overwritten with `null`. Note that we do not test other scenarios such as being passed `null` as this simply cannot happen -- as stated above, anything received as `null` is removed from the payload completely and therefore would not have a null value passed to `CreateCustomerDetailsService`.