### PR TITLE
Remove `GET /admin/{regimeId}/customers` endpoint

### DIFF
--- a/app/controllers/admin/customers.controller.js
+++ b/app/controllers/admin/customers.controller.js
@@ -12,10 +12,6 @@ class CustomersController {
 
     return h.response().code(204)
   }
-
-  static async show (_req, h) {
-    return h.response().code(204)
-  }
 }
 
 module.exports = CustomersController

--- a/app/routes/customer.routes.js
+++ b/app/routes/customer.routes.js
@@ -12,16 +12,6 @@ const routes = [
         scope: ['admin']
       }
     }
-  },
-  {
-    method: 'GET',
-    path: '/admin/{regimeId}/customers',
-    handler: CustomersController.show,
-    options: {
-      auth: {
-        scope: ['admin']
-      }
-    }
   }
 ]
 

--- a/test/controllers/admin/customers.controller.test.js
+++ b/test/controllers/admin/customers.controller.test.js
@@ -74,20 +74,4 @@ describe('Customers controller', () => {
       expect(serviceStub.calledOnce).to.be.true()
     })
   })
-
-  describe('Show customer files: GET /admin/{regimeId}/customers', () => {
-    const options = token => {
-      return {
-        method: 'GET',
-        url: '/admin/wrls/customers',
-        headers: { authorization: `Bearer ${token}` }
-      }
-    }
-
-    it('returns success status 204', async () => {
-      const response = await server.inject(options(authToken))
-
-      expect(response.statusCode).to.equal(204)
-    })
-  })
 })


### PR DESCRIPTION
When developing the QA customer files endpoints, we created a dummy endpoint `GET /admin/{regimeId}/customers` prior to creating `ListCustomerFilesService`. However during development, another endpoint `GET /admin/test/{regime}/customer-files` was created which we eventually used, but we did not remove the original incorrect endpoint. This change resolves this.