### PR TITLE
Create `StreamTransformDatRowService`

### DIFF
--- a/app/services/files/transform_records_to_file.service.js
+++ b/app/services/files/transform_records_to_file.service.js
@@ -11,7 +11,7 @@ const { temporaryFilePath } = require('../../../config/server.config')
 
 const StreamReadableDataService = require('../streams/stream_readable_data.service')
 const StreamReadableRecordsService = require('../streams/stream_readable_records.service')
-const StreamTransformCSVService = require('../streams/stream_transform_csv.service')
+const StreamTransformDatRowService = require('../streams/stream_transform_dat_row.service')
 const StreamTransformUsingPresenterService = require('../streams/stream_transform_using_presenter.service')
 const StreamWritableFileService = require('../streams/stream_writable_file.service')
 
@@ -61,8 +61,8 @@ class TransformRecordsToFileService {
   }
 
   /**
-   * Transforms a stream of data and writes it to a file in CSV format. Intended to be used to write a "section" of a
-   * file, ie. head, body or tail.
+   * Transforms a stream of data and writes it to a file in dat format (ie. quotes around everything and
+   * comma-separated). Intended to be used to write a "section" of a file, ie. head, body or tail.
    *
    * @param {ReadableStream} inputStream The stream of data to be written.
    * @param {module:Presenter} presenter The presenter to use to transform the data.
@@ -83,7 +83,7 @@ class TransformRecordsToFileService {
     await promisifiedPipeline(
       inputStream,
       this._presenterTransformStream(presenter, additionalData, lineCount),
-      this._csvTransformStream(),
+      this._datTransformStream(),
       this._writeToFileStream(filenameWithPath, append)
     )
 
@@ -146,10 +146,10 @@ class TransformRecordsToFileService {
   }
 
   /**
-   * Transform stream which returns a comma-separated row of data, terminating in a newline.
+   * Transform stream which returns a quoted and comma-separated row of data, terminating in a newline.
    */
-  static _csvTransformStream () {
-    return StreamTransformCSVService.go()
+  static _datTransformStream () {
+    return StreamTransformDatRowService.go()
   }
 
   /**

--- a/app/services/index.js
+++ b/app/services/index.js
@@ -59,6 +59,7 @@ const ShowTransactionService = require('./transactions/show_transaction.service'
 const StreamReadableDataService = require('./streams/stream_readable_data.service')
 const StreamReadableRecordsService = require('./streams/stream_readable_records.service')
 const StreamTransformCSVService = require('./streams/stream_transform_csv.service')
+const StreamTransformDatRowService = require('./streams/stream_transform_dat_row.service')
 const StreamTransformUsingPresenterService = require('./streams/stream_transform_using_presenter.service')
 const StreamWritableFileService = require('./streams/stream_writable_file.service')
 const TransformRecordsToFileService = require('./files/transform_records_to_file.service')
@@ -129,6 +130,7 @@ module.exports = {
   StreamReadableDataService,
   StreamReadableRecordsService,
   StreamTransformCSVService,
+  StreamTransformDatRowService,
   StreamTransformUsingPresenterService,
   StreamWritableFileService,
   TransformRecordsToFileService,

--- a/app/services/streams/stream_transform_dat_row.service.js
+++ b/app/services/streams/stream_transform_dat_row.service.js
@@ -1,0 +1,31 @@
+'use strict'
+
+/**
+ * @module StreamTransformDatRowService
+ */
+
+const { Transform } = require('stream')
+
+/**
+ * Returns a Transform stream which turns an incoming array into a dat row, ie. comma-separated, with each element
+ * wrapped in double quotes, and ending with a newline.
+ *
+ * @returns {TransformStream} A stream of data.
+ */
+class StreamTransformDatRowService {
+  static go () {
+    return new Transform({
+      objectMode: true,
+      transform: function (array, _encoding, callback) {
+        const datRow = array
+          .map(element => `"${element}"`)
+          .join()
+          .concat('\n')
+
+        callback(null, datRow)
+      }
+    })
+  }
+}
+
+module.exports = StreamTransformDatRowService

--- a/test/services/streams/stream_transform_dat_row.service.test.js
+++ b/test/services/streams/stream_transform_dat_row.service.test.js
@@ -1,0 +1,36 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it } = exports.lab = Lab.script()
+const { expect } = Code
+
+const stream = require('stream')
+
+// Test helpers
+const { StreamHelper } = require('../../support/helpers')
+
+// Thing under test
+const { StreamTransformDatRowService } = require('../../../app/services')
+
+describe('Stream Transform Dat Row service', () => {
+  describe('When data is passed to it', () => {
+    it('returns a stream', async () => {
+      const result = StreamTransformDatRowService.go()
+
+      expect(result).to.be.an.instanceof(stream.Stream)
+    })
+
+    it('streams the correct data', async () => {
+      const testData = ['first', 2, false]
+
+      const transformStream = StreamTransformDatRowService.go()
+      // We use destructuring to pull the sole element of the array into result
+      const [result] = await StreamHelper.testTransformStream(transformStream, testData)
+
+      expect(result).to.equal('"first","2","false"\n')
+    })
+  })
+})


### PR DESCRIPTION
We realised that the format we export customer and transaction files is not strictly CSV, and therefore we need to handle this format differently to the tables we export for reporting purposes (which _are_ in CSV format). As the customer and transaction files have a `.dat` extension, we will therefore refer to this format as "dat". 

This change implements `StreamTransformDatRowService`, which we use to put a stream of data into dat format.