### PR TITLE
Create `DeprecatedEndpointService`

### DIFF
--- a/app/services/index.js
+++ b/app/services/index.js
@@ -21,6 +21,7 @@ const DeleteBillRunService = require('./bill_runs/delete_bill_run.service')
 const DeleteFileService = require('./files/delete_file.service')
 const DeleteInvoiceService = require('./invoices/delete_invoice.service')
 const DeleteLicenceService = require('./licences/delete_licence.service')
+const DeprecatedEndpointService = require('./plugins/deprecated_endpoint.service')
 const ExportDataFiles = require('./files/exports/export_data_files.service')
 const ExportTableToFileService = require('./files/exports/export_table_to_file.service')
 const FetchAndValidateInvoiceService = require('./invoices/fetch_and_validate_invoice.service')
@@ -93,6 +94,7 @@ module.exports = {
   DeleteFileService,
   DeleteInvoiceService,
   DeleteLicenceService,
+  DeprecatedEndpointService,
   ExportDataFiles,
   ExportTableToFileService,
   FetchAndValidateInvoiceService,

--- a/app/services/plugins/deprecated_endpoint.service.js
+++ b/app/services/plugins/deprecated_endpoint.service.js
@@ -1,0 +1,36 @@
+
+'use strict'
+
+/**
+ * @module DeprecatedEndpointService
+ */
+
+class DeprecatedEndpointService {
+  /**
+   * Receives a route, checks to see if it has been deprecated (based on the options added to
+   * `route.options.app.deprecated` in the route file), and if so returns an object containing headers to be added to
+   * the request:
+   * - If the `deprecated` object exists in `route.options.app` then `headers.deprecation` will be set to `true`.
+   * - If `deprecated.succeeded` is `true` and `deprecated.successor` exists then `headers.link` will contain a link
+   *   to the succeeding endpoint.
+   *
+   * @param {object} route The route object to be checked.
+   * @returns {object} Headers to be added to the request.
+   */
+  static go (route) {
+    const headers = {}
+    const { deprecated } = route.settings?.app
+
+    if (deprecated) {
+      headers.deprecation = true
+    }
+
+    if (deprecated?.succeeded && deprecated.successor) {
+      headers.link = `<${deprecated.successor}>; rel="successor-version"`
+    }
+
+    return headers
+  }
+}
+
+module.exports = DeprecatedEndpointService

--- a/test/services/plugins/deprecated_endpoint.service.test.js
+++ b/test/services/plugins/deprecated_endpoint.service.test.js
@@ -1,0 +1,53 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Thing under test
+const { DeprecatedEndpointService } = require('../../../app/services')
+
+describe('Deprecated Endpoint service', () => {
+  describe('when the route is deprecated', () => {
+    describe('and the route is succeeded', () => {
+      it('returns a header object with deprecation and link', () => {
+        const app = {
+          deprecated: {
+            succeeded: true,
+            successor: '/replacement-path'
+          }
+        }
+        const result = DeprecatedEndpointService.go({ settings: { app } })
+
+        expect(result.deprecation).to.be.true()
+        expect(result.link).to.equal('</replacement-path>; rel="successor-version"')
+      })
+    })
+
+    describe('and the route is not succeeded', () => {
+      it('returns a header object with deprecation and without link', () => {
+        const app = {
+          deprecated: {
+            succeeded: false
+          }
+        }
+        const result = DeprecatedEndpointService.go({ settings: { app } })
+
+        expect(result.deprecation).to.be.true()
+        expect(result.link).to.not.exist()
+      })
+    })
+  })
+
+  describe('when the route is not deprecated', () => {
+    it('returns an empty header object', () => {
+      const app = { }
+      const result = DeprecatedEndpointService.go({ settings: { app } })
+
+      expect(result).to.be.empty()
+    })
+  })
+})


### PR DESCRIPTION
As part of our versioning strategy, we wish to be able to mark endpoints as deprecated and optionally provide the endpoint that will be succeeding them. The first stage of implementing this is to create `DeprecatedEndpointService`. This accepts a route, parses its options, and determines whether it is deprecated and if it is being succeeded by another endpoint. It then returns an object containing headers to be added to the response. We use the `deprecation` and `link` headers documented  here:

https://blog.stoplight.io/deprecating-api-endpoints
https://tools.ietf.org/html/draft-dalal-deprecation-header-03

As an example, say an endpoint has the following added to its options:
```js
options: {
  app: {
    deprecated: {
      succeeded: true,
      successor: '/new-link'
    }
  }
}
```

The service will return the following headers:

```js
{
  deprecation: true,
  link: '</new-link>; rel="successor-version"'
}
```