### PR TITLE
Generate and add unique tag in docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -55,6 +55,8 @@ jobs:
       #    of the string is interpreted as a command
       #  - GitHub action's `set-output` truncates multiline strings which is why we have resorted to what you see below
       #    to get a value which contains all the possible tags as a multiline string
+      #  - the 'if' determines if this is a push to `main` or a new tag. If a push to `main` we add a unique tag, for
+      #    example `v0.13.2-2-g9ce6d11`. This is to support testing
       #
       # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#multiline-strings
       # https://github.community/t/set-output-truncates-multiline-strings/16852/8
@@ -63,6 +65,7 @@ jobs:
           echo 'ALL_TAGS<<EOF' >> $GITHUB_ENV
           echo "${{ steps.meta.outputs.tags }}" >> $GITHUB_ENV
           echo "${{ steps.meta.outputs.tags }}" | sed -e 's|${{ env.GHC_REGISTRY }}/defra|docker.io/environmentagency|g' >> $GITHUB_ENV
+          if [ ${{ startsWith(github.ref, 'refs/tags/v') }} = false ]; then echo "${{env.GHC_REGISTRY}}/${{env.IMAGE_NAME}}:$(git describe --always --tags)"; fi >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
 
       # Build and push Docker image with Buildx


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/CMEA-135

Though we are now building Docker images using a GitHub workflow, we inherited a process that is run on a Jenkins instance and pushes to a private [Artifactory](https://jfrog.com/artifactory/) instance. There is no sense in building an image in 2 places. Plus, if we build in just one place we know the image that's on [DockerHub](https://hub.docker.com/repository/docker/environmentagency/sroc-charging-module-api), in [GitHub Container Registry](https://github.com/DEFRA/sroc-charging-module-api/pkgs/container/sroc-charging-module-api), and in our Artifactory instance is one and the same.

Added to that we have been seeing more and more issues when the Jenkins instance builds. We're not sure of the reasons why but now when building we can expect the Jenkins instance to go offline, returning a `504 - Gateway timeout` until such time as the build process finishes. This just adds wait to our need to update or replace the inherited process.

The one thing it does differently is that when a change is made to `main` and a new image is built, it tags that image uniquely using `git describe --always --tags`. This returns, for example, `v0.13.2-2-g9ce6d11`. This is needed to support our testing efforts. When a feature is done our QA will deploy the latest image that includes it to our `TEST` environment. What image is deployed is selected using its [tag](https://docs.docker.com/engine/reference/commandline/tag/). They'll then start their testing. At the end of the day, our non-production environments automatically switch off (a Defra group-wide policy to save money). Unlike standard EC2 based environments, when we wake our environment up in the morning new containers will be started based on the image tag selected. _If_ the tag was `main` and new changes had been merged since testing started the containers that get started would be different from those the previous day.

This can lead to confusion and a lack of confidence in the test result, especially if a change causes existing tests to return different results. This is why our existing process generates and applies a unique tag. If the images deployed to `TEST` use these unique tags the QA can be confident that any time a new container is started it will be based on the same image as when they began testing.

So, this change updates the existing Docker workflow to generate and apply the unique tag but only for changes to `main` (new git tags are ignored).

***Git based tag breakdown***

`git describe` returns a human readable name based on the current commit reference, for example, `v0.13.2-2-g9ce6d11`.

> The command finds the most recent tag that is reachable from a commit. If the tag points to the commit, then only the tag is shown. Otherwise, it suffixes the tag name with the number of additional commits on top of the tagged object and the abbreviated object name of the most recent commit. The result is a "human-readable" object name which can also be used to identify the commit to other git commands.
>
> [Git docs for git-describe](https://git-scm.com/docs/git-describe)

Our example `v0.13.2-2-g9ce6d11` broken down means

- the last tag created for my main branch was `v0.13.2`
- there have been **2** commits to the `main` branch since that tag was created
- the abbreviated commit reference for the lastest commit is `9ce6d11`

The `g` just denotes that the source control system is git.

For reference, the `git describe --always --tags` command broken down means

- `--always` if no tags existed nothing would be shown. As a fallback, we include this argument to tell it to always return the abbreviated commit reference for the last commit.
- `--tags` by default the command only works with annotated tags which is fine for us as that's all we use. But just in case we tell it to reference all tags created, annotated and lightweight