### PR TITLE
Fix 2 - issue with unique Docker Tag

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Shallow clones block `git describe --always --tags` from working later in 'Set all tags'
 
       # Login against DockerHub
       # https://github.com/docker/login-action
@@ -65,7 +67,7 @@ jobs:
           echo 'ALL_TAGS<<EOF' >> $GITHUB_ENV
           echo "${{ steps.meta.outputs.tags }}" >> $GITHUB_ENV
           echo "${{ steps.meta.outputs.tags }}" | sed -e 's|${{ env.GHC_REGISTRY }}/defra|docker.io/environmentagency|g' >> $GITHUB_ENV
-          if [ ${{ startsWith(github.ref, 'refs/tags/v') }} = false ]; then echo "ghcr.io/defa/sroc-charging-mdoule-api:$(git describe --always --tags)"; fi >> $GITHUB_ENV
+          if [ ${{ startsWith(github.ref, 'refs/tags/v') }} = false ]; then echo "ghcr.io/defra/sroc-charging-module-api:$(git describe --always --tags)"; fi >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
 
       # Build and push Docker image with Buildx


### PR DESCRIPTION
In [Generate and add unique tag in Docker workflow](https://github.com/DEFRA/sroc-charging-module-api/pull/543) we added a unique Docker tag for changes to `main`. In [Fix uppercase org name in unique docker tag](https://github.com/DEFRA/sroc-charging-module-api/commit/a074aada8b69cde7ab107a59cc0511ebd35c8226) we sorted an issue with the custom tag not being lowercase.

Unfortunately, the last fix had a typo 🤦. But we have also spotted the tag being generated is just the commit hash (`a074aad`). It should be like `v0.13.2-2-a074aad`.

This change fixes both issues.