### PR TITLE
Rename show endpoints to view

### DIFF
--- a/app/controllers/admin/authorised_systems.controller.js
+++ b/app/controllers/admin/authorised_systems.controller.js
@@ -3,7 +3,7 @@
 const {
   CreateAuthorisedSystemService,
   ListAuthorisedSystemsService,
-  ShowAuthorisedSystemService,
+  ViewAuthorisedSystemService,
   UpdateAuthorisedSystemService
 } = require('../../services')
 
@@ -14,8 +14,8 @@ class AuthorisedSystemsController {
     return h.response(result).code(200)
   }
 
-  static async show (req, h) {
-    const result = await ShowAuthorisedSystemService.go(req.params.id)
+  static async view (req, h) {
+    const result = await ViewAuthorisedSystemService.go(req.params.id)
 
     return h.response(result).code(200)
   }

--- a/app/controllers/admin/regimes.controller.js
+++ b/app/controllers/admin/regimes.controller.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { ListRegimesService, ShowRegimeService } = require('../../services')
+const { ListRegimesService, ViewRegimeService } = require('../../services')
 
 class RegimesController {
   static async index (_req, h) {
@@ -9,8 +9,8 @@ class RegimesController {
     return h.response(result).code(200)
   }
 
-  static async show (req, h) {
-    const result = await ShowRegimeService.go(req.params.id)
+  static async view (req, h) {
+    const result = await ViewRegimeService.go(req.params.id)
 
     return h.response(result).code(200)
   }

--- a/app/controllers/admin/test/test_customer_files.controller.js
+++ b/app/controllers/admin/test/test_customer_files.controller.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { ListCustomerFilesService, ShowCustomerFileService } = require('../../../services')
+const { ListCustomerFilesService, ViewCustomerFileService } = require('../../../services')
 
 class TestCustomerFilesController {
   static async index (req, h) {
@@ -9,8 +9,8 @@ class TestCustomerFilesController {
     return h.response(result).code(200)
   }
 
-  static async show (req, h) {
-    const result = await ShowCustomerFileService.go(req.params.id)
+  static async view (req, h) {
+    const result = await ViewCustomerFileService.go(req.params.id)
 
     return h.response(result).code(200)
   }

--- a/app/controllers/admin/test/test_transactions.controller.js
+++ b/app/controllers/admin/test/test_transactions.controller.js
@@ -1,10 +1,10 @@
 'use strict'
 
-const { ShowTransactionService } = require('../../../services')
+const { ViewTransactionService } = require('../../../services')
 
 class TestTransactionsController {
-  static async show (req, h) {
-    const result = await ShowTransactionService.go(req.params.id)
+  static async view (req, h) {
+    const result = await ViewTransactionService.go(req.params.id)
 
     return h.response(result).code(200)
   }

--- a/app/routes/authorised_system.routes.js
+++ b/app/routes/authorised_system.routes.js
@@ -16,7 +16,7 @@ const routes = [
   {
     method: 'GET',
     path: '/admin/authorised-systems/{id}',
-    handler: AuthorisedSystemsController.show,
+    handler: AuthorisedSystemsController.view,
     options: {
       auth: {
         scope: ['admin']

--- a/app/routes/regime.routes.js
+++ b/app/routes/regime.routes.js
@@ -16,7 +16,7 @@ const routes = [
   {
     method: 'GET',
     path: '/admin/regimes/{id}',
-    handler: RegimesController.show,
+    handler: RegimesController.view,
     options: {
       auth: {
         scope: ['admin']

--- a/app/routes/test.routes.js
+++ b/app/routes/test.routes.js
@@ -44,9 +44,9 @@ const routes = [
   {
     method: 'GET',
     path: '/admin/test/customer-files/{id}',
-    handler: TestCustomerFilesController.show,
+    handler: TestCustomerFilesController.view,
     options: {
-      description: 'Used by the delivery team to show a customer file and its exported customers.',
+      description: 'Used by the delivery team to view a customer file and its exported customers.',
       auth: {
         scope: ['admin']
       }

--- a/app/routes/test.routes.js
+++ b/app/routes/test.routes.js
@@ -22,7 +22,7 @@ const routes = [
   {
     method: 'GET',
     path: '/admin/test/transactions/{id}',
-    handler: TestTransactionsController.show,
+    handler: TestTransactionsController.view,
     options: {
       description: "Used by the delivery team to check all a transaction's data.",
       auth: {

--- a/app/services/authorised_systems/view_authorised_system.service.js
+++ b/app/services/authorised_systems/view_authorised_system.service.js
@@ -1,7 +1,7 @@
 'use strict'
 
 /**
- * @module ShowAuthorisedSystemService
+ * @module ViewAuthorisedSystemService
  */
 
 const Boom = require('@hapi/boom')
@@ -17,7 +17,7 @@ const { JsonPresenter } = require('../../presenters')
  * @param {string} id Id of the regime to find
  * @returns {module:AuthorisedSystemModel} an `AuthorisedSystemModel` if found else it will throw a Boom 404 error
  */
-class ShowAuthorisedSystemService {
+class ViewAuthorisedSystemService {
   static async go (id) {
     const authorisedSystem = await this._authorisedSystem(id)
 
@@ -41,4 +41,4 @@ class ShowAuthorisedSystemService {
   }
 }
 
-module.exports = ShowAuthorisedSystemService
+module.exports = ViewAuthorisedSystemService

--- a/app/services/files/customers/view_customer_file.service.js
+++ b/app/services/files/customers/view_customer_file.service.js
@@ -1,7 +1,7 @@
 'use strict'
 
 /**
- * @module ShowCustomerFileService
+ * @module ViewCustomerFileService
  */
 
 const Boom = require('@hapi/boom')
@@ -17,7 +17,7 @@ const { JsonPresenter } = require('../../../presenters')
  * @param {string} id Id of the customer file to find
  * @returns {module:CustomerFileModel} a `CustomerFileModel` if found else it will throw a Boom 404 error
  */
-class ShowCustomerFileService {
+class ViewCustomerFileService {
   static async go (id) {
     const customerFile = await this._customerFile(id)
 
@@ -41,4 +41,4 @@ class ShowCustomerFileService {
   }
 }
 
-module.exports = ShowCustomerFileService
+module.exports = ViewCustomerFileService

--- a/app/services/index.js
+++ b/app/services/index.js
@@ -53,7 +53,6 @@ const SendBillRunReferenceService = require('./bill_runs/send_bill_run_reference
 const SendCustomerFileService = require('./files/customers/send_customer_file.service')
 const SendFileToS3Service = require('./files/send_file_to_s3.service')
 const SendTransactionFileService = require('./files/transactions/send_transaction_file.service')
-const ShowTransactionService = require('./transactions/show_transaction.service')
 const StreamReadableDataService = require('./streams/stream_readable_data.service')
 const StreamReadableRecordsService = require('./streams/stream_readable_records.service')
 const StreamTransformCSVRowService = require('./streams/stream_transform_csv_row.service')
@@ -70,6 +69,7 @@ const ViewBillRunService = require('./bill_runs/view_bill_run.service')
 const ViewCustomerFileService = require('./files/customers/view_customer_file.service')
 const ViewInvoiceService = require('./invoices/view_invoice.service')
 const ViewRegimeService = require('./regimes/view_regime.service')
+const ViewTransactionService = require('./transactions/view_transaction.service')
 
 module.exports = {
   AdminSendTransactionFileService,
@@ -125,7 +125,6 @@ module.exports = {
   SendCustomerFileService,
   SendFileToS3Service,
   SendTransactionFileService,
-  ShowTransactionService,
   StreamReadableDataService,
   StreamReadableRecordsService,
   StreamTransformCSVRowService,
@@ -141,5 +140,6 @@ module.exports = {
   ViewBillRunService,
   ViewCustomerFileService,
   ViewInvoiceService,
-  ViewRegimeService
+  ViewRegimeService,
+  ViewTransactionService
 }

--- a/app/services/index.js
+++ b/app/services/index.js
@@ -53,7 +53,6 @@ const SendBillRunReferenceService = require('./bill_runs/send_bill_run_reference
 const SendCustomerFileService = require('./files/customers/send_customer_file.service')
 const SendFileToS3Service = require('./files/send_file_to_s3.service')
 const SendTransactionFileService = require('./files/transactions/send_transaction_file.service')
-const ShowAuthorisedSystemService = require('./authorised_systems/show_authorised_system.service')
 const ShowCustomerFileService = require('./files/customers/show_customer_file.service')
 const ShowRegimeService = require('./regimes/show_regime.service')
 const ShowTransactionService = require('./transactions/show_transaction.service')
@@ -68,6 +67,7 @@ const TransformTableToFileService = require('./files/transform_table_to_file.ser
 const UpdateAuthorisedSystemService = require('./authorised_systems/update_authorised_system.service')
 const ValidateBillRunLicenceService = require('./licences/validate_bill_run_licence.service')
 const ValidateBillRunRegion = require('./bill_runs/validate_bill_run_region.service')
+const ViewAuthorisedSystemService = require('./authorised_systems/view_authorised_system.service')
 const ViewBillRunService = require('./bill_runs/view_bill_run.service')
 const ViewInvoiceService = require('./invoices/view_invoice.service')
 
@@ -125,7 +125,6 @@ module.exports = {
   SendCustomerFileService,
   SendFileToS3Service,
   SendTransactionFileService,
-  ShowAuthorisedSystemService,
   ShowCustomerFileService,
   ShowRegimeService,
   ShowTransactionService,
@@ -140,6 +139,7 @@ module.exports = {
   UpdateAuthorisedSystemService,
   ValidateBillRunLicenceService,
   ValidateBillRunRegion,
+  ViewAuthorisedSystemService,
   ViewBillRunService,
   ViewInvoiceService
 }

--- a/app/services/index.js
+++ b/app/services/index.js
@@ -54,7 +54,6 @@ const SendCustomerFileService = require('./files/customers/send_customer_file.se
 const SendFileToS3Service = require('./files/send_file_to_s3.service')
 const SendTransactionFileService = require('./files/transactions/send_transaction_file.service')
 const ShowCustomerFileService = require('./files/customers/show_customer_file.service')
-const ShowRegimeService = require('./regimes/show_regime.service')
 const ShowTransactionService = require('./transactions/show_transaction.service')
 const StreamReadableDataService = require('./streams/stream_readable_data.service')
 const StreamReadableRecordsService = require('./streams/stream_readable_records.service')
@@ -70,6 +69,7 @@ const ValidateBillRunRegion = require('./bill_runs/validate_bill_run_region.serv
 const ViewAuthorisedSystemService = require('./authorised_systems/view_authorised_system.service')
 const ViewBillRunService = require('./bill_runs/view_bill_run.service')
 const ViewInvoiceService = require('./invoices/view_invoice.service')
+const ViewRegimeService = require('./regimes/view_regime.service')
 
 module.exports = {
   AdminSendTransactionFileService,
@@ -126,7 +126,6 @@ module.exports = {
   SendFileToS3Service,
   SendTransactionFileService,
   ShowCustomerFileService,
-  ShowRegimeService,
   ShowTransactionService,
   StreamReadableDataService,
   StreamReadableRecordsService,
@@ -141,5 +140,6 @@ module.exports = {
   ValidateBillRunRegion,
   ViewAuthorisedSystemService,
   ViewBillRunService,
-  ViewInvoiceService
+  ViewInvoiceService,
+  ViewRegimeService
 }

--- a/app/services/index.js
+++ b/app/services/index.js
@@ -53,7 +53,6 @@ const SendBillRunReferenceService = require('./bill_runs/send_bill_run_reference
 const SendCustomerFileService = require('./files/customers/send_customer_file.service')
 const SendFileToS3Service = require('./files/send_file_to_s3.service')
 const SendTransactionFileService = require('./files/transactions/send_transaction_file.service')
-const ShowCustomerFileService = require('./files/customers/show_customer_file.service')
 const ShowTransactionService = require('./transactions/show_transaction.service')
 const StreamReadableDataService = require('./streams/stream_readable_data.service')
 const StreamReadableRecordsService = require('./streams/stream_readable_records.service')
@@ -68,6 +67,7 @@ const ValidateBillRunLicenceService = require('./licences/validate_bill_run_lice
 const ValidateBillRunRegion = require('./bill_runs/validate_bill_run_region.service')
 const ViewAuthorisedSystemService = require('./authorised_systems/view_authorised_system.service')
 const ViewBillRunService = require('./bill_runs/view_bill_run.service')
+const ViewCustomerFileService = require('./files/customers/view_customer_file.service')
 const ViewInvoiceService = require('./invoices/view_invoice.service')
 const ViewRegimeService = require('./regimes/view_regime.service')
 
@@ -125,7 +125,6 @@ module.exports = {
   SendCustomerFileService,
   SendFileToS3Service,
   SendTransactionFileService,
-  ShowCustomerFileService,
   ShowTransactionService,
   StreamReadableDataService,
   StreamReadableRecordsService,
@@ -140,6 +139,7 @@ module.exports = {
   ValidateBillRunRegion,
   ViewAuthorisedSystemService,
   ViewBillRunService,
+  ViewCustomerFileService,
   ViewInvoiceService,
   ViewRegimeService
 }

--- a/app/services/regimes/view_regime.service.js
+++ b/app/services/regimes/view_regime.service.js
@@ -1,7 +1,7 @@
 'use strict'
 
 /**
- * @module ShowRegimeService
+ * @module ViewRegimeService
  */
 
 const Boom = require('@hapi/boom')
@@ -17,7 +17,7 @@ const { JsonPresenter } = require('../../presenters')
  * @param {string} id Id of the regime to find
  * @returns {module:RegimeModel} a `RegimeModel` if found else it will throw a B
  */
-class ShowRegimeService {
+class ViewRegimeService {
   static async go (id) {
     const regime = await this._regime(id)
 
@@ -41,4 +41,4 @@ class ShowRegimeService {
   }
 }
 
-module.exports = ShowRegimeService
+module.exports = ViewRegimeService

--- a/app/services/transactions/view_transaction.service.js
+++ b/app/services/transactions/view_transaction.service.js
@@ -1,7 +1,7 @@
 'use strict'
 
 /**
- * @module ShowTransactionService
+ * @module ViewTransactionService
  */
 
 const Boom = require('@hapi/boom')
@@ -19,7 +19,7 @@ const { JsonPresenter } = require('../../presenters')
  * @returns {module:TransactionModel} an instance `TransactionModel` if found else it will throw a `Boom.notFound()`
  * error (404)
  */
-class ShowTransactionService {
+class ViewTransactionService {
   static async go (id) {
     const transaction = await this._transaction(id)
 
@@ -60,4 +60,4 @@ class ShowTransactionService {
   }
 }
 
-module.exports = ShowTransactionService
+module.exports = ViewTransactionService

--- a/test/controllers/admin/authorised_systems.controller.test.js
+++ b/test/controllers/admin/authorised_systems.controller.test.js
@@ -85,7 +85,7 @@ describe('Authorised systems controller', () => {
     })
   })
 
-  describe('Show authorised system: GET /admin/authorised-systems/{id}', () => {
+  describe('View authorised system: GET /admin/authorised-systems/{id}', () => {
     const options = (id, token) => {
       return {
         method: 'GET',

--- a/test/controllers/admin/regimes.controller.test.js
+++ b/test/controllers/admin/regimes.controller.test.js
@@ -79,7 +79,7 @@ describe('Regimes controller', () => {
     })
   })
 
-  describe('Show regime: GET /admin/regimes/{id}', () => {
+  describe('View regime: GET /admin/regimes/{id}', () => {
     const options = (id, token) => {
       return {
         method: 'GET',

--- a/test/controllers/admin/test/test_customer_files.controller.test.js
+++ b/test/controllers/admin/test/test_customer_files.controller.test.js
@@ -21,7 +21,7 @@ const {
 
 // Things we need to stub
 const JsonWebToken = require('jsonwebtoken')
-const { ListCustomerFilesService, ShowCustomerFileService } = require('../../../../app/services')
+const { ListCustomerFilesService, ViewCustomerFileService } = require('../../../../app/services')
 
 describe('Test customer files controller', () => {
   let server
@@ -88,7 +88,7 @@ describe('Test customer files controller', () => {
     })
   })
 
-  describe('Show customer file: GET /admin/test/customer-files/{id}', () => {
+  describe('View customer file: GET /admin/test/customer-files/{id}', () => {
     let customerFileId
     const options = (id, token) => {
       return {
@@ -104,7 +104,7 @@ describe('Test customer files controller', () => {
 
     describe('When the customer file exists', () => {
       beforeEach(async () => {
-        Sinon.stub(ShowCustomerFileService, 'go').returns({
+        Sinon.stub(ViewCustomerFileService, 'go').returns({
           id: customerFileId,
           regimeId: regime.id,
           region: 'A',

--- a/test/controllers/admin/test/test_transactions_controller.test.js
+++ b/test/controllers/admin/test/test_transactions_controller.test.js
@@ -49,7 +49,7 @@ describe('Test transactions controller', () => {
     Sinon.restore()
   })
 
-  describe('Show transaction: GET /admin/test/transactions/{id}', () => {
+  describe('View transaction: GET /admin/test/transactions/{id}', () => {
     const options = (id, token) => {
       return {
         method: 'GET',

--- a/test/services/authorised_systems/view_authorised_system.service.test.js
+++ b/test/services/authorised_systems/view_authorised_system.service.test.js
@@ -13,9 +13,9 @@ const AuthorisedSystemModel = require('../../../app/models/authorised_system.mod
 const { DataError } = require('objection')
 
 // Thing under test
-const { ShowAuthorisedSystemService } = require('../../../app/services')
+const { ViewAuthorisedSystemService } = require('../../../app/services')
 
-describe('Show Authorised System service', () => {
+describe('View Authorised System service', () => {
   beforeEach(async () => {
     await DatabaseHelper.clean()
   })
@@ -25,7 +25,7 @@ describe('Show Authorised System service', () => {
       it('returns a result that includes a list of related regimes', async () => {
         const authorisedSystem = await AuthorisedSystemHelper.addAdminSystem()
 
-        const result = await ShowAuthorisedSystemService.go(authorisedSystem.id)
+        const result = await ViewAuthorisedSystemService.go(authorisedSystem.id)
 
         // The admin user's authorisations are created when it's seeded into the db. So, the AuthorisedSystemHelper
         // automatically handles creating the regime as part of `addAdminSystem()` to replicate how the system would
@@ -38,7 +38,7 @@ describe('Show Authorised System service', () => {
     it('returns the matching record', async () => {
       const authorisedSystem = await AuthorisedSystemHelper.addSystem('1234546789', 'system1')
 
-      const result = await ShowAuthorisedSystemService.go(authorisedSystem.id)
+      const result = await ViewAuthorisedSystemService.go(authorisedSystem.id)
 
       expect(result instanceof AuthorisedSystemModel).to.equal(true)
       expect(result.id).to.equal(authorisedSystem.id)
@@ -52,7 +52,7 @@ describe('Show Authorised System service', () => {
       const authorisedSystem = await AuthorisedSystemHelper
         .addSystem('1234546789', 'system1', [regime1, regime2, regime3])
 
-      const result = await ShowAuthorisedSystemService.go(authorisedSystem.id)
+      const result = await ViewAuthorisedSystemService.go(authorisedSystem.id)
 
       expect(result.regimes.length).to.equal(3)
       expect(result.regimes[0].slug).to.equal('ice')
@@ -62,7 +62,7 @@ describe('Show Authorised System service', () => {
   describe('When there is no matching regime', () => {
     it('throws an error', async () => {
       const id = GeneralHelper.uuid4()
-      const err = await expect(ShowAuthorisedSystemService.go(id)).to.reject(Error, `No authorised system found with id ${id}`)
+      const err = await expect(ViewAuthorisedSystemService.go(id)).to.reject(Error, `No authorised system found with id ${id}`)
 
       expect(err).to.be.an.error()
     })
@@ -70,7 +70,7 @@ describe('Show Authorised System service', () => {
 
   describe('When an invalid UUID is used', () => {
     it('returns throws an error', async () => {
-      const err = await expect(ShowAuthorisedSystemService.go('123456789')).to.reject(DataError)
+      const err = await expect(ViewAuthorisedSystemService.go('123456789')).to.reject(DataError)
 
       expect(err).to.be.an.error()
     })

--- a/test/services/files/customers/view_customer_file.service.test.js
+++ b/test/services/files/customers/view_customer_file.service.test.js
@@ -17,7 +17,7 @@ const { CustomerFileModel } = require('../../../../app/models')
 const { DataError } = require('objection')
 
 // Thing under test
-const { ShowCustomerFileService } = require('../../../../app/services')
+const { ViewCustomerFileService } = require('../../../../app/services')
 
 describe('Show Customer File service', () => {
   beforeEach(async () => {
@@ -28,7 +28,7 @@ describe('Show Customer File service', () => {
     it('returns the details for it', async () => {
       const customerFile = await CustomerHelper.addCustomerFile()
 
-      const result = await ShowCustomerFileService.go(customerFile.id)
+      const result = await ViewCustomerFileService.go(customerFile.id)
 
       expect(result).to.be.an.instanceOf(CustomerFileModel)
       expect(result.id).to.equal(customerFile.id)
@@ -39,7 +39,7 @@ describe('Show Customer File service', () => {
       await CustomerHelper.addExportedCustomer(customerFile, 'BB02BEEB')
       await CustomerHelper.addExportedCustomer(customerFile, 'CC02BEEB')
 
-      const result = await ShowCustomerFileService.go(customerFile.id)
+      const result = await ViewCustomerFileService.go(customerFile.id)
 
       expect(result.exportedCustomers.length).to.equal(2)
       expect(result.exportedCustomers[0].customerReference).to.equal('BB02BEEB')
@@ -49,7 +49,7 @@ describe('Show Customer File service', () => {
   describe('When there is no matching customer file', () => {
     it('throws an error', async () => {
       const id = GeneralHelper.uuid4()
-      const err = await expect(ShowCustomerFileService.go(id)).to.reject(Error, `No customer file found with id ${id}`)
+      const err = await expect(ViewCustomerFileService.go(id)).to.reject(Error, `No customer file found with id ${id}`)
 
       expect(err).to.be.an.error()
     })
@@ -57,7 +57,7 @@ describe('Show Customer File service', () => {
 
   describe('When an invalid UUID is used', () => {
     it('throws an error', async () => {
-      const err = await expect(ShowCustomerFileService.go('123456789')).to.reject(DataError)
+      const err = await expect(ViewCustomerFileService.go('123456789')).to.reject(DataError)
 
       expect(err).to.be.an.error()
     })

--- a/test/services/regimes/view_regime.service.test.js
+++ b/test/services/regimes/view_regime.service.test.js
@@ -18,7 +18,7 @@ const RegimeModel = require('../../../app/models/regime.model')
 const { DataError } = require('objection')
 
 // Thing under test
-const { ShowRegimeService } = require('../../../app/services')
+const { ViewRegimeService } = require('../../../app/services')
 
 describe('Show Regime service', () => {
   beforeEach(async () => {
@@ -29,7 +29,7 @@ describe('Show Regime service', () => {
     it('returns a regime', async () => {
       const regime = await RegimeHelper.addRegime('ice', 'Ice')
 
-      const result = await ShowRegimeService.go(regime.id)
+      const result = await ViewRegimeService.go(regime.id)
 
       expect(result instanceof RegimeModel).to.equal(true)
       expect(result.id).to.equal(regime.id)
@@ -40,7 +40,7 @@ describe('Show Regime service', () => {
       await AuthorisedSystemHelper.addSystem('1234546789', 'system1', [regime])
       await AuthorisedSystemHelper.addSystem('987654321', 'system2', [regime])
 
-      const result = await ShowRegimeService.go(regime.id)
+      const result = await ViewRegimeService.go(regime.id)
 
       expect(result.authorisedSystems.length).to.equal(2)
       expect(result.authorisedSystems[0].name).to.equal('system1')
@@ -50,7 +50,7 @@ describe('Show Regime service', () => {
   describe('When there is no matching regime', () => {
     it('returns throws an error', async () => {
       const id = GeneralHelper.uuid4()
-      const err = await expect(ShowRegimeService.go(id)).to.reject(Error, `No regime found with id ${id}`)
+      const err = await expect(ViewRegimeService.go(id)).to.reject(Error, `No regime found with id ${id}`)
 
       expect(err).to.be.an.error()
     })
@@ -58,7 +58,7 @@ describe('Show Regime service', () => {
 
   describe('When an invalid UUID is used', () => {
     it('returns throws an error', async () => {
-      const err = await expect(ShowRegimeService.go('123456789')).to.reject(DataError)
+      const err = await expect(ViewRegimeService.go('123456789')).to.reject(DataError)
 
       expect(err).to.be.an.error()
     })

--- a/test/services/transactions/view_transaction.service.test.js
+++ b/test/services/transactions/view_transaction.service.test.js
@@ -20,7 +20,7 @@ const { BillRunModel, InvoiceModel, LicenceModel, TransactionModel } = require('
 const { DataError } = require('objection')
 
 // Thing under test
-const { ShowTransactionService } = require('../../../app/services')
+const { ViewTransactionService } = require('../../../app/services')
 
 describe('Show Transaction service', () => {
   beforeEach(async () => {
@@ -54,14 +54,14 @@ describe('Show Transaction service', () => {
     })
 
     it('returns a transaction', async () => {
-      const result = await ShowTransactionService.go(creditTransaction.id)
+      const result = await ViewTransactionService.go(creditTransaction.id)
 
       expect(result instanceof TransactionModel).to.equal(true)
       expect(result.id).to.equal(creditTransaction.id)
     })
 
     it("returns a result that includes the related 'bill run'", async () => {
-      const result = await ShowTransactionService.go(creditTransaction.id)
+      const result = await ViewTransactionService.go(creditTransaction.id)
 
       const billRun = await BillRunModel.query().findById(creditTransaction.billRunId)
 
@@ -69,7 +69,7 @@ describe('Show Transaction service', () => {
     })
 
     it("returns a result that includes the related 'invoice'", async () => {
-      const result = await ShowTransactionService.go(creditTransaction.id)
+      const result = await ViewTransactionService.go(creditTransaction.id)
 
       const invoice = await InvoiceModel.query().findById(creditTransaction.invoiceId)
 
@@ -77,7 +77,7 @@ describe('Show Transaction service', () => {
     })
 
     it("returns a result that includes the related 'licence'", async () => {
-      const result = await ShowTransactionService.go(creditTransaction.id)
+      const result = await ViewTransactionService.go(creditTransaction.id)
 
       const licence = await LicenceModel.query().findById(creditTransaction.licenceId)
 
@@ -85,19 +85,19 @@ describe('Show Transaction service', () => {
     })
 
     it('returns a positive signedChargeValue if the transaction is a debit', async () => {
-      const result = await ShowTransactionService.go(debitTransaction.id)
+      const result = await ViewTransactionService.go(debitTransaction.id)
 
       expect(Math.sign(result.signedChargeValue)).to.equal(1)
     })
 
     it('returns a negative signedChargeValue if the transaction is a credit', async () => {
-      const result = await ShowTransactionService.go(creditTransaction.id)
+      const result = await ViewTransactionService.go(creditTransaction.id)
 
       expect(Math.sign(result.signedChargeValue)).to.equal(-1)
     })
 
     it("returns the 'transactionType' for the invoice", async () => {
-      const result = await ShowTransactionService.go(creditTransaction.id)
+      const result = await ViewTransactionService.go(creditTransaction.id)
 
       expect(result.invoice.transactionType).to.equal('C')
     })
@@ -106,7 +106,7 @@ describe('Show Transaction service', () => {
   describe('When there is no matching transaction', () => {
     it('throws an error', async () => {
       const id = GeneralHelper.uuid4()
-      const err = await expect(ShowTransactionService.go(id)).to.reject(Error, `No transaction found with id ${id}`)
+      const err = await expect(ViewTransactionService.go(id)).to.reject(Error, `No transaction found with id ${id}`)
 
       expect(err).to.be.an.error()
     })
@@ -114,7 +114,7 @@ describe('Show Transaction service', () => {
 
   describe('When an invalid UUID is used', () => {
     it('throws an error', async () => {
-      const err = await expect(ShowTransactionService.go('123456789')).to.reject(DataError)
+      const err = await expect(ViewTransactionService.go('123456789')).to.reject(DataError)
 
       expect(err).to.be.an.error()
     })


### PR DESCRIPTION
https://github.com/DEFRA/sroc-service-team/issues/68

When we first started building the project we focused on the admin endpoints, specifically `regimes` and `authorised_systems`. They were relatively simple and we needed the underlying data anyway in order to build the rest of the service.

But we were coming from a Ruby on Rails background which meant we used their conventions. Specifically, `show` for responding to a `GET` request.

In later endpoints, we switched to `view` as this was the terminology used by the rest of the team and in our documentation. So, we have an inconsistency in endpoint naming that this change resolves.