### PR TITLE
Implement `ListCustomerFilesService`

### DIFF
--- a/app/controllers/customer_files.controller.js
+++ b/app/controllers/customer_files.controller.js
@@ -1,12 +1,8 @@
 'use strict'
 
-const { ListCustomerFilesService } = require('../services')
-
 class CustomerFilesController {
   static async index (req, h) {
-    const result = await ListCustomerFilesService.go()
-
-    return h.response(result).code(200)
+    return h.response().code(204)
   }
 }
 

--- a/app/presenters/index.js
+++ b/app/presenters/index.js
@@ -8,8 +8,9 @@ const CreateTransactionPresenter = require('./create_transaction.presenter')
 const CustomerFileBodyPresenter = require('./customer_file_body.presenter')
 const CustomerFileHeadPresenter = require('./customer_file_head.presenter')
 const CustomerFileTailPresenter = require('./customer_file_tail.presenter')
-const JsonPresenter = require('./json.presenter')
 const InvoiceRebillingPresenter = require('./invoice_rebilling.presenter')
+const JsonPresenter = require('./json.presenter')
+const ListCustomerFilesPresenter = require('./list_customer_files.presenter')
 const RulesServicePresenter = require('./rules_service.presenter')
 const TableFilePresenter = require('./table_file.presenter')
 const TransactionFileBodyPresenter = require('./transaction_file_body.presenter')
@@ -32,6 +33,7 @@ module.exports = {
   CustomerFileTailPresenter,
   InvoiceRebillingPresenter,
   JsonPresenter,
+  ListCustomerFilesPresenter,
   RulesServicePresenter,
   TableFilePresenter,
   TransactionFileBodyPresenter,

--- a/app/presenters/list_customer_files.presenter.js
+++ b/app/presenters/list_customer_files.presenter.js
@@ -1,0 +1,23 @@
+'use strict'
+
+/**
+ * @module ListCustomerFilesPresenter
+ */
+
+const BasePresenter = require('./base.presenter')
+
+/**
+ * Formats data for the list customer files endpoint.
+ */
+class ListCustomerFilesPresenter extends BasePresenter {
+  _presentation (data) {
+    return data.map(file => {
+      return {
+        fileReference: file.fileReference,
+        exportedCustomers: file.exportedCustomers.map(customer => customer.customerReference)
+      }
+    })
+  }
+}
+
+module.exports = ListCustomerFilesPresenter

--- a/app/services/files/customers/list_customer_files.service.js
+++ b/app/services/files/customers/list_customer_files.service.js
@@ -5,11 +5,10 @@
  */
 
 const { CustomerFileModel } = require('../../../models')
-// NOTE: REPLACE THIS WITH BETTER PRESENTER
-const { JsonPresenter } = require('../../../presenters')
+const { ListCustomerFilesPresenter } = require('../../../presenters')
 
 class ListCustomerFilesService {
-  static async go (regime, days = 30) {
+  static async go (regime, days) {
     const customerFiles = await this._customerFiles(regime.id, days)
 
     return this._response(customerFiles)
@@ -45,7 +44,7 @@ class ListCustomerFilesService {
   }
 
   static _response (customerFiles) {
-    const presenter = new JsonPresenter(customerFiles)
+    const presenter = new ListCustomerFilesPresenter(customerFiles)
 
     return presenter.go()
   }

--- a/app/services/files/customers/list_customer_files.service.js
+++ b/app/services/files/customers/list_customer_files.service.js
@@ -4,9 +4,45 @@
  * @module ListCustomerFilesService
  */
 
+const { CustomerFileModel } = require('../../../models')
+// NOTE: REPLACE THIS WITH BETTER PRESENTER
+const { JsonPresenter } = require('../../../presenters')
+
 class ListCustomerFilesService {
-  static async go () {
-    return true
+  static async go (regime, days = 30) {
+    const customerFiles = await this._customerFiles(regime.id, days)
+
+    return this._response(customerFiles)
+  }
+
+  static _customerFiles (regimeId, days) {
+    const startDate = this._startDate(days)
+
+    return CustomerFileModel
+      .query()
+      .where('regimeId', regimeId)
+      // do we want a modifier here?
+      .where('status', 'exported')
+      .where('exportedAt', '>', startDate)
+  }
+
+  /**
+   * Returns a date object of a given number of days ago, set to midnight (ie. the start of the day)
+   */
+  static _startDate (days) {
+    const date = new Date()
+
+    // Set time to midnight and date to `days` days ago
+    date.setHours(0, 0, 0, 0)
+    date.setDate(date.getDate() - days)
+
+    return date
+  }
+
+  static _response (customerFiles) {
+    const presenter = new JsonPresenter(customerFiles)
+
+    return presenter.go()
   }
 }
 

--- a/app/services/files/customers/list_customer_files.service.js
+++ b/app/services/files/customers/list_customer_files.service.js
@@ -24,6 +24,11 @@ class ListCustomerFilesService {
       // do we want a modifier here?
       .where('status', 'exported')
       .where('exportedAt', '>', startDate)
+      .select('fileReference')
+      .withGraphFetched('exportedCustomers')
+      .modifyGraph('exportedCustomers', builder => {
+        builder.select('customerReference')
+      })
   }
 
   /**

--- a/app/services/files/customers/list_customer_files.service.js
+++ b/app/services/files/customers/list_customer_files.service.js
@@ -8,6 +8,16 @@ const { CustomerFileModel } = require('../../../models')
 const { ListCustomerFilesPresenter } = require('../../../presenters')
 
 class ListCustomerFilesService {
+  /**
+   * Returns exported customer files and the customer references in them. The number of days to go back is required,
+   * where 0 = all customer files exported today, 1 = all customer files exported yesterday and today, etc.
+   *
+   * @param {module:RegimeModel} regime Instance of `RegimeModel` for the regime the customer files belong to.
+   * @param {integer} days The number of days of exported files to return.
+   * @returns {Object[]} customerObj An array of objects representing exported customer files.
+   * @returns {string} customerObj.fileReference The file reference of the exported customer file.
+   * @returns {string[]} customerObj.exportedCustomers An array of customer references included in the exported file.
+   */
   static async go (regime, days) {
     const customerFiles = await this._customerFiles(regime.id, days)
 
@@ -20,7 +30,6 @@ class ListCustomerFilesService {
     return CustomerFileModel
       .query()
       .where('regimeId', regimeId)
-      // do we want a modifier here?
       .where('status', 'exported')
       .where('exportedAt', '>', startDate)
       .select('fileReference')

--- a/test/controllers/presroc/customer_files.controller.test.js
+++ b/test/controllers/presroc/customer_files.controller.test.js
@@ -57,12 +57,10 @@ describe('List Customer Files controller', () => {
     }
 
     describe('When the request is valid', () => {
-      it('returns `true`', async () => {
+      it('returns a 204 response', async () => {
         const response = await server.inject(options(authToken))
-        const responsePayload = JSON.parse(response.payload)
 
-        expect(response.statusCode).to.equal(200)
-        expect(responsePayload).to.be.true()
+        expect(response.statusCode).to.equal(204)
       })
     })
   })

--- a/test/presenters/list_customer_files.presenter.test.js
+++ b/test/presenters/list_customer_files.presenter.test.js
@@ -1,0 +1,53 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Thing under test
+const { ListCustomerFilesPresenter } = require('../../app/presenters')
+
+describe('List Customer Files presenter', () => {
+  it.only('correctly presents the data', () => {
+    const data = [
+      {
+        fileReference: 'FILE1',
+        exportedCustomers: [
+          { customerReference: 'CUST11' }, { customerReference: 'CUST12' }, { customerReference: 'CUST13' }
+        ]
+      },
+      {
+        fileReference: 'FILE2',
+        exportedCustomers: [
+          { customerReference: 'CUST21' }, { customerReference: 'CUST22' }, { customerReference: 'CUST23' }
+        ]
+      },
+      {
+        fileReference: 'FILE3',
+        exportedCustomers: [
+          { customerReference: 'CUST31' }, { customerReference: 'CUST32' }, { customerReference: 'CUST33' }
+        ]
+      }
+    ]
+
+    const testPresenter = new ListCustomerFilesPresenter(data)
+    const result = testPresenter.go()
+
+    expect(result).to.have.length(3)
+    expect(result[0]).to.equal({
+      fileReference: 'FILE1',
+      exportedCustomers: ['CUST11', 'CUST12', 'CUST13']
+    })
+    expect(result[1]).to.equal({
+      fileReference: 'FILE2',
+      exportedCustomers: ['CUST21', 'CUST22', 'CUST23']
+    })
+    expect(result[2]).to.equal({
+      fileReference: 'FILE3',
+      exportedCustomers: ['CUST31', 'CUST32', 'CUST33']
+    })
+  })
+})

--- a/test/presenters/list_customer_files.presenter.test.js
+++ b/test/presenters/list_customer_files.presenter.test.js
@@ -11,7 +11,7 @@ const { expect } = Code
 const { ListCustomerFilesPresenter } = require('../../app/presenters')
 
 describe('List Customer Files presenter', () => {
-  it.only('correctly presents the data', () => {
+  it('correctly presents the data', () => {
     const data = [
       {
         fileReference: 'FILE1',

--- a/test/services/files/customers/list_customer_files.service.test.js
+++ b/test/services/files/customers/list_customer_files.service.test.js
@@ -94,6 +94,13 @@ describe('List Customer Files service', () => {
         ])
       })
 
+      it('returns files exported on the specified day', async () => {
+        const customerFiles = await ListCustomerFilesService.go(regime, 1)
+        const result = customerFiles.map(file => file.fileReference)
+
+        expect(result).to.include(yesterdayFile.fileReference)
+      })
+
       it('returns customer references in the exported files', async () => {
         const customerFiles = await ListCustomerFilesService.go(regime, 30)
         const result = customerFiles.map(file => file.exportedCustomers[0])

--- a/test/services/files/customers/list_customer_files.service.test.js
+++ b/test/services/files/customers/list_customer_files.service.test.js
@@ -55,17 +55,27 @@ describe('List Customer Files service', () => {
     describe('for the requested regime', () => {
       beforeEach(async () => {
         todayFile = await CustomerHelper.addCustomerFile(regime, 'A', 'nalac50001', 'exported')
+        await CustomerHelper.addExportedCustomer(todayFile, '0DAY')
+
         yesterdayFile = await CustomerHelper.addCustomerFile(regime, 'A', 'nalac50002', 'exported', GeneralHelper.daysAgoDate(1))
+        await CustomerHelper.addExportedCustomer(yesterdayFile, '1DAY')
+
         lastWeekFile = await CustomerHelper.addCustomerFile(regime, 'A', 'nalac50003', 'exported', GeneralHelper.daysAgoDate(7))
+        await CustomerHelper.addExportedCustomer(lastWeekFile, '7DAY')
+
         tooOldFile = await CustomerHelper.addCustomerFile(regime, 'A', 'nalac50004', 'exported', GeneralHelper.daysAgoDate(31))
+        await CustomerHelper.addExportedCustomer(tooOldFile, '31DAY')
+
         initialisedFile = await CustomerHelper.addCustomerFile(regime, 'A', 'nalac50005', 'initialised')
 
         const otherRegime = await RegimeHelper.addRegime('other', 'Other')
         otherRegimeFile = await CustomerHelper.addCustomerFile(otherRegime, 'A', 'nalac50006', 'exported')
+        await CustomerHelper.addExportedCustomer(otherRegimeFile, 'OTHER0DAY')
       })
 
       it('returns files exported in the last 30 days', async () => {
         const customerFiles = await ListCustomerFilesService.go(regime)
+        console.log('🚀 ~ file: list_customer_files.service.test.js ~ line 78 ~ it.only ~ customerFiles', customerFiles[0])
         const result = customerFiles.map(file => file.fileReference)
 
         expect(result).to.include([

--- a/test/services/files/customers/list_customer_files.service.test.js
+++ b/test/services/files/customers/list_customer_files.service.test.js
@@ -4,16 +4,91 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it } = exports.lab = Lab.script()
+const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
+
+// Test helpers
+const { DatabaseHelper, CustomerHelper, GeneralHelper, RegimeHelper } = require('../../../support/helpers')
 
 // Thing under test
 const { ListCustomerFilesService } = require('../../../../app/services')
 
 describe('List Customer Files service', () => {
-  it('returns `true`', async () => {
-    const result = await ListCustomerFilesService.go()
+  let regime
 
-    expect(result).to.be.true()
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+
+    regime = await RegimeHelper.addRegime('regime', 'Regime')
+  })
+
+  describe('When there are no customer files', () => {
+    describe('for the requested regime', () => {
+      beforeEach(async () => {
+        await CustomerHelper.addCustomerFile()
+      })
+
+      it('returns an empty array', async () => {
+        const result = await ListCustomerFilesService.go(regime)
+
+        expect(result).to.equal([])
+      })
+    })
+
+    describe('for any regimes', () => {
+      it('returns an empty array', async () => {
+        const result = await ListCustomerFilesService.go(regime)
+
+        expect(result).to.equal([])
+      })
+    })
+  })
+
+  describe('When there are customer files', () => {
+    let todayFile
+    let yesterdayFile
+    let lastWeekFile
+    let tooOldFile
+    let initialisedFile
+    let otherRegimeFile
+
+    describe('for the requested regime', () => {
+      beforeEach(async () => {
+        todayFile = await CustomerHelper.addCustomerFile(regime, 'A', 'nalac50001', 'exported')
+        yesterdayFile = await CustomerHelper.addCustomerFile(regime, 'A', 'nalac50002', 'exported', GeneralHelper.daysAgoDate(1))
+        lastWeekFile = await CustomerHelper.addCustomerFile(regime, 'A', 'nalac50003', 'exported', GeneralHelper.daysAgoDate(7))
+        tooOldFile = await CustomerHelper.addCustomerFile(regime, 'A', 'nalac50004', 'exported', GeneralHelper.daysAgoDate(31))
+        initialisedFile = await CustomerHelper.addCustomerFile(regime, 'A', 'nalac50005', 'initialised')
+
+        const otherRegime = await RegimeHelper.addRegime('other', 'Other')
+        otherRegimeFile = await CustomerHelper.addCustomerFile(otherRegime, 'A', 'nalac50006', 'exported')
+      })
+
+      it('returns files exported in the last 30 days', async () => {
+        const customerFiles = await ListCustomerFilesService.go(regime)
+        const result = customerFiles.map(file => file.fileReference)
+
+        expect(result).to.include([
+          todayFile.fileReference,
+          yesterdayFile.fileReference,
+          lastWeekFile.fileReference
+        ])
+        expect(result).to.not.include(tooOldFile.fileReference)
+      })
+
+      it('does not return records for other regimes', async () => {
+        const customerFiles = await ListCustomerFilesService.go(regime)
+        const result = customerFiles.map(file => file.fileReference)
+
+        expect(result).to.not.include(otherRegimeFile.fileReference)
+      })
+
+      it('only returns exported files', async () => {
+        const customerFiles = await ListCustomerFilesService.go(regime)
+        const result = customerFiles.map(file => file.fileReference)
+
+        expect(result).to.not.include(initialisedFile.fileReference)
+      })
+    })
   })
 })

--- a/test/support/helpers/customer.helper.js
+++ b/test/support/helpers/customer.helper.js
@@ -26,6 +26,7 @@ class CustomerFileHelper {
         regimeId: this._regimeId(regime),
         region,
         fileReference,
+        status,
         exportedAt: this._exportedAt(status, exportedAt)
       })
       .returning('*')

--- a/test/support/helpers/customer.helper.js
+++ b/test/support/helpers/customer.helper.js
@@ -14,18 +14,19 @@ class CustomerFileHelper {
    * generate a random UUID and use that instead
    * @param {string} [region] Region to use. Defaults to 'A'
    * @param {string} [fileReference] File reference to use. Defaults to 'nalac50001'
-   * @param {string} [status] Status to use. Defaults to 'exported'. If set to `exported` it will also default
-   * `exported_at` to `Date.now()`
+   * @param {string} [status] Status to use. Defaults to 'exported'. If set to `exported` it will set `exported_at` to
+   * the `exportedAt` parameter.
+   * @param {date} [exportedAt] Date to use for `exported_at`. Defaults to the current date.
    *
    * @returns {module:CustomerFileModel} The newly created instance of `CustomerFileModel`
    */
-  static addCustomerFile (regime = null, region = 'A', fileReference = 'nalac50001', status = 'exported') {
+  static addCustomerFile (regime = null, region = 'A', fileReference = 'nalac50001', status = 'exported', exportedAt = new Date()) {
     return CustomerFileModel.query()
       .insert({
         regimeId: this._regimeId(regime),
         region,
         fileReference,
-        exportedAt: this._exportedAt(status)
+        exportedAt: this._exportedAt(status, exportedAt)
       })
       .returning('*')
   }
@@ -52,8 +53,8 @@ class CustomerFileHelper {
     return regime?.id ?? GeneralHelper.uuid4()
   }
 
-  static _exportedAt (status) {
-    return status === 'exported' ? new Date().toISOString() : null
+  static _exportedAt (status, exportDate) {
+    return status === 'exported' ? exportDate.toISOString() : null
   }
 
   static _customerFileId (customerFile) {

--- a/test/support/helpers/general.helper.js
+++ b/test/support/helpers/general.helper.js
@@ -82,6 +82,19 @@ class GeneralHelper {
       .stringify(date)
       .replace(/"/g, '')
   }
+
+  /**
+   * Returns the date a given number of days ago, where 0 = today, 1 = yesterday, etc. The returned Date object will
+   * have its time set to the current time, eg. if Date.now() is 2021-09-06T14:01:15.929Z then daysAgoDate(1) would be
+   * 2021-09-05T14:01:15.929Z.
+   */
+  static daysAgoDate (days) {
+    const date = new Date()
+
+    date.setDate(date.getDate() - days)
+
+    return date
+  }
 }
 
 module.exports = GeneralHelper


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/projects/CMEA/boards/907/backlog?selectedIssue=CMEA-166

We continue with this feature by implementing the `ListCustomerFilesService`, along with the `ListCustomerFilesPresenter` it uses to format its output. Note that we do not yet enforce the acceptance criteria that the output should default to 30 days; this will be handled in a future branch.

As part of development, we have amended `CustomerHelper.addCustomerFile()` to accept an export date, defaulting to the current date to avoid breaking existing tests. While doing this, we noticed that it was not setting the customer file status, so we fixed this.

Finally, we remove the service from `CustomerFilesController` -- after developing the service fully, the tests now fail as they don't perform the required setup. Rather than continuing to develop the controller in this branch, we remove the service with the intent of reinstating it in a future branch.