### PR TITLE
List customer files controller and route

### DIFF
--- a/app/controllers/customer_files.controller.js
+++ b/app/controllers/customer_files.controller.js
@@ -1,8 +1,12 @@
 'use strict'
 
+const { ListCustomerFilesService } = require('../services')
+
 class CustomerFilesController {
   static async index (req, h) {
-    return h.response().code(204)
+    const result = await ListCustomerFilesService.go(req.app.regime, req.params.days)
+
+    return h.response(result).code(200)
   }
 }
 

--- a/app/routes/customer_files.routes.js
+++ b/app/routes/customer_files.routes.js
@@ -1,12 +1,25 @@
 'use strict'
 
 const { CustomerFilesController } = require('../controllers')
+const Joi = require('joi')
 
 const routes = [
   {
     method: 'GET',
     path: '/v2/{regimeId}/customer-files/{days?}',
-    handler: CustomerFilesController.index
+    handler: CustomerFilesController.index,
+    options: {
+      validate: {
+        params: {
+          days: Joi.number().integer().positive().default(30)
+        },
+        options: {
+          // We only want to validate the days parameter and not regimeId. Setting allowUnknown to `true` means we don't
+          // need to provide additional validation for regimeId.
+          allowUnknown: true
+        }
+      }
+    }
   }
 ]
 

--- a/app/routes/customer_files.routes.js
+++ b/app/routes/customer_files.routes.js
@@ -5,7 +5,7 @@ const { CustomerFilesController } = require('../controllers')
 const routes = [
   {
     method: 'GET',
-    path: '/v2/{regimeId}/customer-files',
+    path: '/v2/{regimeId}/customer-files/{days?}',
     handler: CustomerFilesController.index
   }
 ]

--- a/app/server.js
+++ b/app/server.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const Hapi = require('@hapi/hapi')
+const Joi = require('joi')
 const { ServerConfig, TestConfig } = require('../config')
 const { JwtStrategyAuthLib } = require('./lib')
 const {
@@ -57,6 +58,9 @@ const registerPlugins = async (server) => {
 const init = async () => {
   // Create the hapi server
   const server = Hapi.server(ServerConfig.hapi)
+
+  // Set default validator (required when adding validation to a route)
+  server.validator(Joi)
 
   await registerPlugins(server)
   await server.initialize()

--- a/test/controllers/presroc/customer_files.controller.test.js
+++ b/test/controllers/presroc/customer_files.controller.test.js
@@ -61,7 +61,7 @@ describe('List Customer Files controller', () => {
     }
 
     beforeEach(async () => {
-      listStub = Sinon.stub(ListCustomerFilesService, 'go')
+      listStub = Sinon.stub(ListCustomerFilesService, 'go').returns(['result'])
     })
 
     afterEach(async () => {
@@ -73,6 +73,13 @@ describe('List Customer Files controller', () => {
         const response = await server.inject(options(authToken))
 
         expect(response.statusCode).to.equal(200)
+      })
+
+      it('returns the output of ListCustomerFilesService', async () => {
+        const response = await server.inject(options(authToken))
+        const payload = JSON.parse(response.payload)
+
+        expect(payload).to.equal(['result'])
       })
 
       it('calls ListCustomerFilesService', async () => {

--- a/test/controllers/presroc/customer_files.controller.test.js
+++ b/test/controllers/presroc/customer_files.controller.test.js
@@ -5,7 +5,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, before, beforeEach, after } = exports.lab = Lab.script()
+const { describe, it, before, beforeEach, after, afterEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // For running our service
@@ -21,11 +21,13 @@ const {
 
 // Things we need to stub
 const JsonWebToken = require('jsonwebtoken')
+const { ListCustomerFilesService } = require('../../../app/services')
 
 describe('List Customer Files controller', () => {
   const clientID = '1234546789'
   let server
   let authToken
+  let regime
 
   before(async () => {
     authToken = AuthorisationHelper.nonAdminToken(clientID)
@@ -43,24 +45,52 @@ describe('List Customer Files controller', () => {
     await DatabaseHelper.clean()
     server = await init()
 
-    const regime = await RegimeHelper.addRegime('wrls', 'WRLS')
+    regime = await RegimeHelper.addRegime('wrls', 'WRLS')
     await AuthorisedSystemHelper.addSystem(clientID, 'system1', [regime])
   })
 
   describe('List customer files: GET /v2/{regimeId}/customer-files', () => {
-    const options = (token) => {
+    let listStub
+
+    const options = (token, pathParam = '') => {
       return {
         method: 'GET',
-        url: '/v2/wrls/customer-files',
+        url: `/v2/${regime.slug}/customer-files/${pathParam}`,
         headers: { authorization: `Bearer ${token}` }
       }
     }
 
+    beforeEach(async () => {
+      listStub = Sinon.stub(ListCustomerFilesService, 'go')
+    })
+
+    afterEach(async () => {
+      listStub.restore()
+    })
+
     describe('When the request is valid', () => {
-      it('returns a 204 response', async () => {
+      it('returns a 200 response', async () => {
         const response = await server.inject(options(authToken))
 
-        expect(response.statusCode).to.equal(204)
+        expect(response.statusCode).to.equal(200)
+      })
+
+      it('calls ListCustomerFilesService', async () => {
+        await server.inject(options(authToken))
+
+        expect(listStub.calledOnce).to.be.true()
+      })
+
+      it('passes the regime to ListCustomerFilesService', async () => {
+        await server.inject(options(authToken))
+
+        expect(listStub.firstCall.firstArg.id).to.equal(regime.id)
+      })
+
+      it('passes the days parameter to ListCustomerFilesService', async () => {
+        await server.inject(options(authToken, '30'))
+
+        expect(listStub.firstCall.args[1]).to.equal('30')
       })
     })
   })

--- a/test/controllers/presroc/customer_files.controller.test.js
+++ b/test/controllers/presroc/customer_files.controller.test.js
@@ -49,7 +49,7 @@ describe('List Customer Files controller', () => {
     await AuthorisedSystemHelper.addSystem(clientID, 'system1', [regime])
   })
 
-  describe('List customer files: GET /v2/{regimeId}/customer-files', () => {
+  describe('List customer files: GET /v2/{regimeId}/customer-files/{days?}', () => {
     let listStub
 
     const options = (token, pathParam = '') => {
@@ -88,9 +88,49 @@ describe('List Customer Files controller', () => {
       })
 
       it('passes the days parameter to ListCustomerFilesService', async () => {
-        await server.inject(options(authToken, '30'))
+        await server.inject(options(authToken, '15'))
 
-        expect(listStub.firstCall.args[1]).to.equal('30')
+        expect(listStub.firstCall.args[1]).to.equal(15)
+      })
+
+      it('defaults to 30 days if the days parameter is not specified', async () => {
+        await server.inject(options(authToken))
+
+        expect(listStub.firstCall.args[1]).to.equal(30)
+      })
+    })
+
+    describe('When the request is invalid', () => {
+      describe('because an invalid days parameter was provided', () => {
+        it('returns a 400 response', async () => {
+          const response = await server.inject(options(authToken, 'FAIL'))
+
+          expect(response.statusCode).to.equal(400)
+        })
+      })
+
+      describe('because a string was provided for the days parameter', () => {
+        it('returns a 400 response', async () => {
+          const response = await server.inject(options(authToken, 'FAIL'))
+
+          expect(response.statusCode).to.equal(400)
+        })
+      })
+
+      describe('because a negative number was provided for the days parameter', () => {
+        it('returns a 400 response', async () => {
+          const response = await server.inject(options(authToken, '-1'))
+
+          expect(response.statusCode).to.equal(400)
+        })
+      })
+
+      describe('because a non-integer number was provided for the days parameter', () => {
+        it('returns a 400 response', async () => {
+          const response = await server.inject(options(authToken, '4.2'))
+
+          expect(response.statusCode).to.equal(400)
+        })
       })
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/projects/CMEA/boards/907?selectedIssue=CMEA-57

We finish up by updating the route definition to accept an optional path parameter and add validation (which we also use to set the default of 30 days).