### PR TITLE
Amend 0 days parameter with `ListCustomerFilesController`

### DIFF
--- a/app/routes/customer_files.routes.js
+++ b/app/routes/customer_files.routes.js
@@ -11,7 +11,7 @@ const routes = [
     options: {
       validate: {
         params: {
-          days: Joi.number().integer().positive().default(30)
+          days: Joi.number().integer().min(0).default(30)
         },
         options: {
           // We only want to validate the days parameter and not regimeId. Setting allowUnknown to `true` means we don't

--- a/test/controllers/presroc/customer_files.controller.test.js
+++ b/test/controllers/presroc/customer_files.controller.test.js
@@ -100,6 +100,12 @@ describe('List Customer Files controller', () => {
         expect(listStub.firstCall.args[1]).to.equal(15)
       })
 
+      it('accepts a value of 0 days', async () => {
+        await server.inject(options(authToken, '0'))
+
+        expect(listStub.firstCall.args[1]).to.equal(0)
+      })
+
       it('defaults to 30 days if the days parameter is not specified', async () => {
         await server.inject(options(authToken))
 


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/projects/CMEA/boards/907?selectedIssue=CMEA-57

While doing some final checks, we realised that the `positive()` validation requirement rejects the request if a parameter of `0` is used. We fix this by using `min(0)` instead.