### PR TITLE
Expand info returned in customer-files endpoint

### DIFF
--- a/app/presenters/list_customer_files.presenter.js
+++ b/app/presenters/list_customer_files.presenter.js
@@ -13,7 +13,10 @@ class ListCustomerFilesPresenter extends BasePresenter {
   _presentation (data) {
     return data.map(file => {
       return {
+        id: file.id,
         fileReference: file.fileReference,
+        status: file.status,
+        exportedAt: file.exportedAt,
         exportedCustomers: file.exportedCustomers.map(customer => customer.customerReference)
       }
     })

--- a/app/services/files/customers/list_customer_files.service.js
+++ b/app/services/files/customers/list_customer_files.service.js
@@ -32,7 +32,7 @@ class ListCustomerFilesService {
       .where('regimeId', regimeId)
       .where('status', 'exported')
       .where('exportedAt', '>', startDate)
-      .select('fileReference')
+      .select('id', 'fileReference', 'status', 'exportedAt')
       .withGraphFetched('exportedCustomers')
       .modifyGraph('exportedCustomers', builder => {
         builder.select('customerReference')

--- a/test/presenters/list_customer_files.presenter.test.js
+++ b/test/presenters/list_customer_files.presenter.test.js
@@ -7,6 +7,9 @@ const Code = require('@hapi/code')
 const { describe, it } = exports.lab = Lab.script()
 const { expect } = Code
 
+// Test helpers
+const { GeneralHelper } = require('../support/helpers')
+
 // Thing under test
 const { ListCustomerFilesPresenter } = require('../../app/presenters')
 
@@ -14,19 +17,29 @@ describe('List Customer Files presenter', () => {
   it('correctly presents the data', () => {
     const data = [
       {
+        id: GeneralHelper.uuid4(),
         fileReference: 'FILE1',
+        status: 'initialised',
+        exportedAt: null,
         exportedCustomers: [
           { customerReference: 'CUST11' }, { customerReference: 'CUST12' }, { customerReference: 'CUST13' }
         ]
       },
       {
+        id: GeneralHelper.uuid4(),
         fileReference: 'FILE2',
+        status: 'pending',
+        exportedAt: null,
         exportedCustomers: [
           { customerReference: 'CUST21' }, { customerReference: 'CUST22' }, { customerReference: 'CUST23' }
         ]
       },
       {
+        id: GeneralHelper.uuid4(),
+
         fileReference: 'FILE3',
+        status: 'exported',
+        exportedAt: '2021-01-12T14:41:10.511Z',
         exportedCustomers: [
           { customerReference: 'CUST31' }, { customerReference: 'CUST32' }, { customerReference: 'CUST33' }
         ]
@@ -38,15 +51,24 @@ describe('List Customer Files presenter', () => {
 
     expect(result).to.have.length(3)
     expect(result[0]).to.equal({
+      id: data[0].id,
       fileReference: 'FILE1',
+      status: data[0].status,
+      exportedAt: data[0].exportedAt,
       exportedCustomers: ['CUST11', 'CUST12', 'CUST13']
     })
     expect(result[1]).to.equal({
+      id: data[1].id,
       fileReference: 'FILE2',
+      status: data[1].status,
+      exportedAt: data[1].exportedAt,
       exportedCustomers: ['CUST21', 'CUST22', 'CUST23']
     })
     expect(result[2]).to.equal({
+      id: data[2].id,
       fileReference: 'FILE3',
+      status: data[2].status,
+      exportedAt: data[2].exportedAt,
       exportedCustomers: ['CUST31', 'CUST32', 'CUST33']
     })
   })

--- a/test/presenters/list_customer_files.presenter.test.js
+++ b/test/presenters/list_customer_files.presenter.test.js
@@ -52,21 +52,21 @@ describe('List Customer Files presenter', () => {
     expect(result).to.have.length(3)
     expect(result[0]).to.equal({
       id: data[0].id,
-      fileReference: 'FILE1',
+      fileReference: data[0].fileReference,
       status: data[0].status,
       exportedAt: data[0].exportedAt,
       exportedCustomers: ['CUST11', 'CUST12', 'CUST13']
     })
     expect(result[1]).to.equal({
       id: data[1].id,
-      fileReference: 'FILE2',
+      fileReference: data[1].fileReference,
       status: data[1].status,
       exportedAt: data[1].exportedAt,
       exportedCustomers: ['CUST21', 'CUST22', 'CUST23']
     })
     expect(result[2]).to.equal({
       id: data[2].id,
-      fileReference: 'FILE3',
+      fileReference: data[2].fileReference,
       status: data[2].status,
       exportedAt: data[2].exportedAt,
       exportedCustomers: ['CUST31', 'CUST32', 'CUST33']


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/CMEA-57

In [Implement ListCustomerFilesService](https://github.com/DEFRA/sroc-charging-module-api/pull/554) we built the service which will be used by the new public version of our customer files endpoint.

The intent is now that we have a public version of the endpoint we should be able to delete `/admin/test` version. However, we've spotted that the 2 return very different data. The `/admin/test` one returns

```json
[
    {
        "id": "13273263-787c-4868-9fd4-1a6b8a25c415",
        "regimeId": "48faa47b-e1fc-4892-ab8c-5d6862f1a99f",
        "region": "A",
        "fileReference": "nalac50001",
        "status": "exported",
        "exportedAt": "2021-09-21T22:40:45.398Z",
        "createdAt": "2021-09-21T22:40:44.859Z",
        "updatedAt": "2021-09-21T22:40:45.403Z"
    }
]
```

The new public `/v2/{regime}/` one returns only

```json
[
    {
        "fileReference": "nalac50001",
        "exportedCustomers": [
            "BB02BEEB"
        ]
    }
]
```

Ideally, before we delete the old one we should try and include some of that additional data in the public one.

So, this change updates the endpoint so it returns

```json
[
    {
        "id": "13273263-787c-4868-9fd4-1a6b8a25c415",
        "fileReference": "nalac50001",
        "status": "exported",
        "exportedAt": "2021-09-21T22:40:45.398Z",
        "exportedCustomers": [
            "BB02BEEB"
        ]
    }
]
```
