### PR TITLE
Delete Licence not updating bill run status

### DIFF
--- a/app/controllers/bill_runs_licences.controller.js
+++ b/app/controllers/bill_runs_licences.controller.js
@@ -8,7 +8,7 @@ class BillRunsLicencesController {
     await ValidateBillRunLicenceService.go(req.app.billRun.id, req.app.licence)
 
     // We start DeleteLicenceService without await so that it runs in the background
-    DeleteLicenceService.go(req.app.licence, req.app.notifier)
+    DeleteLicenceService.go(req.app.licence, req.app.billRun, req.app.notifier)
 
     return h.response().code(204)
   }

--- a/app/controllers/bill_runs_licences.controller.js
+++ b/app/controllers/bill_runs_licences.controller.js
@@ -5,7 +5,7 @@ const { DeleteLicenceService, ValidateBillRunLicenceService } = require('../serv
 class BillRunsLicencesController {
   static async delete (req, h) {
     // We validate the licence within the controller so a validation error is returned immediately
-    await ValidateBillRunLicenceService.go(req.app.billRun.id, req.app.licence)
+    await ValidateBillRunLicenceService.go(req.app.billRun, req.app.licence)
 
     // We start DeleteLicenceService without await so that it runs in the background
     DeleteLicenceService.go(req.app.licence, req.app.billRun, req.app.notifier)

--- a/app/services/licences/delete_licence.service.js
+++ b/app/services/licences/delete_licence.service.js
@@ -20,10 +20,12 @@ class DeleteLicenceService {
    * bill run has been generated.
    *
    * @param {module:LicenceModel} licence The licence to be deleted.
+   * @param {module:BillRunModel} billRun The bill run the licence belongs to, which we use to determine its current
+   * status.
    * @param {@module:RequestNotifierLib} notifier Instance of `RequestNotifierLib` class. We use it to log errors rather
    * than throwing them as this service is intended to run in the background.
    */
-  static async go (licence, notifier) {
+  static async go (licence, billRun, notifier) {
     try {
       await this._deleteLicence(licence, notifier)
     } catch (error) {

--- a/app/services/licences/delete_licence.service.js
+++ b/app/services/licences/delete_licence.service.js
@@ -29,7 +29,7 @@ class DeleteLicenceService {
   static async go (licence, billRun, notifier) {
     try {
       await LicenceModel.transaction(async trx => {
-        const initialBillRunStatus = await this._getCurrentBillRunStatus(billRun, trx)
+        const { status: initialBillRunStatus } = billRun
 
         await this._setBillRunStatus(billRun, 'pending', trx)
         await this._deleteLicence(licence, notifier, trx)

--- a/test/controllers/presroc/bill_runs_licences.controller.test.js
+++ b/test/controllers/presroc/bill_runs_licences.controller.test.js
@@ -52,7 +52,7 @@ describe('Licences controller', () => {
     Sinon.restore()
   })
 
-  describe('Delete a licence: DELETE /v2/{regimeId}/bill-runs/{billRunId}/licences/{licenceId}', () => {
+  describe.only('Delete a licence: DELETE /v2/{regimeId}/bill-runs/{billRunId}/licences/{licenceId}', () => {
     let validationStub
     let deletionStub
 

--- a/test/controllers/presroc/bill_runs_licences.controller.test.js
+++ b/test/controllers/presroc/bill_runs_licences.controller.test.js
@@ -52,7 +52,7 @@ describe('Licences controller', () => {
     Sinon.restore()
   })
 
-  describe.only('Delete a licence: DELETE /v2/{regimeId}/bill-runs/{billRunId}/licences/{licenceId}', () => {
+  describe('Delete a licence: DELETE /v2/{regimeId}/bill-runs/{billRunId}/licences/{licenceId}', () => {
     let validationStub
     let deletionStub
 

--- a/test/services/licences/delete_licence.service.test.js
+++ b/test/services/licences/delete_licence.service.test.js
@@ -81,7 +81,7 @@ describe('Delete Licence service', () => {
        *   .toKnexQuery() gives us the underlying Knex query
        *   .toString() gives us the SQL query as a string
        *
-       * Finally, we push query strings to the queries array if they set the status to 'generating'.
+       * Finally, we push query strings to the queries array if they set the status to 'pending'.
        */
       const queries = []
       for (let call = 0; call < spy.callCount; call++) {

--- a/test/services/licences/delete_licence.service.test.js
+++ b/test/services/licences/delete_licence.service.test.js
@@ -29,7 +29,7 @@ const { GenerateBillRunService } = require('../../../app/services')
 // Thing under test
 const { DeleteLicenceService } = require('../../../app/services')
 
-describe.only('Delete Licence service', () => {
+describe('Delete Licence service', () => {
   let billRun
   let invoice
   let licence

--- a/test/services/licences/delete_licence.service.test.js
+++ b/test/services/licences/delete_licence.service.test.js
@@ -39,7 +39,7 @@ const { RequestRulesServiceCharge } = require('../../../app/services')
 // Thing under test
 const { DeleteLicenceService } = require('../../../app/services')
 
-describe('Delete Licence service', () => {
+describe.only('Delete Licence service', () => {
   let regime
   let authorisedSystem
   let billRun
@@ -81,7 +81,7 @@ describe('Delete Licence service', () => {
 
   describe('When a valid licence is supplied', () => {
     it('deletes the licence', async () => {
-      await DeleteLicenceService.go(licence, notifierFake)
+      await DeleteLicenceService.go(licence, billRun, notifierFake)
 
       const result = await LicenceModel.query().findById(transaction.licenceId)
 
@@ -89,7 +89,7 @@ describe('Delete Licence service', () => {
     })
 
     it('deletes the licence transactions', async () => {
-      await DeleteLicenceService.go(licence, notifierFake)
+      await DeleteLicenceService.go(licence, billRun, notifierFake)
 
       const transactions = await TransactionModel.query().select().where({ billRunId: billRun.id })
 
@@ -103,7 +103,7 @@ describe('Delete Licence service', () => {
         // Generate the bill run to ensure its values are updated before we delete the licence
         await GenerateBillRunService.go(billRun)
 
-        await DeleteLicenceService.go(licence, notifierFake)
+        await DeleteLicenceService.go(licence, billRun, notifierFake)
 
         const result = await InvoiceModel.query().findById(transaction.invoiceId)
         expect(result.debitLineCount).to.equal(0)
@@ -134,14 +134,14 @@ describe('Delete Licence service', () => {
         })
 
         it('to `true` when still applicable', async () => {
-          await DeleteLicenceService.go(secondLicence, notifierFake)
+          await DeleteLicenceService.go(secondLicence, billRun, notifierFake)
 
           const result = await InvoiceModel.query().findById(transaction.invoiceId)
           expect(result.zeroValueInvoice).to.be.true()
         })
 
         it('to `false` when not applicable', async () => {
-          await DeleteLicenceService.go(licence, notifierFake)
+          await DeleteLicenceService.go(licence, billRun, notifierFake)
 
           const result = await InvoiceModel.query().findById(secondTransaction.invoiceId)
           expect(result.zeroValueInvoice).to.be.false()
@@ -172,14 +172,14 @@ describe('Delete Licence service', () => {
         })
 
         it('to `true` when still applicable', async () => {
-          await DeleteLicenceService.go(secondLicence, notifierFake)
+          await DeleteLicenceService.go(secondLicence, billRun, notifierFake)
 
           const result = await InvoiceModel.query().findById(transaction.invoiceId)
           expect(result.deminimisInvoice).to.be.true()
         })
 
         it('to `false` when not applicable', async () => {
-          await DeleteLicenceService.go(licence, notifierFake)
+          await DeleteLicenceService.go(licence, billRun, notifierFake)
 
           const result = await InvoiceModel.query().findById(secondTransaction.invoiceId)
           expect(result.deminimisInvoice).to.be.false()
@@ -204,14 +204,14 @@ describe('Delete Licence service', () => {
         })
 
         it('to `true` when still applicable', async () => {
-          await DeleteLicenceService.go(licence, notifierFake)
+          await DeleteLicenceService.go(licence, billRun, notifierFake)
 
           const result = await InvoiceModel.query().findById(minimumChargeLicence.invoiceId)
           expect(result.minimumChargeInvoice).to.be.true()
         })
 
         it('to `false` when not applicable', async () => {
-          await DeleteLicenceService.go(minimumChargeLicence, notifierFake)
+          await DeleteLicenceService.go(minimumChargeLicence, billRun, notifierFake)
 
           const result = await InvoiceModel.query().findById(licence.invoiceId)
           expect(result.minimumChargeInvoice).to.be.false()
@@ -247,7 +247,7 @@ describe('Delete Licence service', () => {
           describe('if the one less than £25 is deleted', () => {
             describe("from an 'intialised' bill run", () => {
               it('sets the `minimumChargeInvoice` flag correctly (false)', async () => {
-                await DeleteLicenceService.go(lessThanMinLicence, notifierFake)
+                await DeleteLicenceService.go(lessThanMinLicence, billRun, notifierFake)
 
                 const result = await InvoiceModel.query().findById(lessThanMinLicence.invoiceId)
                 expect(result.minimumChargeInvoice).to.be.false()
@@ -257,7 +257,7 @@ describe('Delete Licence service', () => {
             describe("from a 'generated' bill run", () => {
               it('sets the `minimumChargeInvoice` flag correctly (false)', async () => {
                 await GenerateBillRunService.go(fixBillRun)
-                await DeleteLicenceService.go(lessThanMinLicence, notifierFake)
+                await DeleteLicenceService.go(lessThanMinLicence, billRun, notifierFake)
 
                 const result = await InvoiceModel.query().findById(lessThanMinLicence.invoiceId)
                 expect(result.minimumChargeInvoice).to.be.false()
@@ -268,7 +268,7 @@ describe('Delete Licence service', () => {
           describe('if the one more than £25 is deleted', () => {
             describe("from an 'intialised' bill run", () => {
               it('sets the `minimumChargeInvoice` flag correctly (false)', async () => {
-                await DeleteLicenceService.go(moreThanMinLicence, notifierFake)
+                await DeleteLicenceService.go(moreThanMinLicence, billRun, notifierFake)
 
                 const result = await InvoiceModel.query().findById(moreThanMinLicence.invoiceId)
                 expect(result.minimumChargeInvoice).to.be.false()
@@ -278,7 +278,7 @@ describe('Delete Licence service', () => {
             describe("from an 'generated' bill run", () => {
               it('sets the `minimumChargeInvoice` flag correctly (true)', async () => {
                 await GenerateBillRunService.go(fixBillRun)
-                await DeleteLicenceService.go(moreThanMinLicence, notifierFake)
+                await DeleteLicenceService.go(moreThanMinLicence, billRun, notifierFake)
 
                 const result = await InvoiceModel.query().findById(moreThanMinLicence.invoiceId)
                 expect(result.minimumChargeInvoice).to.be.true()
@@ -294,7 +294,7 @@ describe('Delete Licence service', () => {
 
         await GenerateBillRunService.go(billRun)
 
-        await DeleteLicenceService.go(licence, notifierFake)
+        await DeleteLicenceService.go(licence, billRun, notifierFake)
 
         const result = await BillRunModel.query().findById(transaction.billRunId)
         expect(result.invoiceValue).to.equal(0)
@@ -305,14 +305,14 @@ describe('Delete Licence service', () => {
 
     describe('when there are no licences left', () => {
       it('deletes the invoice', async () => {
-        await DeleteLicenceService.go(licence, notifierFake)
+        await DeleteLicenceService.go(licence, billRun, notifierFake)
 
         const result = await InvoiceModel.query().findById(transaction.invoiceId)
         expect(result).to.be.undefined()
       })
 
       it('updates the bill run level figures', async () => {
-        await DeleteLicenceService.go(licence, notifierFake)
+        await DeleteLicenceService.go(licence, billRun, notifierFake)
 
         const result = await BillRunModel.query().findById(transaction.billRunId)
         expect(result.debitLineCount).to.equal(0)
@@ -324,7 +324,7 @@ describe('Delete Licence service', () => {
   describe('When an error occurs', () => {
     it('calls the notifier', async () => {
       const invalidParamater = GeneralHelper.uuid4()
-      await DeleteLicenceService.go(invalidParamater, notifierFake)
+      await DeleteLicenceService.go(invalidParamater, billRun, notifierFake)
 
       expect(notifierFake.omfg.callCount).to.equal(1)
       expect(notifierFake.omfg.firstArg).to.equal('Error deleting licence')


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/projects/CMEA/boards/907?selectedIssue=CMEA-141

Unlike other endpoints which set off a background task and return a response immediately, Delete Licence does not update the bill run status to reflect the fact that an operation is running which could affect the bill run values. We therefore update `DeleteLicenceService` to do this.

One case to consider is when deleting the licence causes the invoice to be empty and therefore deleted, which in turn causes the bill run to be empty, in which case the status will be changed to `initialised`. We ensure that this is not overwritten by reverting to the original status by checking whether the status changed during deletion before restoring it.

Finally, we update the service's unit tests to use our new test helpers.