### PR TITLE
Fix deleting a deminimis invoice recalculation

### DIFF
--- a/app/services/invoices/delete_invoice.service.js
+++ b/app/services/invoices/delete_invoice.service.js
@@ -89,7 +89,9 @@ class DeleteInvoiceService {
         creditNoteCount: raw('credit_note_count - 1'),
         creditNoteValue: raw('credit_note_value - ?', invoice.$absoluteNetTotal())
       })
-    } else {
+      // Deminimis invoices (ones less than £5 in value) are not included in the invoice values when a bill run is
+      // generated. So, their values shouldn't be deducted when deleted
+    } else if (!invoice.deminimisInvoice) {
       Object.assign(update, {
         invoiceCount: raw('invoice_count - 1'),
         invoiceValue: raw('invoice_value - ?', invoice.$absoluteNetTotal())

--- a/test/services/invoices/delete_invoice.service.test.js
+++ b/test/services/invoices/delete_invoice.service.test.js
@@ -360,9 +360,6 @@ describe('Delete Invoice service', () => {
         const otherLicence = await NewLicenceHelper.create(otherInvoice, { licenceNumber: 'OTHER_LICENCE' })
         const otherTransaction = await NewTransactionHelper.create(otherLicence, { customerReference: 'SOMEONE_ELSE' })
 
-        await otherTransaction.$query().patch({ billRunId: billRun.id })
-        await LicenceModel.query().patch({ billRunId: billRun.id }).findById(otherTransaction.licenceId)
-        await InvoiceModel.query().patch({ billRunId: billRun.id }).findById(otherTransaction.invoiceId)
       })
 
       it('leaves the bill run status as-is', async () => {

--- a/test/services/invoices/delete_invoice.service.test.js
+++ b/test/services/invoices/delete_invoice.service.test.js
@@ -10,12 +10,11 @@ const { expect } = Code
 
 // Test helpers
 const {
-  AuthorisedSystemHelper,
-  BillRunHelper,
   DatabaseHelper,
   GeneralHelper,
-  RegimeHelper,
-  RulesServiceHelper
+  NewTransactionHelper,
+  NewInvoiceHelper,
+  NewLicenceHelper
 } = require('../../support/helpers')
 
 const {
@@ -25,39 +24,16 @@ const {
   TransactionModel
 } = require('../../../app/models')
 
-const { presroc: requestFixtures } = require('../../support/fixtures/create_transaction')
-const { presroc: chargeFixtures } = require('../../support/fixtures/calculate_charge')
-
-const { rulesService: rulesServiceResponse } = chargeFixtures.simple
-
-const { CreateTransactionService, GenerateBillRunService } = require('../../../app/services')
-
-// Things we need to stub
-const { RequestRulesServiceCharge } = require('../../../app/services')
+const { GenerateBillRunService } = require('../../../app/services')
 
 // Thing under test
 const { DeleteInvoiceService } = require('../../../app/services')
 
 describe('Delete Invoice service', () => {
-  let billRun
-  let authorisedSystem
-  let regime
-  let payload
-  let invoice
-  let rulesServiceStub
   let notifierFake
 
   beforeEach(async () => {
     await DatabaseHelper.clean()
-    regime = await RegimeHelper.addRegime('wrls', 'WRLS')
-    authorisedSystem = await AuthorisedSystemHelper.addSystem('1234546789', 'system1', [regime])
-
-    // We clone the request fixture as our payload so we have it available for modification in the invalid tests. For
-    // the valid tests we can use it straight as
-    payload = GeneralHelper.cloneObject(requestFixtures.simple)
-
-    rulesServiceStub = Sinon.stub(RequestRulesServiceCharge, 'go').returns(rulesServiceResponse)
-    billRun = await BillRunHelper.addBillRun(authorisedSystem.id, regime.id)
 
     // Create a fake function to stand in place of Notifier.omfg()
     notifierFake = { omfg: Sinon.fake() }
@@ -68,10 +44,15 @@ describe('Delete Invoice service', () => {
   })
 
   describe('When a valid invoice is supplied', () => {
+    let transaction
+    let invoice
+    let billRun
+
     describe("and it's a debit invoice", () => {
       beforeEach(async () => {
-        await CreateTransactionService.go(payload, billRun, authorisedSystem, regime)
-        invoice = await InvoiceModel.query().findOne({ billRunId: billRun.id })
+        transaction = await NewTransactionHelper.create()
+        invoice = await InvoiceModel.query().findById(transaction.invoiceId)
+        billRun = await BillRunModel.query().findById(transaction.billRunId)
       })
 
       it('deletes the invoice', async () => {
@@ -85,41 +66,40 @@ describe('Delete Invoice service', () => {
       it('updates the bill run values', async () => {
         // We generate the bill run and retrieve the invoice again to ensure that the invoice-level figures are updated
         await GenerateBillRunService.go(billRun)
-        invoice = await InvoiceModel.query().findOne({ billRunId: billRun.id })
+        invoice = await invoice.$query()
 
         await DeleteInvoiceService.go(invoice, billRun.id)
 
-        const result = await BillRunModel.query().findById(billRun.id)
+        billRun = await billRun.$query()
 
-        expect(result.debitLineCount).to.equal(0)
-        expect(result.debitLineValue).to.equal(0)
-        expect(result.invoiceCount).to.equal(0)
-        expect(result.invoiceValue).to.equal(0)
+        expect(billRun.debitLineCount).to.equal(0)
+        expect(billRun.debitLineValue).to.equal(0)
+        expect(billRun.invoiceCount).to.equal(0)
+        expect(billRun.invoiceValue).to.equal(0)
       })
 
       it('deletes the invoice licences', async () => {
-        const invoice = await InvoiceModel.query().findOne({ billRunId: billRun.id })
-
         await DeleteInvoiceService.go(invoice, billRun.id)
 
-        const licences = await LicenceModel.query().select().where({ billRunId: billRun.id })
+        const licences = await LicenceModel.query().select().where({ invoiceId: invoice.id })
+
         expect(licences).to.be.empty()
       })
 
       it('deletes the invoice transactions', async () => {
-        const invoice = await InvoiceModel.query().findOne({ billRunId: billRun.id })
-
         await DeleteInvoiceService.go(invoice, billRun.id)
 
-        const transactions = await TransactionModel.query().select().where({ billRunId: billRun.id })
+        const transactions = await TransactionModel.query().select().where({ invoiceId: invoice.id })
+
         expect(transactions).to.be.empty()
       })
     })
 
     describe("and it's a credit invoice", () => {
       beforeEach(async () => {
-        await CreateTransactionService.go({ ...payload, credit: true }, billRun, authorisedSystem, regime)
-        invoice = await InvoiceModel.query().findOne({ billRunId: billRun.id })
+        transaction = await NewTransactionHelper.create(null, { chargeCredit: true })
+        invoice = await InvoiceModel.query().findById(transaction.invoiceId)
+        billRun = await BillRunModel.query().findById(transaction.billRunId)
       })
 
       it('deletes the invoice', async () => {
@@ -133,43 +113,40 @@ describe('Delete Invoice service', () => {
       it('updates the bill run values', async () => {
         // We generate the bill run and retrieve the invoice again to ensure that the invoice-level figures are updated
         await GenerateBillRunService.go(billRun)
-        invoice = await InvoiceModel.query().findOne({ billRunId: billRun.id })
+        invoice = await invoice.$query()
 
         await DeleteInvoiceService.go(invoice, billRun.id)
 
-        const result = await BillRunModel.query().findById(billRun.id)
+        billRun = await billRun.$query()
 
-        expect(result.creditLineCount).to.equal(0)
-        expect(result.creditLineValue).to.equal(0)
-        expect(result.creditNoteCount).to.equal(0)
-        expect(result.creditNoteValue).to.equal(0)
+        expect(billRun.creditLineCount).to.equal(0)
+        expect(billRun.creditLineValue).to.equal(0)
+        expect(billRun.creditNoteCount).to.equal(0)
+        expect(billRun.creditNoteValue).to.equal(0)
       })
 
       it('deletes the invoice licences', async () => {
-        const invoice = await InvoiceModel.query().findOne({ billRunId: billRun.id })
-
         await DeleteInvoiceService.go(invoice, billRun.id)
 
-        const licences = await LicenceModel.query().select().where({ billRunId: billRun.id })
+        const licences = await LicenceModel.query().select().where({ invoiceId: invoice.id })
+
         expect(licences).to.be.empty()
       })
 
       it('deletes the invoice transactions', async () => {
-        const invoice = await InvoiceModel.query().findOne({ billRunId: billRun.id })
-
         await DeleteInvoiceService.go(invoice, billRun.id)
 
-        const transactions = await TransactionModel.query().select().where({ billRunId: billRun.id })
+        const transactions = await TransactionModel.query().select().where({ invoiceId: invoice.id })
+
         expect(transactions).to.be.empty()
       })
     })
 
     describe("and it's a zero value invoice", () => {
       beforeEach(async () => {
-        rulesServiceStub.restore()
-        RulesServiceHelper.mockValue(Sinon, RequestRulesServiceCharge, rulesServiceResponse, 0)
-        await CreateTransactionService.go(payload, billRun, authorisedSystem, regime)
-        invoice = await InvoiceModel.query().findOne({ billRunId: billRun.id })
+        transaction = await NewTransactionHelper.create(null, { chargeValue: 0 })
+        invoice = await InvoiceModel.query().findById(transaction.invoiceId)
+        billRun = await BillRunModel.query().findById(transaction.billRunId)
       })
 
       it('deletes the invoice', async () => {
@@ -183,43 +160,37 @@ describe('Delete Invoice service', () => {
       it('updates the bill run values', async () => {
         // We generate the bill run and retrieve the invoice again to ensure that the invoice-level figures are updated
         await GenerateBillRunService.go(billRun)
-        invoice = await InvoiceModel.query().findOne({ billRunId: billRun.id })
+        invoice = await invoice.$query()
 
         await DeleteInvoiceService.go(invoice, billRun.id)
 
-        const result = await BillRunModel.query().findById(billRun.id)
+        billRun = await billRun.$query()
 
-        expect(result.zeroLineCount).to.equal(0)
+        expect(billRun.zeroLineCount).to.equal(0)
       })
 
       it('deletes the invoice licences', async () => {
-        const invoice = await InvoiceModel.query().findOne({ billRunId: billRun.id })
-
         await DeleteInvoiceService.go(invoice, billRun.id)
 
-        const licences = await LicenceModel.query().select().where({ billRunId: billRun.id })
+        const licences = await LicenceModel.query().select().where({ invoiceId: invoice.id })
+
         expect(licences).to.be.empty()
       })
 
       it('deletes the invoice transactions', async () => {
-        const invoice = await InvoiceModel.query().findOne({ billRunId: billRun.id })
-
         await DeleteInvoiceService.go(invoice, billRun.id)
 
-        const transactions = await TransactionModel.query().select().where({ billRunId: billRun.id })
+        const transactions = await TransactionModel.query().select().where({ invoiceId: invoice.id })
+
         expect(transactions).to.be.empty()
       })
     })
 
     describe("and it's a minimum charge debit invoice", () => {
       beforeEach(async () => {
-        rulesServiceStub.restore()
-        RulesServiceHelper.mockValue(Sinon, RequestRulesServiceCharge, rulesServiceResponse, 500)
-        await CreateTransactionService.go({
-          ...payload,
-          subjectToMinimumCharge: true
-        }, billRun, authorisedSystem, regime)
-        invoice = await InvoiceModel.query().findOne({ billRunId: billRun.id })
+        transaction = await NewTransactionHelper.create(null, { subjectToMinimumCharge: true })
+        invoice = await InvoiceModel.query().findById(transaction.invoiceId)
+        billRun = await BillRunModel.query().findById(transaction.billRunId)
       })
 
       it('deletes the invoice', async () => {
@@ -233,49 +204,42 @@ describe('Delete Invoice service', () => {
       it('updates the bill run values', async () => {
         // We generate the bill run and retrieve the invoice again to ensure that the invoice-level figures are updated
         await GenerateBillRunService.go(billRun)
-        invoice = await InvoiceModel.query().findOne({ billRunId: billRun.id })
+        invoice = await invoice.$query()
 
         await DeleteInvoiceService.go(invoice, billRun.id)
 
-        const result = await BillRunModel.query().findById(billRun.id)
+        billRun = await billRun.$query()
 
-        expect(result.debitLineCount).to.equal(0)
-        expect(result.debitLineValue).to.equal(0)
-        expect(result.subjectToMinimumChargeCount).to.equal(0)
-        expect(result.subjectToMinimumChargeDebitValue).to.equal(0)
-        expect(result.invoiceCount).to.equal(0)
-        expect(result.invoiceValue).to.equal(0)
+        expect(billRun.debitLineCount).to.equal(0)
+        expect(billRun.debitLineValue).to.equal(0)
+        expect(billRun.subjectToMinimumChargeCount).to.equal(0)
+        expect(billRun.subjectToMinimumChargeDebitValue).to.equal(0)
+        expect(billRun.invoiceCount).to.equal(0)
+        expect(billRun.invoiceValue).to.equal(0)
       })
 
       it('deletes the invoice licences', async () => {
-        const invoice = await InvoiceModel.query().findOne({ billRunId: billRun.id })
-
         await DeleteInvoiceService.go(invoice, billRun.id)
 
-        const licences = await LicenceModel.query().select().where({ billRunId: billRun.id })
+        const licences = await LicenceModel.query().select().where({ invoiceId: invoice.id })
+
         expect(licences).to.be.empty()
       })
 
       it('deletes the invoice transactions', async () => {
-        const invoice = await InvoiceModel.query().findOne({ billRunId: billRun.id })
-
         await DeleteInvoiceService.go(invoice, billRun.id)
 
-        const transactions = await TransactionModel.query().select().where({ billRunId: billRun.id })
+        const transactions = await TransactionModel.query().select().where({ invoiceId: invoice.id })
+
         expect(transactions).to.be.empty()
       })
     })
 
     describe("and it's a minimum charge credit invoice", () => {
       beforeEach(async () => {
-        rulesServiceStub.restore()
-        RulesServiceHelper.mockValue(Sinon, RequestRulesServiceCharge, rulesServiceResponse, 500)
-        await CreateTransactionService.go({
-          ...payload,
-          subjectToMinimumCharge: true,
-          credit: true
-        }, billRun, authorisedSystem, regime)
-        invoice = await InvoiceModel.query().findOne({ billRunId: billRun.id })
+        transaction = await NewTransactionHelper.create(null, { subjectToMinimumCharge: true, chargeCredit: true })
+        invoice = await InvoiceModel.query().findById(transaction.invoiceId)
+        billRun = await BillRunModel.query().findById(transaction.billRunId)
       })
 
       it('deletes the invoice', async () => {
@@ -289,77 +253,77 @@ describe('Delete Invoice service', () => {
       it('updates the bill run values', async () => {
         // We generate the bill run and retrieve the invoice again to ensure that the invoice-level figures are updated
         await GenerateBillRunService.go(billRun)
-        invoice = await InvoiceModel.query().findOne({ billRunId: billRun.id })
+        invoice = await invoice.$query()
 
         await DeleteInvoiceService.go(invoice, billRun.id)
 
-        const result = await BillRunModel.query().findById(billRun.id)
+        billRun = await billRun.$query()
 
-        expect(result.creditLineCount).to.equal(0)
-        expect(result.creditLineValue).to.equal(0)
-        expect(result.subjectToMinimumChargeCount).to.equal(0)
-        expect(result.subjectToMinimumChargeCreditValue).to.equal(0)
-        expect(result.creditNoteCount).to.equal(0)
-        expect(result.creditNoteValue).to.equal(0)
+        expect(billRun.creditLineCount).to.equal(0)
+        expect(billRun.creditLineValue).to.equal(0)
+        expect(billRun.subjectToMinimumChargeCount).to.equal(0)
+        expect(billRun.subjectToMinimumChargeCreditValue).to.equal(0)
+        expect(billRun.creditNoteCount).to.equal(0)
+        expect(billRun.creditNoteValue).to.equal(0)
       })
 
       it('deletes the invoice licences', async () => {
-        const invoice = await InvoiceModel.query().findOne({ billRunId: billRun.id })
-
         await DeleteInvoiceService.go(invoice, billRun.id)
 
-        const licences = await LicenceModel.query().select().where({ billRunId: billRun.id })
+        const licences = await LicenceModel.query().select().where({ invoiceId: invoice.id })
+
         expect(licences).to.be.empty()
       })
 
       it('deletes the invoice transactions', async () => {
-        const invoice = await InvoiceModel.query().findOne({ billRunId: billRun.id })
-
         await DeleteInvoiceService.go(invoice, billRun.id)
 
-        const transactions = await TransactionModel.query().select().where({ billRunId: billRun.id })
+        const transactions = await TransactionModel.query().select().where({ invoiceId: invoice.id })
+
         expect(transactions).to.be.empty()
       })
     })
 
     describe("and it's the only invoice in the bill run", () => {
       beforeEach(async () => {
-        await CreateTransactionService.go(payload, billRun, authorisedSystem, regime)
-        invoice = await InvoiceModel.query().findOne({ billRunId: billRun.id })
+        transaction = await NewTransactionHelper.create()
+        invoice = await InvoiceModel.query().findById(transaction.invoiceId)
+        billRun = await BillRunModel.query().findById(transaction.billRunId)
+
         await billRun.$query().patch({ status: 'NOT_INITIALISED' })
       })
 
       it("changes the bill run status to 'initialised'", async () => {
         await DeleteInvoiceService.go(invoice, billRun.id)
 
-        const result = await BillRunModel.query().findById(billRun.id)
+        billRun = await billRun.$query()
 
-        expect(result.status).to.equal('initialised')
+        expect(billRun.status).to.equal('initialised')
       })
     })
 
     describe('and there are other invoices in the bill run', () => {
       beforeEach(async () => {
-        await CreateTransactionService.go(payload, billRun, authorisedSystem, regime)
-        await CreateTransactionService.go({
-          ...payload,
-          customerReference: 'SOMEONE_ELSE'
-        }, billRun, authorisedSystem, regime)
-
-        invoice = await InvoiceModel.query().findOne({
-          billRunId: billRun.id,
-          customerReference: payload.customerReference
-        })
-
+        transaction = await NewTransactionHelper.create()
+        invoice = await InvoiceModel.query().findById(transaction.invoiceId)
+        billRun = await BillRunModel.query().findById(transaction.billRunId)
         await billRun.$query().patch({ status: 'NOT_INITIALISED' })
+
+        const otherInvoice = await NewInvoiceHelper.create(billRun, { customerReference: 'SOMEONE_ELSE' })
+        const otherLicence = await NewLicenceHelper.create(otherInvoice, { licenceNumber: 'OTHER_LICENCE' })
+        const otherTransaction = await NewTransactionHelper.create(otherLicence, { customerReference: 'SOMEONE_ELSE' })
+
+        await otherTransaction.$query().patch({ billRunId: billRun.id })
+        await LicenceModel.query().patch({ billRunId: billRun.id }).findById(otherTransaction.licenceId)
+        await InvoiceModel.query().patch({ billRunId: billRun.id }).findById(otherTransaction.invoiceId)
       })
 
       it('leaves the bill run status as-is', async () => {
         await DeleteInvoiceService.go(invoice, billRun.id)
 
-        const result = await BillRunModel.query().findById(billRun.id)
+        billRun = await billRun.$query()
 
-        expect(result.status).to.equal('NOT_INITIALISED')
+        expect(billRun.status).to.equal('NOT_INITIALISED')
       })
     })
   })

--- a/test/services/invoices/delete_invoice.service.test.js
+++ b/test/services/invoices/delete_invoice.service.test.js
@@ -358,7 +358,7 @@ describe('Delete Invoice service', () => {
 
         const otherInvoice = await NewInvoiceHelper.create(billRun, { customerReference: 'SOMEONE_ELSE' })
         const otherLicence = await NewLicenceHelper.create(otherInvoice, { licenceNumber: 'OTHER_LICENCE' })
-        const otherTransaction = await NewTransactionHelper.create(otherLicence, { customerReference: 'SOMEONE_ELSE' })
+        await NewTransactionHelper.create(otherLicence, { customerReference: 'SOMEONE_ELSE' })
 
       })
 

--- a/test/services/invoices/delete_invoice.service.test.js
+++ b/test/services/invoices/delete_invoice.service.test.js
@@ -359,7 +359,6 @@ describe('Delete Invoice service', () => {
         const otherInvoice = await NewInvoiceHelper.create(billRun, { customerReference: 'SOMEONE_ELSE' })
         const otherLicence = await NewLicenceHelper.create(otherInvoice, { licenceNumber: 'OTHER_LICENCE' })
         await NewTransactionHelper.create(otherLicence, { customerReference: 'SOMEONE_ELSE' })
-
       })
 
       it('leaves the bill run status as-is', async () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/CMEA-171

After a discrepancy with a bill run's summary was reported we tracked it down to an error when a deminimis invoice is deleted.

Deminimis invoices (debits £5 or less) are not included in the bill run summary. This means when it's generated they are not included in the invoice count and total value. So, when deleted they should not impact those values in the bill run. The problem is that we are updating the bill run when a deminimis invoice is deleted.

This change fixes the issue and ensures the bill run summary is correctly updated when a deminimis invoice is deleted.

**How to reproduce**

Create a bill run and add 5 invoices; 4 standard and 1 deminimis. Generate the bill run and it will show 4 invoices in the summary. The invoice value will be the total of the 4 non-deminimis invoices.

All is good so far.

Then delete the deminimis invoice. The debit line count and values should change but the invoice values should not. The deminimis invoice was not included in the original calculation so it should not be affecting them.
