### PR TITLE
Fix `ListCustomerFilesService` time boundary defect

### DIFF
--- a/app/services/files/customers/list_customer_files.service.js
+++ b/app/services/files/customers/list_customer_files.service.js
@@ -31,7 +31,7 @@ class ListCustomerFilesService {
       .query()
       .where('regimeId', regimeId)
       .where('status', 'exported')
-      .where('exportedAt', '>', startDate)
+      .where('exportedAt', '>=', startDate)
       .select('id', 'fileReference', 'status', 'exportedAt')
       .withGraphFetched('exportedCustomers')
       .modifyGraph('exportedCustomers', builder => {

--- a/test/services/files/customers/list_customer_files.service.test.js
+++ b/test/services/files/customers/list_customer_files.service.test.js
@@ -47,7 +47,8 @@ describe('List Customer Files service', () => {
   describe('When there are customer files', () => {
     let todayFile
     let yesterdayFile
-    let yearAgo
+    let yearAgoFile
+    let midnightFile
     let initialisedFile
     let otherRegimeFile
     let todayCustomer
@@ -62,14 +63,17 @@ describe('List Customer Files service', () => {
         yesterdayFile = await CustomerHelper.addCustomerFile(regime, 'A', 'nalac50002', 'exported', GeneralHelper.daysAgoDate(1))
         yesterdayCustomer = await CustomerHelper.addExportedCustomer(yesterdayFile, '1DAY')
 
-        yearAgo = await CustomerHelper.addCustomerFile(regime, 'A', 'nalac50003', 'exported', GeneralHelper.daysAgoDate(365))
-        yearAgoCustomer = await CustomerHelper.addExportedCustomer(yearAgo, '365DAY')
+        yearAgoFile = await CustomerHelper.addCustomerFile(regime, 'A', 'nalac50003', 'exported', GeneralHelper.daysAgoDate(365))
+        yearAgoCustomer = await CustomerHelper.addExportedCustomer(yearAgoFile, '365DAY')
 
         initialisedFile = await CustomerHelper.addCustomerFile(regime, 'A', 'nalac50004', 'initialised')
 
         const otherRegime = await RegimeHelper.addRegime('other', 'Other')
         otherRegimeFile = await CustomerHelper.addCustomerFile(otherRegime, 'A', 'nalac50005', 'exported')
         await CustomerHelper.addExportedCustomer(otherRegimeFile, 'OTHER0DAY')
+
+        midnightFile = await CustomerHelper.addCustomerFile(regime, 'A', 'nalac50006', 'exported', GeneralHelper.daysAgoDate(60, 0, 0, 0, 0))
+        await CustomerHelper.addCustomerFile(regime, 'A', 'nalac50006', 'initialised')
       })
 
       it('returns files exported in the specified number of days', async () => {
@@ -80,7 +84,7 @@ describe('List Customer Files service', () => {
           todayFile.fileReference,
           yesterdayFile.fileReference
         ])
-        expect(result).to.not.include(yearAgo.fileReference)
+        expect(result).to.not.include(yearAgoFile.fileReference)
       })
 
       it("returns only today's files if given an argument of 0 days", async () => {
@@ -90,7 +94,7 @@ describe('List Customer Files service', () => {
         expect(result).to.include(todayFile.fileReference)
         expect(result).to.not.include([
           yesterdayFile.fileReference,
-          yearAgo.fileReference
+          yearAgoFile.fileReference
         ])
       })
 
@@ -124,6 +128,13 @@ describe('List Customer Files service', () => {
         const result = customerFiles.map(file => file.fileReference)
 
         expect(result).to.not.include(initialisedFile.fileReference)
+      })
+
+      it('includes files exported at exactly midnight (ie. 00:00:00.000)', async () => {
+        const customerFiles = await ListCustomerFilesService.go(regime, 60)
+        const result = customerFiles.map(file => file.fileReference)
+
+        expect(result).to.include(midnightFile.fileReference)
       })
     })
   })

--- a/test/support/helpers/general.helper.js
+++ b/test/support/helpers/general.helper.js
@@ -84,14 +84,29 @@ class GeneralHelper {
   }
 
   /**
-   * Returns the date a given number of days ago, where 0 = today, 1 = yesterday, etc. The returned Date object will
-   * have its time set to the current time, eg. if Date.now() is 2021-09-06T14:01:15.929Z then daysAgoDate(1) would be
-   * 2021-09-05T14:01:15.929Z.
+   * Returns the date a given number of days ago, where 0 = today, 1 = yesterday, etc. Optionally, the time element of
+   * the returned date object can be specified, with the hour, minute, second and millisecond component of the time
+   * specified separately. Any not specified will default to the current hour, minute, second or millisecond, eg. if
+   * the current date and time is 2021-03-05T11:06:43.123Z then daysAgoDate(1, 9, 29) would be 2021-03-04T09:29:43.123Z
+   *
+   * @param {integer} days Number of days to go back, eg. 0 = today, 1 = yesterday, etc.
+   * @param {integer} [hour] The hour part of the time to return. Defaults to the current hour.
+   * @param {integer} [minute] The minute part of the time to return. Defaults to the current minute.
+   * @param {integer} [second] The second part of the time to return. Defaults to the current second.
+   * @param {integer} [millisecond] The millisecond part of the time to return. Defaults to the current millisecond.
+   * @returns {date} The resulting date object.
    */
-  static daysAgoDate (days) {
+  static daysAgoDate (
+    days,
+    hour = new Date().getHours(),
+    minute = new Date().getMinutes(),
+    second = new Date().getSeconds(),
+    millisecond = new Date().getMilliseconds()
+  ) {
     const date = new Date()
 
     date.setDate(date.getDate() - days)
+    date.setHours(hour, minute, second, millisecond)
 
     return date
   }


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/projects/CMEA/boards/907?selectedIssue=CMEA-57

It was spotted during testing that any customer files exported at exactly midnight (ie. with a timestamp of `00:00:00.000` are not included in the service output. Although this is the edgiest of edge cases, it is still worth resolving, and it has a very simple cause and solution -- we were selecting the files to be included with `.where('exportedAt', '>', startDate)` when we should have been using `.where('exportedAt', '>=', startDate)`.