### PR TITLE
Fix incorrect `ValidateBillRunLicenceService` parameter issue

### DIFF
--- a/app/controllers/bill_runs_licences.controller.js
+++ b/app/controllers/bill_runs_licences.controller.js
@@ -5,7 +5,7 @@ const { DeleteLicenceService, ValidateBillRunLicenceService } = require('../serv
 class BillRunsLicencesController {
   static async delete (req, h) {
     // We validate the licence within the controller so a validation error is returned immediately
-    await ValidateBillRunLicenceService.go(req.app.billRun, req.app.licence)
+    await ValidateBillRunLicenceService.go(req.app.billRun.id, req.app.licence)
 
     // We start DeleteLicenceService without await so that it runs in the background
     DeleteLicenceService.go(req.app.licence, req.app.billRun, req.app.notifier)

--- a/test/controllers/bill_runs_licences.controller.test.js
+++ b/test/controllers/bill_runs_licences.controller.test.js
@@ -94,12 +94,16 @@ describe('Licences controller', () => {
         await server.inject(options(authToken, billRun.id, licence.id))
 
         expect(validationStub.calledOnce).to.be.true()
+        expect(validationStub.firstCall.args[0]).to.equal(billRun.id)
+        expect(validationStub.firstCall.args[1]).to.equal(licence)
       })
 
       it('calls the licence deletion service', async () => {
         await server.inject(options(authToken, billRun.id, licence.id))
 
         expect(deletionStub.calledOnce).to.be.true()
+        expect(deletionStub.firstCall.args[0]).to.equal(licence)
+        expect(deletionStub.firstCall.args[1]).to.equal(billRun)
       })
     })
 


### PR DESCRIPTION
While updating delete licence to set the status to `pending`, we inadvertently changed the call to `ValidateBillRunLicenceService` to pass the `billRun` object instead of `billRun.id`. We revert this here.