### PR TITLE
Fix deleting a zero value invoice recalculation

### DIFF
--- a/test/services/invoices/delete_invoice.service.test.js
+++ b/test/services/invoices/delete_invoice.service.test.js
@@ -29,7 +29,7 @@ const { GenerateBillRunService } = require('../../../app/services')
 // Thing under test
 const { DeleteInvoiceService } = require('../../../app/services')
 
-describe('Delete Invoice service', () => {
+describe.only('Delete Invoice service', () => {
   let notifierFake
 
   beforeEach(async () => {
@@ -167,6 +167,10 @@ describe('Delete Invoice service', () => {
         billRun = await billRun.$query()
 
         expect(billRun.zeroLineCount).to.equal(0)
+        expect(billRun.creditNoteCount).to.equal(0)
+        expect(billRun.creditNoteValue).to.equal(0)
+        expect(billRun.invoiceCount).to.equal(0)
+        expect(billRun.invoiceValue).to.equal(0)
       })
 
       it('deletes the invoice licences', async () => {

--- a/test/services/invoices/delete_invoice.service.test.js
+++ b/test/services/invoices/delete_invoice.service.test.js
@@ -29,7 +29,7 @@ const { GenerateBillRunService } = require('../../../app/services')
 // Thing under test
 const { DeleteInvoiceService } = require('../../../app/services')
 
-describe.only('Delete Invoice service', () => {
+describe('Delete Invoice service', () => {
   let notifierFake
 
   beforeEach(async () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/CMEA-171

Whilst testing [Fix deleting a deminimis invoice recalculation](https://github.com/DEFRA/sroc-charging-module-api/pull/561) we also ensured we checked what happens when deleting other invoice types. Immediately zero value invoices fell out as having an issue. Because they are zero value the bill run `invoice_value` remains unaffected. But we still decrement the invoice count, just like we were doing for deminimis invoices, even though zero value invoices are also not included in the invoice count.

This change fixes the `DeleteInvoiceService` to also ignore zero value invoices when it comes to updating a bill run's summary details.