### PR TITLE
Update test bill run generator with trans. multiplier

### DIFF
--- a/test/controllers/admin/test/test_bill_runs.controller.test.js
+++ b/test/controllers/admin/test/test_bill_runs.controller.test.js
@@ -70,7 +70,8 @@ describe('Test Bill Run Controller', () => {
           { type: 'mixed-credit', count: 1 },
           { type: 'zero-value', count: 1 },
           { type: 'deminimis', count: 1 },
-          { type: 'minimum-charge', count: 1 }
+          { type: 'minimum-charge', count: 1 },
+          { type: 'standard', count: 1 }
         ]
       }
 
@@ -97,9 +98,9 @@ describe('Test Bill Run Controller', () => {
       expect(response.statusCode).to.equal(201)
       expect(responsePayload.billRun.id).to.exist()
 
-      expect(invoices.length).to.equal(5)
+      expect(invoices.length).to.equal(6)
 
-      expect(transactions.length).to.equal(15)
+      expect(transactions.length).to.equal(18)
       expect(transactions.filter(tran => tran.chargeCredit).length).to.equal(4)
       expect(transactions.filter(tran => tran.subjectToMinimumCharge).length).to.equal(3)
     })

--- a/test/support/generators/bill_run.generator.js
+++ b/test/support/generators/bill_run.generator.js
@@ -40,6 +40,7 @@ class BillRunGenerator {
         customerIndex += 1
         const customerReference = `CM${customerIndex.toString().padStart(9, '0')}`
         const licenceNumber = `SROC/TF${customerIndex.toString().padStart(4, '0')}/01`
+        const transactionMultiplier = payload.transactionMultiplier == null ? 1 : payload.transactionMultiplier
 
         invoices.push({
           region: payload.region,
@@ -47,7 +48,8 @@ class BillRunGenerator {
           periodStart: '01-APR-2018',
           periodEnd: '31-MAR-2019',
           licenceNumber: licenceNumber,
-          type: options.type
+          type: options.type,
+          transactionMultiplier: transactionMultiplier
         })
       }
     })
@@ -111,9 +113,9 @@ class BillRunGenerator {
     ]
 
     invoiceData.data = this._transactionData(...transactionData, false, false)
-    await this._addTransaction(invoiceData)
-    await this._addTransaction(invoiceData)
-    await this._addTransaction(invoiceData)
+    for (let index = 0; index < invoiceData.invoice.transactionMultiplier; index++) {
+      await this._addTransaction(invoiceData)
+    }
   }
 
   static async _deminimisInvoice (invoiceData) {
@@ -137,11 +139,14 @@ class BillRunGenerator {
     ]
 
     invoiceData.data = this._transactionData(...transactionData, false, true)
-    await this._addTransaction(invoiceData)
-    await this._addTransaction(invoiceData)
+    for (let index = 0; index < (invoiceData.invoice.transactionMultiplier * 2); index++) {
+      await this._addTransaction(invoiceData)
+    }
 
     invoiceData.data = this._transactionData(...transactionData, true, true)
-    await this._addTransaction(invoiceData)
+    for (let index = 0; index < invoiceData.invoice.transactionMultiplier; index++) {
+      await this._addTransaction(invoiceData)
+    }
   }
 
   static async _mixedInvoice (invoiceData) {
@@ -152,11 +157,14 @@ class BillRunGenerator {
     ]
 
     invoiceData.data = this._transactionData(...transactionData, false, false)
-    await this._addTransaction(invoiceData)
-    await this._addTransaction(invoiceData)
+    for (let index = 0; index < (invoiceData.invoice.transactionMultiplier * 2); index++) {
+      await this._addTransaction(invoiceData)
+    }
 
     invoiceData.data = this._transactionData(...transactionData, true, false)
-    await this._addTransaction(invoiceData)
+    for (let index = 0; index < invoiceData.invoice.transactionMultiplier; index++) {
+      await this._addTransaction(invoiceData)
+    }
   }
 
   static async _mixedCredit (invoiceData) {
@@ -167,11 +175,14 @@ class BillRunGenerator {
     ]
 
     invoiceData.data = this._transactionData(...transactionData, true, false)
-    await this._addTransaction(invoiceData)
-    await this._addTransaction(invoiceData)
+    for (let index = 0; index < (invoiceData.invoice.transactionMultiplier * 2); index++) {
+      await this._addTransaction(invoiceData)
+    }
 
     invoiceData.data = this._transactionData(...transactionData, false, false)
-    await this._addTransaction(invoiceData)
+    for (let index = 0; index < invoiceData.invoice.transactionMultiplier; index++) {
+      await this._addTransaction(invoiceData)
+    }
   }
 
   static _transactionData (invoice, volume, chargeValue, credit, subjectToMinimumCharge) {

--- a/test/support/generators/bill_run.generator.js
+++ b/test/support/generators/bill_run.generator.js
@@ -66,6 +66,9 @@ class BillRunGenerator {
     }
 
     switch (invoice.type) {
+      case 'standard':
+        await this._standardInvoice(invoiceData)
+        break
       case 'mixed-invoice':
         await this._mixedInvoice(invoiceData)
         break
@@ -181,6 +184,19 @@ class BillRunGenerator {
 
     invoiceData.data = this._transactionData(...transactionData, false, false)
     for (let index = 0; index < invoiceData.invoice.transactionMultiplier; index++) {
+      await this._addTransaction(invoiceData)
+    }
+  }
+
+  static async _standardInvoice (invoiceData) {
+    const transactionData = [
+      invoiceData.invoice,
+      '50.22',
+      91.82
+    ]
+
+    invoiceData.data = this._transactionData(...transactionData, false, false)
+    for (let index = 0; index < (invoiceData.invoice.transactionMultiplier); index++) {
       await this._addTransaction(invoiceData)
     }
   }

--- a/test/support/generators/bill_run.generator.js
+++ b/test/support/generators/bill_run.generator.js
@@ -116,7 +116,7 @@ class BillRunGenerator {
     ]
 
     invoiceData.data = this._transactionData(...transactionData, false, false)
-    for (let index = 0; index < invoiceData.invoice.transactionMultiplier; index++) {
+    for (let index = 0; index < invoiceData.invoice.transactionMultiplier * 3; index++) {
       await this._addTransaction(invoiceData)
     }
   }
@@ -196,7 +196,7 @@ class BillRunGenerator {
     ]
 
     invoiceData.data = this._transactionData(...transactionData, false, false)
-    for (let index = 0; index < (invoiceData.invoice.transactionMultiplier); index++) {
+    for (let index = 0; index < (invoiceData.invoice.transactionMultiplier * 3); index++) {
       await this._addTransaction(invoiceData)
     }
   }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/CMEA-141

We've been trying to create a test where we can see the bill run status go to `pending` when a licence is deleted. Problem is, with a whole bunch of transactions the service is proving too fast to see it in our acceptance tests.

We have the bill run generator test endpoint. The only issue is the current counts relate to the number of invoices. The number of transactions per invoice is set in the code.

To give us a bit more flexibility, this change allows us to affect the number of transactions added per invoice by the generator.

It also adds a new invoice type of `standard` which just adds debit transactions.

```json
{
    "region": "A",
    "transactionMultiplier": 5,
    "mix": [
        { "type": "mixed-invoice", "count": 1 },
        { "type": "mixed-credit", "count": 1 },
        { "type": "zero-value", "count": 1 },
        { "type": "deminimis", "count": 1 },
        { "type": "minimum-charge", "count": 1 },
        { "type": "standard", "count": 1 }
    ]
}
```

**Note**

It's not always a direct translation. For example, if we set `transactionMultiplier` to 2 for a mixed invoice, we'll get 4 standard transactions and 2 credit transactions. This is because we are multiplying whatever we were adding before by the transaction multiplier.