### PR TITLE
Fix Delete Licence not correctly updating bill run summary

### DIFF
--- a/app/services/licences/delete_licence.service.js
+++ b/app/services/licences/delete_licence.service.js
@@ -10,15 +10,17 @@ const DeleteInvoiceService = require('../invoices/delete_invoice.service')
 
 class DeleteLicenceService {
   /**
-   * Deletes a licence along with its transactions and updates the invoice accordingly. Intended to be run as a
-   * background task by a controller, ie. called without an await. While the licence is being deleted, the bill run's
-   * status will be set to `pending`, and restored to its original status afterwards. Note that the licence will _not_
-   * be validated to ensure it is linked to the bill run; it is expected that this will be done from the calling
+   * Deletes a licence along with its transactions and updates the invoice and bill run accordingly. Intended to be run
+   * as a background task by a controller, ie. called without an await. While the licence is being deleted, the bill
+   * run's status will be set to `pending`, and restored to its original status afterwards. Note that the licence will
+   * _not_ be validated to ensure it is linked to the bill run; it is expected that this will be done from the calling
    * controller so that it can present the appropriate error to the user immediately.
    *
    * The invoice will be updated by subtracting the licence's credit/debit line count/value etc. and updating the zero
    * value, deminimis and minimum charge invoice flags. Note that this will be done regardless of whether or not the
    * bill run has been generated.
+   *
+   * If the bill run has been generated then the credit note/invoice count and value fields will be updated.
    *
    * @param {module:LicenceModel} licence The licence to be deleted.
    * @param {module:BillRunModel} billRun The bill run the licence belongs to, which we use to determine its current
@@ -29,11 +31,12 @@ class DeleteLicenceService {
   static async go (licence, billRun, notifier) {
     try {
       await LicenceModel.transaction(async trx => {
-        const { status: initialBillRunStatus } = billRun
+        // We need to know the bill run's initial status before it's set to `pending`
+        const { status: initialStatus } = billRun
 
         await this._setBillRunStatusPending(billRun, trx)
-        await this._deleteLicence(licence, notifier, initialBillRunStatus, trx)
-        await this._revertBillRunStatus(billRun, initialBillRunStatus, trx)
+        await this._deleteLicence(licence, notifier, initialStatus, trx)
+        await this._revertBillRunStatus(billRun, initialStatus, trx)
       })
     } catch (error) {
       notifier.omfg('Error deleting licence', { id: licence.id, error })
@@ -63,7 +66,7 @@ class DeleteLicenceService {
     return status
   }
 
-  static async _deleteLicence (licence, notifier, initialBillRunStatus, trx) {
+  static async _deleteLicence (licence, notifier, initialStatus, trx) {
     // We only need to delete the licence as it will cascade down to the transaction level.
     await LicenceModel
       .query(trx)
@@ -75,11 +78,9 @@ class DeleteLicenceService {
     const billRun = await licence.$relatedQuery('billRun', trx)
 
     if (licences.length) {
-      // Store the invoice's current transaction type (credit/invoice/zero) as we may need it to adjust the bill run
-      const invoiceTransactionType = this._transactionType(invoice)
-      const invoiceAbsoluteNetTotal = invoice.$absoluteNetTotal()
+      const previousInvoice = invoice.$clone()
       await this._handleInvoice(billRun, invoice, licence, trx)
-      await this._handleBillRun(billRun, invoice, licence, invoiceTransactionType, invoiceAbsoluteNetTotal, initialBillRunStatus, trx)
+      await this._handleBillRun(billRun, invoice, licence, previousInvoice, initialStatus, trx)
     } else {
       await DeleteInvoiceService.go(invoice, billRun, notifier, trx)
     }
@@ -100,8 +101,14 @@ class DeleteLicenceService {
    * Updates the bill run instance that the licence belongs to, then uses the updated fields to generate a patch which
    * is applied to the bill run in the db.
    */
-  static async _handleBillRun (billRun, invoice, licence, invoiceTransactionType, previousInvoiceAbsoluteNetTotal, initialBillRunStatus, trx) {
-    this._updateBillRunInstance(billRun, invoice, licence, invoiceTransactionType, previousInvoiceAbsoluteNetTotal, initialBillRunStatus)
+  static async _handleBillRun (billRun, invoice, licence, previousInvoice, initialStatus, trx) {
+    this._updateInstance(billRun, licence)
+
+    // We only need to update the bill run instance if it's been generated
+    if (initialStatus === 'generated') {
+      this._updateBillRunInstance(billRun, invoice, previousInvoice)
+    }
+
     const billRunPatch = this._billRunPatch(billRun)
     await billRun.$query(trx).patch(billRunPatch)
   }
@@ -202,39 +209,33 @@ class DeleteLicenceService {
   }
 
   /**
-   * Updates the bill run instance by first calling _updateInstance to update the standard fields, then updates two
-   * additional fields unique to the bill run, and finally adjusts the credit note/invoice count if the invoice that
-   * the licence belongs to is now zero value.
+   * Updates the bill run instance by removing the previous invoice net total from the appropriate credit/invoice field
+   * (based on whether the previous invoice was overall credit or invoice) and decrementing the appropriate count by 1;
+   * and then adding the new net invoice total to the appropriate credit/invoice field (based on whether the invoice is
+   * now overall credit or invoice) and incrementing the count by 1.
    */
-  static _updateBillRunInstance (billRun, invoice, licence, previousTransactionType, previousInvoiceAbsoluteNetTotal, initialBillRunStatus) {
-    this._updateInstance(billRun, licence)
-
-    // We only update the bill run stats if the bill run is generated
-    if (initialBillRunStatus !== 'generated') {
-      return
-    }
-
-    const currentInvoiceAbsoluteNetTotal = invoice.$absoluteNetTotal()
-    const currentTransactionType = this._transactionType(invoice)
+  static _updateBillRunInstance (billRun, updatedInvoice, previousInvoice) {
+    const previousTransactionType = this._transactionType(previousInvoice)
+    const currentTransactionType = this._transactionType(updatedInvoice)
 
     // Remove the old invoice value from the appropriate bill run field and adjust the count accordingly
     if (previousTransactionType === 'C') {
       billRun.creditNoteCount -= 1
-      billRun.creditNoteValue -= previousInvoiceAbsoluteNetTotal
+      billRun.creditNoteValue -= previousInvoice.$absoluteNetTotal()
     }
     if (previousTransactionType === 'I') {
       billRun.invoiceCount -= 1
-      billRun.invoiceValue -= previousInvoiceAbsoluteNetTotal
+      billRun.invoiceValue -= previousInvoice.$absoluteNetTotal()
     }
 
     // Add the new invoice value to the appropriate bill run field and adjust the count accordingly
     if (currentTransactionType === 'C') {
       billRun.creditNoteCount += 1
-      billRun.creditNoteValue += currentInvoiceAbsoluteNetTotal
+      billRun.creditNoteValue += updatedInvoice.$absoluteNetTotal()
     }
     if (currentTransactionType === 'I') {
       billRun.invoiceCount += 1
-      billRun.invoiceValue += currentInvoiceAbsoluteNetTotal
+      billRun.invoiceValue += updatedInvoice.$absoluteNetTotal()
     }
   }
 

--- a/app/services/licences/delete_licence.service.js
+++ b/app/services/licences/delete_licence.service.js
@@ -163,7 +163,7 @@ class DeleteLicenceService {
     return {
       ...this._entityPatch(billRun),
       creditNoteCount: billRun.creditNoteCount,
-      creditNoteValue: billRun.crediteNoteValue,
+      creditNoteValue: billRun.creditNoteValue,
       invoiceCount: billRun.invoiceCount,
       invoiceValue: billRun.invoiceValue
     }

--- a/app/services/licences/delete_licence.service.js
+++ b/app/services/licences/delete_licence.service.js
@@ -75,11 +75,11 @@ class DeleteLicenceService {
     const billRun = await licence.$relatedQuery('billRun', trx)
 
     if (licences.length) {
-      // Store the invoice's current transaction type (C=Credit, I=Invoice) as we may need it to adjust the bill run
+      // Store the invoice's current transaction type (credit/invoice/zero) as we may need it to adjust the bill run
       const invoiceTransactionType = this._transactionType(invoice)
-      const invoiceNetTotal = invoice.$netTotal()
+      const invoiceAbsoluteNetTotal = invoice.$absoluteNetTotal()
       await this._handleInvoice(billRun, invoice, licence, trx)
-      await this._handleBillRun(billRun, invoice, licence, invoiceTransactionType, invoiceNetTotal, initialBillRunStatus, trx)
+      await this._handleBillRun(billRun, invoice, licence, invoiceTransactionType, invoiceAbsoluteNetTotal, initialBillRunStatus, trx)
     } else {
       await DeleteInvoiceService.go(invoice, billRun, notifier, trx)
     }
@@ -100,8 +100,8 @@ class DeleteLicenceService {
    * Updates the bill run instance that the licence belongs to, then uses the updated fields to generate a patch which
    * is applied to the bill run in the db.
    */
-  static async _handleBillRun (billRun, invoice, licence, invoiceTransactionType, previousNetTotal, initialBillRunStatus, trx) {
-    this._updateBillRunInstance(billRun, invoice, licence, invoiceTransactionType, previousNetTotal, initialBillRunStatus)
+  static async _handleBillRun (billRun, invoice, licence, invoiceTransactionType, previousInvoiceAbsoluteNetTotal, initialBillRunStatus, trx) {
+    this._updateBillRunInstance(billRun, invoice, licence, invoiceTransactionType, previousInvoiceAbsoluteNetTotal, initialBillRunStatus)
     const billRunPatch = this._billRunPatch(billRun)
     await billRun.$query(trx).patch(billRunPatch)
   }
@@ -206,7 +206,7 @@ class DeleteLicenceService {
    * additional fields unique to the bill run, and finally adjusts the credit note/invoice count if the invoice that
    * the licence belongs to is now zero value.
    */
-  static _updateBillRunInstance (billRun, invoice, licence, previousTransactionType, previousInvoiceNetTotal, initialBillRunStatus) {
+  static _updateBillRunInstance (billRun, invoice, licence, previousTransactionType, previousInvoiceAbsoluteNetTotal, initialBillRunStatus) {
     this._updateInstance(billRun, licence)
 
     // We only update the bill run stats if the bill run is generated
@@ -214,72 +214,34 @@ class DeleteLicenceService {
       return
     }
 
-    const currentLicenceNetTotal = licence.$netTotal()
-    const currentInvoiceNetTotal = invoice.$netTotal()
+    const currentInvoiceAbsoluteNetTotal = invoice.$absoluteNetTotal()
     const currentTransactionType = this._transactionType(invoice)
 
-    /**
-     * if the updated invoice was a credit note and is still a credit note then subtract the licence net total from billRun.creditNoteValue
-     * if the updated invoice was an invoice and still is an invoice then subtract the licence net total from billRun.invoiceValue
-     * if the updated invoice was a credit note but is now an invoice then subtract net total from creditNoteValue and add to invoiceValue
-     *  and subtract 1 from creditNoteCount and increment invoiceCount
-     * if the updated invoice was an invoice but is now a credit note then subtract net total from invoiceValue and add to creditNoteValue
-     *  and subtract 1 from invoiceCount and increment creditNoteCount
-     * if the updated invoice was a credit note but is now zero value then subtract net total from creditNoteValue
-     *  and subtract 1 from creditNoteCount
-     * if the updated invoice was an invoice but is now zero value then subtract net total from invoiceValue
-     *  and subtract 1 from invoiceCount
-     */
-
-    if (previousTransactionType === 'C' && currentTransactionType === 'C') {
-      billRun.creditNoteValue += currentLicenceNetTotal
-    }
-
-    if (previousTransactionType === 'C' && currentTransactionType === 'I') {
-      billRun.creditNoteValue += previousInvoiceNetTotal
-      billRun.invoiceValue += currentInvoiceNetTotal
+    // Remove the old invoice value from the appropriate bill run field and adjust the count accordingly
+    if (previousTransactionType === 'C') {
       billRun.creditNoteCount -= 1
-      billRun.invoiceCount += 1
+      billRun.creditNoteValue -= previousInvoiceAbsoluteNetTotal
     }
-
-    if (previousTransactionType === 'C' && currentTransactionType === 'Z') {
-      billRun.creditNoteValue -= previousInvoiceNetTotal
-      billRun.creditNoteCount -= 1
-    }
-
-    if (previousTransactionType === 'I' && currentTransactionType === 'I') {
-      billRun.invoiceValue -= currentLicenceNetTotal
-    }
-
-    if (previousTransactionType === 'I' && currentTransactionType === 'C') {
-      billRun.invoiceValue -= previousInvoiceNetTotal
-      billRun.creditNoteValue -= currentInvoiceNetTotal
+    if (previousTransactionType === 'I') {
       billRun.invoiceCount -= 1
+      billRun.invoiceValue -= previousInvoiceAbsoluteNetTotal
+    }
+
+    // Add the new invoice value to the appropriate bill run field and adjust the count accordingly
+    if (currentTransactionType === 'C') {
       billRun.creditNoteCount += 1
+      billRun.creditNoteValue += currentInvoiceAbsoluteNetTotal
     }
-
-    if (previousTransactionType === 'I' && currentTransactionType === 'Z') {
-      billRun.invoiceValue -= previousInvoiceNetTotal
-      billRun.invoiceCount -= 1
-    }
-
-    if (previousTransactionType === 'Z' && currentTransactionType === 'Z') {
-      // Nothing needed
-    }
-
-    if (previousTransactionType === 'Z' && currentTransactionType === 'I') {
-      billRun.invoiceValue += currentInvoiceNetTotal
+    if (currentTransactionType === 'I') {
       billRun.invoiceCount += 1
-    }
-
-    if (previousTransactionType === 'Z' && currentTransactionType === 'C') {
-      billRun.creditNoteCount += 1
-      billRun.creditNoteValue -= currentInvoiceNetTotal
+      billRun.invoiceValue += currentInvoiceAbsoluteNetTotal
     }
   }
 
   /**
-   * Returns 'C' if the invoice is a credit, 'I' if it is a debit, and 'Z' if it is zero value
+   * Returns 'C' if the invoice is a credit, 'I' if it is a debit, and 'Z' if it is zero value. The regular
+   * $transactionType() method will return 'I' if it has a net value of 0 (ie. is zero value) so we need this helper
+   * method so we can distinguish between a debit and zero value.
    */
   static _transactionType (invoice) {
     return invoice.$zeroValueInvoice() ? 'Z' : invoice.$transactionType()

--- a/app/services/licences/delete_licence.service.js
+++ b/app/services/licences/delete_licence.service.js
@@ -34,7 +34,7 @@ class DeleteLicenceService {
         // We need to know the bill run's initial status before it's set to `pending`
         const { status: initialStatus } = billRun
 
-        await this._setBillRunStatusPending(billRun, trx)
+        await this._setBillRunStatusPending(billRun)
         await this._deleteLicence(licence, notifier, initialStatus, trx)
         await this._revertBillRunStatus(billRun, initialStatus, trx)
       })

--- a/test/services/licences/delete_licence.service.test.js
+++ b/test/services/licences/delete_licence.service.test.js
@@ -52,7 +52,7 @@ describe('Delete Licence service', () => {
     Sinon.restore()
   })
 
-  describe.only('When a valid licence is supplied', () => {
+  describe('When a valid licence is supplied', () => {
     it('deletes the licence', async () => {
       await DeleteLicenceService.go(licence, billRun, notifierFake)
 
@@ -274,7 +274,7 @@ describe('Delete Licence service', () => {
           await NewTransactionHelper.create(zeroValueLicence, { chargeValue: 0 })
         })
 
-        describe.only('and a licence with a debit value is deleted', () => {
+        describe('and a licence with a debit value is deleted', () => {
           it('correctly updates the bill run level figures', async () => {
             await GenerateBillRunService.go(billRun)
 
@@ -284,7 +284,6 @@ describe('Delete Licence service', () => {
             expect(result.zeroLineCount).to.equal(1)
             expect(result.invoiceCount).to.equal(0)
             expect(result.invoiceValue).to.equal(0)
-            expect(result.netTotal).to.equal(0)
           })
         })
 
@@ -303,7 +302,6 @@ describe('Delete Licence service', () => {
             expect(result.zeroLineCount).to.equal(1)
             expect(result.creditNoteCount).to.equal(0)
             expect(result.creditNoteValue).to.equal(0)
-            expect(result.netTotal).to.equal(0)
           })
         })
       })

--- a/test/services/licences/delete_licence.service.test.js
+++ b/test/services/licences/delete_licence.service.test.js
@@ -29,7 +29,7 @@ const { GenerateBillRunService } = require('../../../app/services')
 // Thing under test
 const { DeleteLicenceService } = require('../../../app/services')
 
-describe('Delete Licence service', () => {
+describe.only('Delete Licence service', () => {
   let billRun
   let invoice
   let licence
@@ -102,6 +102,9 @@ describe('Delete Licence service', () => {
         // Generate the bill run to ensure its values are updated before we delete the licence
         await GenerateBillRunService.go(billRun)
 
+        // Refresh bill run
+        billRun = await billRun.$query()
+
         await DeleteLicenceService.go(licence, billRun, notifierFake)
 
         const result = await InvoiceModel.query().findById(transaction.invoiceId)
@@ -124,9 +127,15 @@ describe('Delete Licence service', () => {
 
           // Generate the bill run to ensure its values are updated before we delete the licence
           await GenerateBillRunService.go(billRun)
+
+          // Refresh bill run
+          billRun = await billRun.$query()
         })
 
         it('to `true` when still applicable', async () => {
+          // Refresh licence entity
+          secondLicence = await secondLicence.$query()
+
           await DeleteLicenceService.go(secondLicence, billRun, notifierFake)
 
           const result = await InvoiceModel.query().findById(transaction.invoiceId)
@@ -134,6 +143,9 @@ describe('Delete Licence service', () => {
         })
 
         it('to `false` when not applicable', async () => {
+          // Refresh licence entity
+          licence = await licence.$query()
+
           await DeleteLicenceService.go(licence, billRun, notifierFake)
 
           const result = await InvoiceModel.query().findById(secondTransaction.invoiceId)
@@ -156,9 +168,15 @@ describe('Delete Licence service', () => {
 
           // Generate the bill run to ensure its values are updated before we delete the licence
           await GenerateBillRunService.go(billRun)
+
+          // Refresh bill run
+          billRun = await billRun.$query()
         })
 
         it('to `true` when still applicable', async () => {
+          // Refresh licence entity
+          secondLicence = await secondLicence.$query()
+
           await DeleteLicenceService.go(secondLicence, billRun, notifierFake)
 
           const result = await InvoiceModel.query().findById(transaction.invoiceId)
@@ -166,6 +184,9 @@ describe('Delete Licence service', () => {
         })
 
         it('to `false` when not applicable', async () => {
+          // Refresh licence entity
+          licence = await licence.$query()
+
           await DeleteLicenceService.go(licence, billRun, notifierFake)
 
           const result = await InvoiceModel.query().findById(secondTransaction.invoiceId)
@@ -184,9 +205,15 @@ describe('Delete Licence service', () => {
 
           // Generate the bill run to ensure its values are updated before we delete the licence
           await GenerateBillRunService.go(billRun)
+
+          // Refresh bill run
+          billRun = await billRun.$query()
         })
 
         it('to `true` when still applicable', async () => {
+          // Refresh licence entity
+          licence = await licence.$query()
+
           await DeleteLicenceService.go(licence, billRun, notifierFake)
 
           const result = await InvoiceModel.query().findById(minimumChargeLicence.invoiceId)
@@ -194,6 +221,9 @@ describe('Delete Licence service', () => {
         })
 
         it('to `false` when not applicable', async () => {
+          // Refresh licence entity
+          minimumChargeLicence = await minimumChargeLicence.$query()
+
           await DeleteLicenceService.go(minimumChargeLicence, billRun, notifierFake)
 
           const result = await InvoiceModel.query().findById(licence.invoiceId)
@@ -224,6 +254,9 @@ describe('Delete Licence service', () => {
           describe('if the one less than £25 is deleted', () => {
             describe("from an 'initialised' bill run", () => {
               it('sets the `minimumChargeInvoice` flag correctly (false)', async () => {
+                // Refresh licence entity
+                lessThanMinLicence = await lessThanMinLicence.$query()
+
                 await DeleteLicenceService.go(lessThanMinLicence, fixBillRun, notifierFake)
 
                 const result = await InvoiceModel.query().findById(fixInvoice.id)
@@ -234,6 +267,13 @@ describe('Delete Licence service', () => {
             describe("from a 'generated' bill run", () => {
               it('sets the `minimumChargeInvoice` flag correctly (false)', async () => {
                 await GenerateBillRunService.go(fixBillRun)
+
+                // Refresh bill run
+                fixBillRun = await fixBillRun.$query()
+
+                // Refresh licence entity
+                lessThanMinLicence = await lessThanMinLicence.$query()
+
                 await DeleteLicenceService.go(lessThanMinLicence, fixBillRun, notifierFake)
 
                 const result = await InvoiceModel.query().findById(fixInvoice.id)
@@ -245,6 +285,9 @@ describe('Delete Licence service', () => {
           describe('if the one more than £25 is deleted', () => {
             describe("from an 'initialised' bill run", () => {
               it('sets the `minimumChargeInvoice` flag correctly (false)', async () => {
+                // Refresh licence entity
+                moreThanMinLicence = await moreThanMinLicence.$query()
+
                 await DeleteLicenceService.go(moreThanMinLicence, fixBillRun, notifierFake)
 
                 const result = await InvoiceModel.query().findById(fixInvoice.id)
@@ -255,6 +298,13 @@ describe('Delete Licence service', () => {
             describe("from a 'generated' bill run", () => {
               it('sets the `minimumChargeInvoice` flag correctly (true)', async () => {
                 await GenerateBillRunService.go(fixBillRun)
+
+                // Refresh bill run
+                fixBillRun = await fixBillRun.$query()
+
+                // Refresh licence entity
+                moreThanMinLicence = await moreThanMinLicence.$query()
+
                 await DeleteLicenceService.go(moreThanMinLicence, fixBillRun, notifierFake)
 
                 const result = await InvoiceModel.query().findById(fixInvoice.id)
@@ -265,43 +315,218 @@ describe('Delete Licence service', () => {
         })
       })
 
-      describe('when an invoice contains a licence with zero value', () => {
-        let zeroValueLicence
-
-        beforeEach(async () => {
-          // Create a licence with zero value
-          zeroValueLicence = await NewLicenceHelper.create(invoice, { licenceNumber: 'ZERO01' })
-          await NewTransactionHelper.create(zeroValueLicence, { chargeValue: 0 })
-        })
-
-        describe('and a licence with a debit value is deleted', () => {
+      describe('when an invoice is overall in debit', () => {
+        describe('and it remains a debit after deleting licence', () => {
           it('correctly updates the bill run level figures', async () => {
+            // Create a credit licence small enough to leave the invoice as a debit
+            let creditLicence = await NewLicenceHelper.create(invoice, { licenceNumber: 'CREDIT' })
+            await NewTransactionHelper.create(creditLicence, { chargeValue: 50, chargeCredit: true })
+
             await GenerateBillRunService.go(billRun)
 
+            // Refresh entities
+            billRun = await billRun.$query()
+            creditLicence = await creditLicence.$query()
+
+            // Delete the credit licence to leave the invoice a debit
+            await DeleteLicenceService.go(creditLicence, billRun, notifierFake)
+
+            const result = await BillRunModel.query().findById(transaction.billRunId)
+
+            expect(result.invoiceCount).to.equal(1)
+            expect(result.invoiceValue).to.equal(772)
+            expect(result.creditNoteCount).to.be.equal(0)
+            expect(result.creditNoteValue).to.equal(0)
+          })
+        })
+
+        describe('and it becomes a credit after deleting licence', () => {
+          it('correctly updates the bill run level figures', async () => {
+            // Create a credit licence small enough to leave the invoice as a debit
+            const creditLicence = await NewLicenceHelper.create(invoice, { licenceNumber: 'CREDIT' })
+            await NewTransactionHelper.create(creditLicence, { chargeValue: 50, chargeCredit: true })
+
+            await GenerateBillRunService.go(billRun)
+
+            // Refresh entities
+            billRun = await billRun.$query()
+            licence = await licence.$query()
+
+            // Delete the debit licence to make the invoice a credit
             await DeleteLicenceService.go(licence, billRun, notifierFake)
 
-            const result = await BillRunModel.query().findById(zeroValueLicence.billRunId)
-            expect(result.zeroLineCount).to.equal(1)
+            const result = await BillRunModel.query().findById(transaction.billRunId)
+            expect(result.creditNoteCount).to.be.equal(1)
+            expect(result.creditNoteValue).to.equal(50)
             expect(result.invoiceCount).to.equal(0)
             expect(result.invoiceValue).to.equal(0)
           })
         })
 
-        describe('and a licence with a credit value is deleted', () => {
+        describe('and it becomes zero value after deleting licence', () => {
+          it('correctly updates the bill run level figures', async () => {
+            // Create a zero value licence
+            const zeroValueLicence = await NewLicenceHelper.create(invoice, { licenceNumber: 'ZERO' })
+            await NewTransactionHelper.create(zeroValueLicence, { chargeValue: 0, chargeCredit: true })
+
+            await GenerateBillRunService.go(billRun)
+
+            // Refresh entities
+            billRun = await billRun.$query()
+            licence = await licence.$query()
+
+            // Delete the debit licence to make the invoice a credit
+            await DeleteLicenceService.go(licence, billRun, notifierFake)
+
+            const result = await BillRunModel.query().findById(transaction.billRunId)
+            expect(result.zeroLineCount).to.equal(1)
+            expect(result.invoiceCount).to.equal(0)
+            expect(result.invoiceValue).to.equal(0)
+          })
+        })
+      })
+
+      describe('when an invoice is overall in credit', () => {
+        describe('and it remains a credit after deleting licence', () => {
+          it('correctly updates the bill run level figures', async () => {
+            // Create a credit licence big enough to make the invoice a credit
+            const creditLicence = await NewLicenceHelper.create(invoice, { licenceNumber: 'CREDIT' })
+            await NewTransactionHelper.create(creditLicence, { chargeValue: 50000, chargeCredit: true })
+
+            await GenerateBillRunService.go(billRun)
+
+            // Refresh entities
+            billRun = await billRun.$query()
+            licence = await licence.$query()
+
+            // Delete the debit licence to leave the invoice a credit
+            await DeleteLicenceService.go(licence, billRun, notifierFake)
+
+            const result = await BillRunModel.query().findById(transaction.billRunId)
+            expect(result.creditNoteCount).to.be.equal(1)
+            expect(result.creditNoteValue).to.equal(50000)
+            expect(result.invoiceCount).to.equal(0)
+            expect(result.invoiceValue).to.equal(0)
+          })
+        })
+
+        describe('and it becomes a debit after deleting licence', () => {
+          it('correctly updates the bill run level figures', async () => {
+            // Create a credit licence big enough to make the invoice a credit
+            let creditLicence = await NewLicenceHelper.create(invoice, { licenceNumber: 'CREDIT' })
+            await NewTransactionHelper.create(creditLicence, { chargeValue: 50000, chargeCredit: true })
+
+            await GenerateBillRunService.go(billRun)
+
+            // Refresh entities
+            billRun = await billRun.$query()
+            creditLicence = await creditLicence.$query()
+
+            // Delete the credit licence to make the invoice a debit
+            await DeleteLicenceService.go(creditLicence, billRun, notifierFake)
+
+            const result = await BillRunModel.query().findById(transaction.billRunId)
+            expect(result.invoiceCount).to.equal(1)
+            expect(result.invoiceValue).to.equal(772)
+            expect(result.creditNoteCount).to.be.equal(0)
+            expect(result.creditNoteValue).to.equal(0)
+          })
+        })
+
+        describe('and it becomes zero value after deleting licence', () => {
           beforeEach(async () => {
             // Patch the existing transaction to be a credit
             transaction.$query().patch({ chargeCredit: true })
           })
 
           it('correctly updates the bill run level figures', async () => {
+            // Create a zero value licence
+            const zeroValueLicence = await NewLicenceHelper.create(invoice, { licenceNumber: 'ZERO' })
+            await NewTransactionHelper.create(zeroValueLicence, { chargeValue: 0, chargeCredit: true })
+
             await GenerateBillRunService.go(billRun)
 
+            // Refresh entities
+            billRun = await billRun.$query()
+            licence = await licence.$query()
+
+            // Delete the debit licence to make the invoice a credit
             await DeleteLicenceService.go(licence, billRun, notifierFake)
 
-            const result = await BillRunModel.query().findById(zeroValueLicence.billRunId)
+            const result = await BillRunModel.query().findById(transaction.billRunId)
             expect(result.zeroLineCount).to.equal(1)
             expect(result.creditNoteCount).to.equal(0)
             expect(result.creditNoteValue).to.equal(0)
+          })
+        })
+      })
+
+      describe('when an invoice is overall zero value', () => {
+        let creditLicence
+        let zeroValueLicence
+
+        beforeEach(async () => {
+          // Create a credit licence
+          creditLicence = await NewLicenceHelper.create(invoice, { licenceNumber: 'CREDIT' })
+          await NewTransactionHelper.create(creditLicence, { chargeCredit: true })
+
+          // Create a zero value licence
+          zeroValueLicence = await NewLicenceHelper.create(invoice, { licenceNumber: 'ZERO' })
+          await NewTransactionHelper.create(zeroValueLicence, { chargeCredit: true, chargeValue: 0 })
+
+          // Generate the bill run and refresh its instance
+          await GenerateBillRunService.go(billRun)
+          billRun = await billRun.$query()
+        })
+
+        describe('and it remains zero value after deleting licence', () => {
+          it('correctly updates the bill run level figures', async () => {
+            // Refresh licence entity
+            zeroValueLicence = await zeroValueLicence.$query()
+
+            // Delete the zero value licence to leave the invoice overall zero value
+            await DeleteLicenceService.go(zeroValueLicence, billRun, notifierFake)
+
+            const result = await BillRunModel.query().findById(transaction.billRunId)
+
+            expect(result.invoiceCount).to.equal(0)
+            expect(result.invoiceValue).to.equal(0)
+            expect(result.creditNoteCount).to.be.equal(0)
+            expect(result.creditNoteValue).to.equal(0)
+          })
+        })
+
+        describe('and it becomes a credit after deleting licence', () => {
+          it('correctly updates the bill run level figures', async () => {
+            // Refresh licence entity
+            licence = await licence.$query()
+
+            // Delete the debit licence to make the invoice a credit
+            await DeleteLicenceService.go(licence, billRun, notifierFake)
+
+            const result = await BillRunModel.query().findById(transaction.billRunId)
+            expect(result.creditNoteCount).to.be.equal(1)
+            expect(result.creditNoteValue).to.equal(772)
+            expect(result.invoiceCount).to.equal(0)
+            expect(result.invoiceValue).to.equal(0)
+            expect(result.zeroLineCount).to.equal(1)
+          })
+        })
+
+        describe('and it becomes a debit after deleting licence', () => {
+          it('correctly updates the bill run level figures', async () => {
+            // Refresh licence entity
+            creditLicence = await creditLicence.$query()
+
+            // Delete the credit licence to make the invoice a credit
+            await DeleteLicenceService.go(creditLicence, billRun, notifierFake)
+
+            const result = await BillRunModel.query().findById(transaction.billRunId)
+            expect(result.invoiceCount).to.equal(1)
+            expect(result.invoiceValue).to.equal(772)
+            expect(result.creditNoteCount).to.be.equal(0)
+            expect(result.creditNoteValue).to.equal(0)
+            expect(result.zeroLineCount).to.equal(1)
           })
         })
       })

--- a/test/services/licences/delete_licence.service.test.js
+++ b/test/services/licences/delete_licence.service.test.js
@@ -31,7 +31,7 @@ const { GenerateBillRunService } = require('../../../app/services')
 // Thing under test
 const { DeleteLicenceService } = require('../../../app/services')
 
-describe.only('Delete Licence service', () => {
+describe('Delete Licence service', () => {
   let billRun
   let invoice
   let licence

--- a/test/support/helpers/new_invoice.helper.js
+++ b/test/support/helpers/new_invoice.helper.js
@@ -17,6 +17,9 @@ class NewInvoiceHelper {
   static async create (billRun, overrides = {}) {
     if (!billRun) {
       billRun = await NewBillRunHelper.create()
+    } else {
+      // Refresh the bill run we've been passed to ensure any previous changes aren't overwritten
+      billRun = await billRun.$query()
     }
 
     const invoiceValues = {

--- a/test/support/helpers/new_licence.helper.js
+++ b/test/support/helpers/new_licence.helper.js
@@ -17,6 +17,9 @@ class NewLicenceHelper {
   static async create (invoice, overrides) {
     if (!invoice) {
       invoice = await NewInvoiceHelper.create()
+    } else {
+      // Refresh the invoice we've been passed to ensure any previous changes aren't overwritten
+      invoice = await invoice.$query()
     }
 
     const licenceValues = {

--- a/test/support/helpers/new_transaction.helper.js
+++ b/test/support/helpers/new_transaction.helper.js
@@ -26,6 +26,9 @@ class NewTransactionHelper {
   static async create (licence, overrides = {}) {
     if (!licence) {
       licence = await NewLicenceHelper.create()
+    } else {
+      // Refresh the licence we've been passed to ensure any previous changes aren't overwritten
+      licence = await licence.$query()
     }
 
     const transaction = await TransactionModel.query()


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/projects/CMEA/boards/907?selectedIssue=CMEA-178

When deleting a licence, the bill run summary is not correctly updated in scenarios where the invoice changes "type". For example, from a debit/credit to zero value; from a credit to a debit; etc. In these cases, the bill run level values `creditNoteCount`, `creditNoteValue`, `invoiceCount` and `invoiceValue` were not correctly being adjusted to account for the change in type.

This was initially discovered in the following scenario:
* A debit transaction is created on licence `L001`;
* A zero-value transaction is created on licence `L002`;
* Licence `L001` is deleted;
* The invoice count should be `0` but it remains `1`.

(Note that the original defect report noted that `creditNoteValue` is also incorrect if the above steps are followed using a credit transaction; this turned out to be due to a typo in the code, which we quickly spotted and resolved.)

To fix the defect, we remove the invoice's previous net value (ie. the one it had prior to the licence being deleted) from the appropriate bill run credit/invoice value (determined by whether the invoice was previously an overall credit or debit) and decrement the appropriate bill run credit/invoice count by 1. We then add the invoice's new net value to the appropriate bill run value (determined by whether the invoice is now an overall credit or debit) and increment the appropriate count by 1. This accounts for all scenarios where the type changes, as well as those where it doesn't (as we are simply removing one value from the credit/debit field, and adding the new value back to it).

While doing this, we encountered a problem with the new test helpers; because they adjust the values of the entity they are passed, they must be given an updated/refreshed entity or else the adjusted values will be incorrect. For example, if a licence has a transaction with value `1000` added to it and then has another transaction of value `500` added to it without it being refreshed, the helper will add the `500` value to the invoice's initial value of `0`. This can be avoided by refreshing the entity we pass to the helper prior to calling it; however it would be easy to forget to do this so we updated the helpers to automatically do it for us. This may slow the tests down a little; if it becomes too much to bear then we can look into this further (for example, adding an optional field, defaulting to `true`, so we can request that the entity isn't refreshed if we know this isn't necessary).

One thing to note is that refreshing an entity before use also applies to the services we call; this is why the tests have been amended to refresh the bill run after generation, and refresh each licence we pass to `DeleteLicenceService`.