### PR TITLE
Fix postcode should not be a required property

### DIFF
--- a/app/presenters/customer_file_body.presenter.js
+++ b/app/presenters/customer_file_body.presenter.js
@@ -29,15 +29,8 @@ class CustomerFileBodyPresenter extends BasePresenter {
       col08: this._cleanseNull(data.addressLine4),
       col09: this._cleanseNull(data.addressLine5),
       col10: this._cleanseNull(data.addressLine6),
-      col11: this._handlePostcode(data.postcode)
+      col11: data.postcode
     }
-  }
-
-  /**
-   * Returns the trimmed postcode, or '.' if the postcode is either null or '' after trimming
-   */
-  _handlePostcode (postcode) {
-    return postcode?.trim() ? postcode.trim() : '.'
   }
 }
 

--- a/app/translators/customer.translator.js
+++ b/app/translators/customer.translator.js
@@ -24,7 +24,7 @@ class CustomerTranslator extends BaseTranslator {
       addressLine4: Joi.string().max(240).default(null),
       addressLine5: Joi.string().max(60).default(null),
       addressLine6: Joi.string().max(60).default(null),
-      postcode: Joi.string().max(60).required()
+      postcode: Joi.string().max(60).default('.')
     })
   }
 

--- a/test/presenters/customer_file_body.presenter.test.js
+++ b/test/presenters/customer_file_body.presenter.test.js
@@ -51,27 +51,4 @@ describe('Customer File Body Presenter', () => {
     expect(result.col10).to.equal(data.addressLine6)
     expect(result.col11).to.equal(data.postcode)
   })
-
-  describe('when given an empty postcode', () => {
-    it("returns a '.' for an empty postcode", () => {
-      const presenter = new CustomerFileBodyPresenter({ ...data, postcode: '' })
-      const result = presenter.go()
-
-      expect(result.col11).to.equal('.')
-    })
-
-    it("returns a '.' for a null postcode", () => {
-      const presenter = new CustomerFileBodyPresenter({ ...data, postcode: null })
-      const result = presenter.go()
-
-      expect(result.col11).to.equal('.')
-    })
-
-    it("returns a '.' for a postcode of only spaces", () => {
-      const presenter = new CustomerFileBodyPresenter({ ...data, postcode: '   ' })
-      const result = presenter.go()
-
-      expect(result.col11).to.equal('.')
-    })
-  })
 })

--- a/test/services/create_customer_details.service.test.js
+++ b/test/services/create_customer_details.service.test.js
@@ -90,8 +90,7 @@ describe('Create Customer Details service', () => {
           '"region" is required',
           '"customerReference" is required',
           '"customerName" is required',
-          '"addressLine1" is required',
-          '"postcode" is required'
+          '"addressLine1" is required'
         ])
       })
     })

--- a/test/translators/customer.translator.test.js
+++ b/test/translators/customer.translator.test.js
@@ -64,6 +64,18 @@ describe('Customer translator', () => {
         expect(result.addressLine6).to.equal(null)
       })
     })
+
+    describe('when not passed a postcode', () => {
+      it('defaults to `.`', async () => {
+        const validInput = input
+        delete validInput.postcode
+
+        const result = new CustomerTranslator(validInput)
+
+        expect(result).to.not.be.an.error()
+        expect(result.postcode).to.equal('.')
+      })
+    })
   })
 
   describe('Validation', () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/CMEA-181

Currently, `postcode` is required in any customer change requests to the API. We think this decision was rooted in the fact it's a required field in the customer file that goes to SSL with the customer changes in it.

But the original A/C on the story for developing it for CM v2 was

> AC6. Where the postcode is missing from the incoming request, detail field 11 in the customer file is populated with a "." (full stop).

Having double-checked the code in CM v1 we can see this is in the request validation

```javascript
postcode: stringValidator.max(60).allow('', null)
```

When it comes to the customer file the CM is expected to replace blank postcodes with `.`. Again, we can see this is CM v1

```javascript
handlePostcodeValue (value) {
  if (value && value.trim().length) {
    return value
  } else {
    return '.'
  }
}
```

We have properly dropped the ⚽ with this one. Hence, this change to sort it out.