### PR TITLE
Fix pending status in delete licence

### DIFF
--- a/app/services/licences/delete_licence.service.js
+++ b/app/services/licences/delete_licence.service.js
@@ -31,7 +31,7 @@ class DeleteLicenceService {
       await LicenceModel.transaction(async trx => {
         const { status: initialBillRunStatus } = billRun
 
-        await this._setBillRunStatusPending(billRun, trx)
+        await this._setBillRunStatusPending(billRun)
         await this._deleteLicence(licence, notifier, trx)
         await this._revertBillRunStatus(billRun, initialBillRunStatus, trx)
       })
@@ -40,9 +40,9 @@ class DeleteLicenceService {
     }
   }
 
-  static async _setBillRunStatusPending (billRun, trx) {
+  static async _setBillRunStatusPending (billRun) {
     await billRun
-      .$query(trx)
+      .$query()
       .patch({ status: 'pending' })
   }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/CMEA-141

In [Delete Licence not updating bill run status](https://github.com/DEFRA/sroc-charging-module-api/pull/559) we thought we solved a problem whereby not setting the bill run status to something other than `generated` when deleting a licence client services couldn't tell when the operation was complete.

The fact we couldn't _see_ the bill run get set to `pending` during testing we just chalked up to the speed of the delete.

On review though, we realised there is a problem with the fix. It is updating the status within the same DB transaction as the delete of the licence. This means as far as the client is concerned, it never sees the status change.

This fixes the previous fix by removing the DB transaction element.

<details>
<summary>Evidence from JMeter</summary>

![Screenshot 2021-10-04 at 00 07 52](https://user-images.githubusercontent.com/1789650/135774539-76e98e07-d7b2-40e5-9a70-8b4d9b2a7709.png)

</details>