### PR TITLE
Delete Licence additional summary fixes

### DIFF
--- a/app/services/licences/delete_licence.service.js
+++ b/app/services/licences/delete_licence.service.js
@@ -218,7 +218,8 @@ class DeleteLicenceService {
     const previousTransactionType = this._transactionType(previousInvoice)
     const currentTransactionType = this._transactionType(updatedInvoice)
 
-    // Remove the old invoice value from the appropriate bill run field and adjust the count accordingly
+    // If the old invoice isn't deminimis, remove its value from the appropriate bill run field and adjust the count
+    if (!previousInvoice.$deminimisInvoice()) {
     if (previousTransactionType === 'C') {
       billRun.creditNoteCount -= 1
       billRun.creditNoteValue -= previousInvoice.$absoluteNetTotal()
@@ -227,8 +228,10 @@ class DeleteLicenceService {
       billRun.invoiceCount -= 1
       billRun.invoiceValue -= previousInvoice.$absoluteNetTotal()
     }
+    }
 
-    // Add the new invoice value to the appropriate bill run field and adjust the count accordingly
+    // If the updated invoice isn't deminimis, add its value to the appropriate bill run field and adjust the count
+    if (!updatedInvoice.$deminimisInvoice()) {
     if (currentTransactionType === 'C') {
       billRun.creditNoteCount += 1
       billRun.creditNoteValue += updatedInvoice.$absoluteNetTotal()
@@ -236,6 +239,7 @@ class DeleteLicenceService {
     if (currentTransactionType === 'I') {
       billRun.invoiceCount += 1
       billRun.invoiceValue += updatedInvoice.$absoluteNetTotal()
+      }
     }
   }
 

--- a/app/services/licences/delete_licence.service.js
+++ b/app/services/licences/delete_licence.service.js
@@ -82,7 +82,7 @@ class DeleteLicenceService {
       await this._handleInvoice(billRun, invoice, licence, trx)
       await this._handleBillRun(billRun, invoice, licence, previousInvoice, initialStatus, trx)
     } else {
-      await DeleteInvoiceService.go(invoice, billRun, notifier, trx)
+      await DeleteInvoiceService.go(invoice, billRun, notifier, initialStatus, trx)
     }
   }
 
@@ -220,25 +220,25 @@ class DeleteLicenceService {
 
     // If the old invoice isn't deminimis, remove its value from the appropriate bill run field and adjust the count
     if (!previousInvoice.$deminimisInvoice()) {
-    if (previousTransactionType === 'C') {
-      billRun.creditNoteCount -= 1
-      billRun.creditNoteValue -= previousInvoice.$absoluteNetTotal()
-    }
-    if (previousTransactionType === 'I') {
-      billRun.invoiceCount -= 1
-      billRun.invoiceValue -= previousInvoice.$absoluteNetTotal()
-    }
+      if (previousTransactionType === 'C') {
+        billRun.creditNoteCount -= 1
+        billRun.creditNoteValue -= previousInvoice.$absoluteNetTotal()
+      }
+      if (previousTransactionType === 'I') {
+        billRun.invoiceCount -= 1
+        billRun.invoiceValue -= previousInvoice.$absoluteNetTotal()
+      }
     }
 
     // If the updated invoice isn't deminimis, add its value to the appropriate bill run field and adjust the count
     if (!updatedInvoice.$deminimisInvoice()) {
-    if (currentTransactionType === 'C') {
-      billRun.creditNoteCount += 1
-      billRun.creditNoteValue += updatedInvoice.$absoluteNetTotal()
-    }
-    if (currentTransactionType === 'I') {
-      billRun.invoiceCount += 1
-      billRun.invoiceValue += updatedInvoice.$absoluteNetTotal()
+      if (currentTransactionType === 'C') {
+        billRun.creditNoteCount += 1
+        billRun.creditNoteValue += updatedInvoice.$absoluteNetTotal()
+      }
+      if (currentTransactionType === 'I') {
+        billRun.invoiceCount += 1
+        billRun.invoiceValue += updatedInvoice.$absoluteNetTotal()
       }
     }
   }

--- a/test/services/licences/delete_licence.service.test.js
+++ b/test/services/licences/delete_licence.service.test.js
@@ -484,6 +484,75 @@ describe('Delete Licence service', () => {
         })
       })
 
+      describe('when an invoice is subject to deminimis', () => {
+        let creditLicence
+
+        beforeEach(async () => {
+          creditLicence = await NewLicenceHelper.create(invoice, { licenceNumber: 'CREDIT' })
+          await NewTransactionHelper.create(creditLicence, { chargeValue: 770, chargeCredit: true })
+
+          await GenerateBillRunService.go(billRun)
+
+          // Refresh bill run
+          billRun = await billRun.$query()
+        })
+
+        describe('and the credit is deleted to leave it in debit', () => {
+          it('correctly updates the bill run level figures', async () => {
+            // Refresh licence entity
+            creditLicence = await creditLicence.$query()
+
+            // Delete the credit licence
+            await DeleteLicenceService.go(creditLicence, billRun, notifierFake)
+
+            const result = await billRun.$query()
+            expect(result.invoiceCount).to.equal(1)
+            expect(result.invoiceValue).to.equal(772)
+          })
+        })
+
+        describe('and the debit is deleted to leave it in credit', () => {
+          it('correctly updates the bill run level figures', async () => {
+            // Delete the debit licence
+            await DeleteLicenceService.go(licence, billRun, notifierFake)
+
+            const result = await billRun.$query()
+            expect(result.creditNoteCount).to.equal(1)
+            expect(result.creditNoteValue).to.equal(770)
+          })
+        })
+      })
+
+      describe('when an invoice becomes subject to deminimis', () => {
+        let creditLicence
+        let debitLicence
+
+        beforeEach(async () => {
+          // Create credit and debits which will make the invoice deminimis once the original licence is deleted
+          creditLicence = await NewLicenceHelper.create(invoice, { licenceNumber: 'CREDIT' })
+          await NewTransactionHelper.create(creditLicence, { chargeValue: 770, chargeCredit: true })
+
+          debitLicence = await NewLicenceHelper.create(invoice, { licenceNumber: 'DEBIT' })
+          await NewTransactionHelper.create(debitLicence)
+
+          await GenerateBillRunService.go(billRun)
+
+          // Refresh bill run
+          billRun = await billRun.$query()
+        })
+
+        it('correctly updates the bill run level figures', async () => {
+          // Delete the debit licence
+          await DeleteLicenceService.go(licence, billRun, notifierFake)
+
+          const result = await billRun.$query()
+          expect(result.invoiceCount).to.equal(0)
+          expect(result.invoiceValue).to.equal(0)
+          expect(result.creditNoteCount).to.equal(0)
+          expect(result.creditNoteValue).to.equal(0)
+        })
+      })
+
       describe('when an invoice is overall zero value', () => {
         let creditLicence
         let zeroValueLicence


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/projects/CMEA/boards/907?selectedIssue=CMEA-178

Two main defects were found during testing of our revised approached to updating the bill run summary when a licence is deleted:

**Defect 1 - deminimis**

The bill run summary was not correctly updated if the invoice the licence was deleted from was subject to deminimis. This was due to us subtracting the count and value of the invoice from the bill run summary, when these would not have been included in the summary in the case of deminimis. We therefore introduce a check that the invoice was deminimis before updating. We also check whether the invoice becomes deminimis _after_ deleting the licence, and if this is the case we don't add the count and value back to the summary.

**Defect 2 - empty invoice deletion**

The second defect was that if an invoice is deleted due to its only licence being deleted, the bill run summary was not being updated. We traced this issue to `DeleteInvoiceService`, which only updates the summary if the bill run status is `generated`. However, due to our recent changes (#559 #575), calling this service from within `DeleteLicenceService` means that the bill run's status is `pending` at the point that it's checked. We therefore update `DeleteInvoiceService` to accept an optional bill run status (defaulting to the current status) and pass in the bill run's initial status so it can correctly check whether the bill run is generated.
