### PR TITLE
Rename `regimeId` to `regimeSlug`

### DIFF
--- a/app/plugins/authorisation.plugin.js
+++ b/app/plugins/authorisation.plugin.js
@@ -9,7 +9,7 @@ const { AuthorisationService } = require('../services')
  * Paths under the `/admin` root are only accessible to requests made with bearer tokens generated using the admin
  * client ID.
  *
- * Paths which have a regime, for example, `/v1/{regimeId}/billruns` are accessible to the admin user plus any request
+ * Paths which have a regime, for example, `/v1/{regimeSlug}/billruns` are accessible to the admin user plus any request
  * made with a bearer token generated using a recognised client ID. However, the client ID must also be linked to the
  * matching regime.
  *
@@ -25,16 +25,16 @@ const AuthorisationPlugin = {
   register: (server, _options) => {
     server.ext('onCredentials', async (request, h) => {
       const { user } = request.auth.credentials
-      const { regimeId } = request.params
+      const { regimeSlug } = request.params
 
-      const authorisationResult = await AuthorisationService.go(user, regimeId)
+      const authorisationResult = await AuthorisationService.go(user, regimeSlug)
 
       if (authorisationResult.authorised) {
         request.app.regime = authorisationResult.regime
         return h.continue
       }
 
-      throw Boom.forbidden(`Unauthorised for regime '${regimeId}'`)
+      throw Boom.forbidden(`Unauthorised for regime '${regimeSlug}'`)
     })
   }
 }

--- a/app/plugins/blipp.plugin.js
+++ b/app/plugins/blipp.plugin.js
@@ -9,14 +9,14 @@
  * An example of the output
  *
  * ```
- *   method  path                     auth          scope  description
- *   ------  -----------------------  ------------  -----  -----------
- *   GET     /                        none          none
- *   GET     /regimes                 jwt-strategy  admin
- *   GET     /regimes/{id}            jwt-strategy  admin
- *   GET     /status                  none          none
- *   GET     /v1/{regimeId}/billruns  jwt-strategy  none
- *   GET     /v2/{regimeId}/billruns  jwt-strategy  none
+ *   method  path                       auth          scope  description
+ *   ------  -------------------------  ------------  -----  -----------
+ *   GET     /                          none          none
+ *   GET     /regimes                   jwt-strategy  admin
+ *   GET     /regimes/{id}              jwt-strategy  admin
+ *   GET     /status                    none          none
+ *   GET     /v1/{regimeSlug}/billruns  jwt-strategy  none
+ *   GET     /v2/{regimeSlug}/billruns  jwt-strategy  none
  * ```
  *
  * {@link https://github.com/danielb2/blipp}

--- a/app/routes/bill_run.routes.js
+++ b/app/routes/bill_run.routes.js
@@ -9,47 +9,47 @@ const {
 const routes = [
   {
     method: 'POST',
-    path: '/v1/{regimeId}/billruns',
+    path: '/v1/{regimeSlug}/billruns',
     handler: NotSupportedController.index
   },
   {
     method: 'POST',
-    path: '/v2/{regimeId}/bill-runs',
+    path: '/v2/{regimeSlug}/bill-runs',
     handler: BillRunsController.create
   },
   {
     method: 'PATCH',
-    path: '/v2/{regimeId}/bill-runs/{billRunId}/generate',
+    path: '/v2/{regimeSlug}/bill-runs/{billRunId}/generate',
     handler: BillRunsController.generate
   },
   {
     method: 'PATCH',
-    path: '/v2/{regimeId}/bill-runs/{billRunId}/approve',
+    path: '/v2/{regimeSlug}/bill-runs/{billRunId}/approve',
     handler: BillRunsController.approve
   },
   {
     method: 'PATCH',
-    path: '/v2/{regimeId}/bill-runs/{billRunId}/send',
+    path: '/v2/{regimeSlug}/bill-runs/{billRunId}/send',
     handler: BillRunsController.send
   },
   {
     method: 'GET',
-    path: '/v2/{regimeId}/bill-runs/{billRunId}/status',
+    path: '/v2/{regimeSlug}/bill-runs/{billRunId}/status',
     handler: BillRunsController.status
   },
   {
     method: 'GET',
-    path: '/v2/{regimeId}/bill-runs/{billRunId}',
+    path: '/v2/{regimeSlug}/bill-runs/{billRunId}',
     handler: BillRunsController.view
   },
   {
     method: 'DELETE',
-    path: '/v2/{regimeId}/bill-runs/{billRunId}',
+    path: '/v2/{regimeSlug}/bill-runs/{billRunId}',
     handler: BillRunsController.delete
   },
   {
     method: 'PATCH',
-    path: '/admin/{regimeId}/bill-runs/{billRunId}/send',
+    path: '/admin/{regimeSlug}/bill-runs/{billRunId}/send',
     handler: AdminBillRunsController.send,
     options: {
       auth: {

--- a/app/routes/bill_run_invoice.routes.js
+++ b/app/routes/bill_run_invoice.routes.js
@@ -5,17 +5,17 @@ const { BillRunsInvoicesController } = require('../controllers')
 const routes = [
   {
     method: 'DELETE',
-    path: '/v2/{regimeId}/bill-runs/{billRunId}/invoices/{invoiceId}',
+    path: '/v2/{regimeSlug}/bill-runs/{billRunId}/invoices/{invoiceId}',
     handler: BillRunsInvoicesController.delete
   },
   {
     method: 'GET',
-    path: '/v2/{regimeId}/bill-runs/{billRunId}/invoices/{invoiceId}',
+    path: '/v2/{regimeSlug}/bill-runs/{billRunId}/invoices/{invoiceId}',
     handler: BillRunsInvoicesController.view
   },
   {
     method: 'PATCH',
-    path: '/v2/{regimeId}/bill-runs/{billRunId}/invoices/{invoiceId}/rebill',
+    path: '/v2/{regimeSlug}/bill-runs/{billRunId}/invoices/{invoiceId}/rebill',
     handler: BillRunsInvoicesController.rebill
   }
 ]

--- a/app/routes/bill_run_licence.routes.js
+++ b/app/routes/bill_run_licence.routes.js
@@ -5,7 +5,7 @@ const { BillRunsLicencesController } = require('../controllers')
 const routes = [
   {
     method: 'DELETE',
-    path: '/v2/{regimeId}/bill-runs/{billRunId}/licences/{licenceId}',
+    path: '/v2/{regimeSlug}/bill-runs/{billRunId}/licences/{licenceId}',
     handler: BillRunsLicencesController.delete
   }
 ]

--- a/app/routes/bill_run_transaction.routes.js
+++ b/app/routes/bill_run_transaction.routes.js
@@ -8,17 +8,17 @@ const {
 const routes = [
   {
     method: 'POST',
-    path: '/v1/{regimeId}/billruns/{billRunId}/transactions',
+    path: '/v1/{regimeSlug}/billruns/{billRunId}/transactions',
     handler: NotSupportedController.index
   },
   {
     method: 'POST',
-    path: '/v2/{regimeId}/bill-runs/{billRunId}/transactions',
+    path: '/v2/{regimeSlug}/bill-runs/{billRunId}/transactions',
     handler: BillRunsTransactionsController.create
   },
   {
     method: 'GET',
-    path: '/v2/{regimeId}/bill-runs/{billRunId}/transactions/{transactionId}',
+    path: '/v2/{regimeSlug}/bill-runs/{billRunId}/transactions/{transactionId}',
     handler: BillRunsTransactionsController.view
   }
 ]

--- a/app/routes/calculate_charge.routes.js
+++ b/app/routes/calculate_charge.routes.js
@@ -5,12 +5,12 @@ const { NotSupportedController, CalculateChargeController } = require('../contro
 const routes = [
   {
     method: 'POST',
-    path: '/v1/{regimeId}/calculate-charge',
+    path: '/v1/{regimeSlug}/calculate-charge',
     handler: NotSupportedController.index
   },
   {
     method: 'POST',
-    path: '/v2/{regimeId}/calculate-charge',
+    path: '/v2/{regimeSlug}/calculate-charge',
     handler: CalculateChargeController.calculate
   }
 ]

--- a/app/routes/customer.routes.js
+++ b/app/routes/customer.routes.js
@@ -5,7 +5,7 @@ const { CustomersController } = require('../controllers')
 const routes = [
   {
     method: 'PATCH',
-    path: '/admin/{regimeId}/customers',
+    path: '/admin/{regimeSlug}/customers',
     handler: CustomersController.send,
     options: {
       auth: {

--- a/app/routes/customer_details.routes.js
+++ b/app/routes/customer_details.routes.js
@@ -8,12 +8,12 @@ const {
 const routes = [
   {
     method: 'POST',
-    path: '/v1/{regimeId}/customer-changes',
+    path: '/v1/{regimeSlug}/customer-changes',
     handler: NotSupportedController.index
   },
   {
     method: 'POST',
-    path: '/v2/{regimeId}/customer-changes',
+    path: '/v2/{regimeSlug}/customer-changes',
     handler: CustomerDetailsController.create
   }
 ]

--- a/app/routes/customer_files.routes.js
+++ b/app/routes/customer_files.routes.js
@@ -6,7 +6,7 @@ const Joi = require('joi')
 const routes = [
   {
     method: 'GET',
-    path: '/v2/{regimeId}/customer-files/{days?}',
+    path: '/v2/{regimeSlug}/customer-files/{days?}',
     handler: CustomerFilesController.index,
     options: {
       validate: {
@@ -14,8 +14,8 @@ const routes = [
           days: Joi.number().integer().min(0).default(30)
         },
         options: {
-          // We only want to validate the days parameter and not regimeId. Setting allowUnknown to `true` means we don't
-          // need to provide additional validation for regimeId.
+          // We only want to validate the days parameter and not regimeSlug. Setting allowUnknown to `true` means we
+          // don't need to provide additional validation for regimeSlug.
           allowUnknown: true
         }
       }

--- a/app/routes/test.routes.js
+++ b/app/routes/test.routes.js
@@ -10,7 +10,7 @@ const {
 const routes = [
   {
     method: 'POST',
-    path: '/admin/test/{regimeId}/bill-runs',
+    path: '/admin/test/{regimeSlug}/bill-runs',
     handler: TestBillRunsController.create,
     options: {
       description: 'Used by the delivery team to automatically generate bill runs for testing.',
@@ -32,7 +32,7 @@ const routes = [
   },
   {
     method: 'GET',
-    path: '/admin/test/{regimeId}/customer-files',
+    path: '/admin/test/{regimeSlug}/customer-files',
     handler: TestCustomerFilesController.index,
     options: {
       description: 'Used by the delivery team to list all customer files for a regime.',

--- a/app/routes/transaction.routes.js
+++ b/app/routes/transaction.routes.js
@@ -5,12 +5,12 @@ const { NotSupportedController } = require('../controllers')
 const routes = [
   {
     method: 'GET',
-    path: '/v1/{regimeId}/transactions',
+    path: '/v1/{regimeSlug}/transactions',
     handler: NotSupportedController.index
   },
   {
     method: 'GET',
-    path: '/v1/{regimeId}/transactions/{transactionId}',
+    path: '/v1/{regimeSlug}/transactions/{transactionId}',
     handler: NotSupportedController.index
   }
 ]

--- a/app/services/plugins/db_errors.service.js
+++ b/app/services/plugins/db_errors.service.js
@@ -54,7 +54,7 @@ class DbErrorsService {
 
     if (error.constraint === 'transactions_regime_id_client_id_unique') {
       boomError = new Boom.Boom(
-        `A transaction with Client ID '${data.payload.clientId}' for Regime '${data.params.regimeId}' already exists.`,
+        `A transaction with Client ID '${data.payload.clientId}' for Regime '${data.params.regimeSlug}' already exists.`,
         { statusCode: 409 }
       )
       boomError.output.payload.clientId = data.payload.clientId

--- a/test/controllers/admin/bill_runs.controller.test.js
+++ b/test/controllers/admin/bill_runs.controller.test.js
@@ -58,7 +58,7 @@ describe('Admin Bill Runs controller', () => {
     sendStub.restore()
   })
 
-  describe('Send bill run: PATCH /admin/{regimeId}/bill-runs/{billRunId}/send', () => {
+  describe('Send bill run: PATCH /admin/{regimeSlug}/bill-runs/{billRunId}/send', () => {
     const options = (token, billRunId) => {
       return {
         method: 'PATCH',

--- a/test/controllers/admin/customers.controller.test.js
+++ b/test/controllers/admin/customers.controller.test.js
@@ -53,7 +53,7 @@ describe('Customers controller', () => {
     Sinon.restore()
   })
 
-  describe('Sending customer files: PATCH /admin/{regimeId}/customers', () => {
+  describe('Sending customer files: PATCH /admin/{regimeSlug}/customers', () => {
     const options = token => {
       return {
         method: 'PATCH',

--- a/test/controllers/admin/test/test_bill_runs.controller.test.js
+++ b/test/controllers/admin/test/test_bill_runs.controller.test.js
@@ -52,7 +52,7 @@ describe('Test Bill Run Controller', () => {
     Sinon.restore()
   })
 
-  describe('Generating a test bill run: POST /admin/test/{regimeId}/bill-runs', () => {
+  describe('Generating a test bill run: POST /admin/test/{regimeSlug}/bill-runs', () => {
     const options = (token, payload) => {
       return {
         method: 'POST',

--- a/test/controllers/bill_runs.controller.test.js
+++ b/test/controllers/bill_runs.controller.test.js
@@ -75,7 +75,7 @@ describe('Bill Runs controller', () => {
     Nock.cleanAll()
   })
 
-  describe('Adding a bill run: POST /v2/{regimeId}/bill-runs', () => {
+  describe('Adding a bill run: POST /v2/{regimeSlug}/bill-runs', () => {
     const options = (token, payload) => {
       return {
         method: 'POST',
@@ -115,7 +115,7 @@ describe('Bill Runs controller', () => {
     })
   })
 
-  describe('Generate a bill run summary: PATCH /v2/{regimeId}/bill-runs/{billRunId}/generate', () => {
+  describe('Generate a bill run summary: PATCH /v2/{regimeSlug}/bill-runs/{billRunId}/generate', () => {
     let payload
 
     const options = (token, billRunId) => {
@@ -162,7 +162,7 @@ describe('Bill Runs controller', () => {
     })
   })
 
-  describe('Get bill run status: GET /v2/{regimeId}/bill-runs/{billRunId}/status', () => {
+  describe('Get bill run status: GET /v2/{regimeSlug}/bill-runs/{billRunId}/status', () => {
     const options = (token, billRunId) => {
       return {
         method: 'GET',
@@ -197,7 +197,7 @@ describe('Bill Runs controller', () => {
     })
   })
 
-  describe('View bill run: GET /v2/{regimeId}/bill-runs/{billRunId}', () => {
+  describe('View bill run: GET /v2/{regimeSlug}/bill-runs/{billRunId}', () => {
     const options = (token, billRunId) => {
       return {
         method: 'GET',
@@ -232,7 +232,7 @@ describe('Bill Runs controller', () => {
     })
   })
 
-  describe('Approve bill run: PATCH /v2/{regimeId}/bill-runs/{billRunId}/approve', () => {
+  describe('Approve bill run: PATCH /v2/{regimeSlug}/bill-runs/{billRunId}/approve', () => {
     const options = (token, billRunId) => {
       return {
         method: 'PATCH',
@@ -271,7 +271,7 @@ describe('Bill Runs controller', () => {
     })
   })
 
-  describe('Send bill run: PATCH /v2/{regimeId}/bill-runs/{billRunId}/send', () => {
+  describe('Send bill run: PATCH /v2/{regimeSlug}/bill-runs/{billRunId}/send', () => {
     let sendCustomerFileStub
     let sendTransactionFileStub
 
@@ -340,7 +340,7 @@ describe('Bill Runs controller', () => {
     })
   })
 
-  describe('Delete bill run: DELETE /v2/{regimeId}/bill-runs/{billRunId}', () => {
+  describe('Delete bill run: DELETE /v2/{regimeSlug}/bill-runs/{billRunId}', () => {
     const options = (token, billRunId) => {
       return {
         method: 'DELETE',

--- a/test/controllers/bill_runs_invoices.controller.test.js
+++ b/test/controllers/bill_runs_invoices.controller.test.js
@@ -55,7 +55,7 @@ describe('Invoices controller', () => {
     Sinon.restore()
   })
 
-  describe('Delete an invoice: DELETE /v2/{regimeId}/bill-runs/{billRunId}/invoices/{invoiceId}', () => {
+  describe('Delete an invoice: DELETE /v2/{regimeSlug}/bill-runs/{billRunId}/invoices/{invoiceId}', () => {
     const options = (token, billRunId, invoiceId) => {
       return {
         method: 'DELETE',
@@ -132,7 +132,7 @@ describe('Invoices controller', () => {
     })
   })
 
-  describe('View bill run invoice: GET /v2/{regimeId}/bill-runs/{billRunId}/invoices/{invoiceId}', () => {
+  describe('View bill run invoice: GET /v2/{regimeSlug}/bill-runs/{billRunId}/invoices/{invoiceId}', () => {
     const options = (token, billRunId, invoiceId) => {
       return {
         method: 'GET',
@@ -192,7 +192,7 @@ describe('Invoices controller', () => {
     })
   })
 
-  describe('Rebill bill run invoice: PATCH /v2/{regimeId}/bill-runs/{billRunId}/invoices/{invoiceId}/rebill', () => {
+  describe('Rebill bill run invoice: PATCH /v2/{regimeSlug}/bill-runs/{billRunId}/invoices/{invoiceId}/rebill', () => {
     let cancelInvoice
     let rebillInvoice
     let validationStub

--- a/test/controllers/bill_runs_licences.controller.test.js
+++ b/test/controllers/bill_runs_licences.controller.test.js
@@ -52,7 +52,7 @@ describe('Licences controller', () => {
     Sinon.restore()
   })
 
-  describe('Delete a licence: DELETE /v2/{regimeId}/bill-runs/{billRunId}/licences/{licenceId}', () => {
+  describe('Delete a licence: DELETE /v2/{regimeSlug}/bill-runs/{billRunId}/licences/{licenceId}', () => {
     let validationStub
     let deletionStub
 

--- a/test/controllers/bill_runs_transactions.controller.test.js
+++ b/test/controllers/bill_runs_transactions.controller.test.js
@@ -60,7 +60,7 @@ describe('Bill runs transactions controller', () => {
     Nock.cleanAll()
   })
 
-  describe('Create a bill run transaction: POST /v2/{regimeId}/bill-runs/{billRunId}/transactions', () => {
+  describe('Create a bill run transaction: POST /v2/{regimeSlug}/bill-runs/{billRunId}/transactions', () => {
     let payload
 
     const options = (token, payload, billRunId) => {
@@ -135,7 +135,7 @@ describe('Bill runs transactions controller', () => {
     })
   })
 
-  describe('View bill run transaction: GET /v2/{regimeId}/bill-runs/{billRunId}/transactions/{transactionId}', () => {
+  describe('View bill run transaction: GET /v2/{regimeSlug}/bill-runs/{billRunId}/transactions/{transactionId}', () => {
     const options = (token, billRunId, transactionId) => {
       return {
         method: 'GET',

--- a/test/controllers/calculate_charge.controller.test.js
+++ b/test/controllers/calculate_charge.controller.test.js
@@ -60,7 +60,7 @@ describe('Calculate charge controller', () => {
     Nock.cleanAll()
   })
 
-  describe('Calculating a charge: POST /v2/{regimeId}/calculate-charge', () => {
+  describe('Calculating a charge: POST /v2/{regimeSlug}/calculate-charge', () => {
     const options = (token, payload) => {
       return {
         method: 'POST',

--- a/test/controllers/customer_details.controller.test.js
+++ b/test/controllers/customer_details.controller.test.js
@@ -50,7 +50,7 @@ describe('Customer Details controller', () => {
     Sinon.restore()
   })
 
-  describe('Creating a details change: POST /v2/{regimeId}/customer-changes', () => {
+  describe('Creating a details change: POST /v2/{regimeSlug}/customer-changes', () => {
     const options = (token, payload) => {
       return {
         method: 'POST',

--- a/test/controllers/customer_files.controller.test.js
+++ b/test/controllers/customer_files.controller.test.js
@@ -49,7 +49,7 @@ describe('List Customer Files controller', () => {
     await AuthorisedSystemHelper.addSystem(clientID, 'system1', [regime])
   })
 
-  describe('List customer files: GET /v2/{regimeId}/customer-files/{days?}', () => {
+  describe('List customer files: GET /v2/{regimeSlug}/customer-files/{days?}', () => {
     let listStub
 
     const options = (token, pathParam = '') => {

--- a/test/features/authorisation.test.js
+++ b/test/features/authorisation.test.js
@@ -118,7 +118,7 @@ describe('Authorisation with the API', () => {
     })
   })
 
-  describe('When accessing a /{regimeId}/action (system) route', () => {
+  describe('When accessing a /{regimeSlug}/action (system) route', () => {
     afterEach(async () => {
       Sinon.restore()
     })

--- a/test/services/plugins/db_errors.service.test.js
+++ b/test/services/plugins/db_errors.service.test.js
@@ -63,7 +63,7 @@ describe('Db Errors service', () => {
               clientId: 'DOUBLEIMPACT'
             },
             params: {
-              regimeId: 'wrls'
+              regimeSlug: 'wrls'
             }
           }
 

--- a/test/support/generators/README.md
+++ b/test/support/generators/README.md
@@ -9,6 +9,6 @@ Generators allow us to create this volume of data quickly and avoid
 - the overhead of sending thousands of transaction requests across the network
 - 'spamming' the rules service just for testing purposes
 
-They follow the convention of [services](/app/services) being `static` and with a single `go()` method to initate the action. But unlike the main application code, we are comfortable with these not having specific unit tests. Integration tests through the `/admin/test/{regimeId}/bill-runs/generate` is sufficient.
+They follow the convention of [services](/app/services) being `static` and with a single `go()` method to initate the action. But unlike the main application code, we are comfortable with these not having specific unit tests. Integration tests through the `/admin/test/{regimeSlug}/bill-runs/generate` is sufficient.
 
 They also rely heavily on test helpers and libraries. It's for these reasons they sit here in `/test/support/generators'.

--- a/test/support/helpers/route.helper.js
+++ b/test/support/helpers/route.helper.js
@@ -86,14 +86,14 @@ class RouteHelper {
   /**
    * Adds a route to a Hapi server instance which can only accessed by authorised systems and the admin.
    *
-   * Intended to mimic routes such as `/v1/{regimeId}/billruns`.
+   * Intended to mimic routes such as `/v1/{regimeSlug}/billruns`.
    *
    * @param {Object} server A Hapi server instance
    */
   static addSystemGetRoute (server) {
     server.route({
       method: 'GET',
-      path: '/test/{regimeId}/system',
+      path: '/test/{regimeSlug}/system',
       handler: (request, _h) => {
         return { type: request.app.regime.slug }
       },
@@ -125,14 +125,14 @@ class RouteHelper {
   /**
    * Adds a route to a Hapi server instance which mocks a bill run `GET`.
    *
-   * Intended to mimic routes such as `/v1/{regimeId}/bill-runs/{billRunId}`.
+   * Intended to mimic routes such as `/v1/{regimeSlug}/bill-runs/{billRunId}`.
    *
    * @param {Object} server A Hapi server instance
    */
   static addBillRunGetRoute (server) {
     server.route({
       method: 'GET',
-      path: '/test/{regimeId}/bill-runs/{billRunId}',
+      path: '/test/{regimeSlug}/bill-runs/{billRunId}',
       handler: (request, _h) => {
         return { id: request.app.billRun.id }
       },
@@ -146,8 +146,8 @@ class RouteHelper {
 
   static addRequestAppCheckRoute (server, type) {
     const paths = {
-      billRun: '/test/{regimeId}/bill-runs/{billRunId}',
-      invoice: '/test/{regimeId}/invoices/{invoiceId}'
+      billRun: '/test/{regimeSlug}/bill-runs/{billRunId}',
+      invoice: '/test/{regimeSlug}/invoices/{invoiceId}'
     }
 
     server.route({


### PR DESCRIPTION
When we created the v2 endpoints, we followed the convention of v1 where the regime part of the endpoint is referred to as `regimeId`, eg. `GET /v2/{regimeId}/bill-runs`. However, this is technically the regime slug -- the regime id is the UUID that identifies the regime. Since we do refer to the actual `regimeId` within the code, we rename the references to the slug to `regimeSlug` to avoid confusion.