### PR TITLE
Create `CalculatePresrocChargeTranslator`

### DIFF
--- a/app/controllers/calculate_charge.controller.js
+++ b/app/controllers/calculate_charge.controller.js
@@ -4,6 +4,9 @@ const { CalculateChargeService } = require('../services')
 
 class CalculateChargeController {
   static async calculate (req, h) {
+    // Set v2 default
+    req.payload.ruleset = 'presroc'
+
     const result = await CalculateChargeService.go(req.payload, req.app.regime)
 
     return h.response(result).code(200)

--- a/app/services/charges/calculate_charge.service.js
+++ b/app/services/charges/calculate_charge.service.js
@@ -4,7 +4,7 @@
  * @module CalculateChargeService
  */
 
-const { CalculateChargeTranslator, RulesServiceTranslator } = require('../../translators')
+const { CalculatePresrocChargeTranslator, RulesServiceTranslator } = require('../../translators')
 const { CalculateChargePresenter, RulesServicePresenter } = require('../../presenters')
 
 const RequestRulesServiceCharge = require('./request_rules_service_charge.service')
@@ -39,7 +39,7 @@ class CalculateChargeService {
   }
 
   static _translateRequest (payload, regime) {
-    return new CalculateChargeTranslator({
+    return new CalculatePresrocChargeTranslator({
       ...payload,
       regime: regime.slug
     })

--- a/app/translators/calculate_charge.translator.js
+++ b/app/translators/calculate_charge.translator.js
@@ -99,33 +99,74 @@ class CalculateChargeTranslator extends BaseTranslator {
   }
 
   _schema () {
-    const validDateFormats = ['DD-MMM-YYYY', 'DD-MM-YYYY', 'YYYY-MM-DD', 'DD/MM/YYYY', 'YYYY/MM/DD']
+    const rules = this._rules()
 
     return Joi.object({
+      authorisedDays: rules.authorisedDays,
+      billableDays: rules.billableDays,
+      compensationCharge: rules.compensationCharge,
+      credit: rules.credit,
+      eiucSource: rules.eiucSource,
+      loss: rules.loss,
+      periodStart: rules.periodStart,
+      periodEnd: rules.periodEnd,
+      regionalChargingArea: rules.regionalChargingArea,
+      ruleset: rules.ruleset,
+      season: rules.season,
+      section126Factor: rules.section126Factor,
+      section127Agreement: rules.section127Agreement,
+      section130Agreement: rules.section130Agreement,
+      source: rules.source,
+      twoPartTariff: rules.twoPartTariff,
+      volume: rules.volume,
+      waterUndertaker: rules.waterUndertaker,
+      regime: rules.regime
+    })
+  }
+
+  _rules () {
+    const validDateFormats = ['DD-MMM-YYYY', 'DD-MM-YYYY', 'YYYY-MM-DD', 'DD/MM/YYYY', 'YYYY/MM/DD']
+
+    return {
       authorisedDays: Joi.number().integer().min(0).max(366).required(),
       billableDays: Joi.number().integer().min(0).max(366).required(),
       compensationCharge: Joi.boolean().required(),
       credit: Joi.boolean().required(),
+
       // validated in the rules service
       eiucSource: Joi.when('compensationCharge', { is: true, then: Joi.string().required() }),
-      loss: Joi.string().required(), // validated in rules service
+
+      // validated in the rules service
+      loss: Joi.string().required(),
+
       periodStart: Joi.date().format(validDateFormats).max(Joi.ref('periodEnd')).min('01-APR-2014').required(),
       periodEnd: Joi.date().format(validDateFormats).required(),
-      regionalChargingArea: Joi.string().required(), // validated in the rules service
+
+      // validated in the rules service
+      regionalChargingArea: Joi.string().required(),
+
       // Set a new field called ruleset. This will be used to determine which ruleset to query in the rules service. If
       // the data comes from a calculate charge request we deafult it. If the data comes from a create transaction
       // request it will already be populated
       ruleset: Joi.string().default('presroc'),
-      season: Joi.string().required(), // validated in rules service
+
+      // validated in rules service
+      season: Joi.string().required(),
+
       section126Factor: Joi.number().allow(null).empty(null).default(1.0),
       section127Agreement: Joi.boolean().required(),
       section130Agreement: Joi.boolean().required(),
-      source: Joi.string().required(), // validated in rules service
+
+      // validated in rules service
+      source: Joi.string().required(),
+
       twoPartTariff: Joi.boolean().required(),
       volume: Joi.number().min(0).required(),
       waterUndertaker: Joi.boolean().when('compensationCharge', { is: true, then: Joi.required() }),
-      regime: Joi.string().required() // needed to determine which endpoints to call in the rules service
-    })
+
+      // needed to determine which endpoints to call in the rules service
+      regime: Joi.string().required()
+    }
   }
 
   _translations () {

--- a/app/translators/calculate_presroc_charge.translator.js
+++ b/app/translators/calculate_presroc_charge.translator.js
@@ -1,14 +1,14 @@
 'use strict'
 
 /**
- * @module CalculateChargeTranslator
+ * @module CalculatePresrocChargeTranslator
  */
 
 const BaseTranslator = require('./base.translator')
 const Joi = require('joi').extend(require('@joi/date'))
 const Boom = require('@hapi/boom')
 
-class CalculateChargeTranslator extends BaseTranslator {
+class CalculatePresrocChargeTranslator extends BaseTranslator {
   constructor (data) {
     super(data)
 
@@ -240,4 +240,4 @@ class CalculateChargeTranslator extends BaseTranslator {
   }
 }
 
-module.exports = CalculateChargeTranslator
+module.exports = CalculatePresrocChargeTranslator

--- a/app/translators/calculate_presroc_charge.translator.js
+++ b/app/translators/calculate_presroc_charge.translator.js
@@ -128,6 +128,8 @@ class CalculatePresrocChargeTranslator extends BaseTranslator {
     const validDateFormats = ['DD-MMM-YYYY', 'DD-MM-YYYY', 'YYYY-MM-DD', 'DD/MM/YYYY', 'YYYY/MM/DD']
 
     return {
+      ruleset: Joi.string().valid('presroc').required(),
+
       authorisedDays: Joi.number().integer().min(0).max(366).required(),
       billableDays: Joi.number().integer().min(0).max(366).required(),
       compensationCharge: Joi.boolean().required(),
@@ -144,10 +146,6 @@ class CalculatePresrocChargeTranslator extends BaseTranslator {
 
       // validated in the rules service
       regionalChargingArea: Joi.string().required(),
-
-      // Set a new field called ruleset. This will be used to determine which ruleset to query in the rules service. It
-      // will already have been validated in order to determine which ruleset charge translator to use.
-      ruleset: Joi.string().required(),
 
       // validated in rules service
       season: Joi.string().required(),

--- a/app/translators/calculate_presroc_charge.translator.js
+++ b/app/translators/calculate_presroc_charge.translator.js
@@ -145,10 +145,9 @@ class CalculatePresrocChargeTranslator extends BaseTranslator {
       // validated in the rules service
       regionalChargingArea: Joi.string().required(),
 
-      // Set a new field called ruleset. This will be used to determine which ruleset to query in the rules service. If
-      // the data comes from a calculate charge request we deafult it. If the data comes from a create transaction
-      // request it will already be populated
-      ruleset: Joi.string().default('presroc'),
+      // Set a new field called ruleset. This will be used to determine which ruleset to query in the rules service. It
+      // will already have been validated in order to determine which ruleset charge translator to use.
+      ruleset: Joi.string().required(),
 
       // validated in rules service
       season: Joi.string().required(),

--- a/app/translators/calculate_sroc_charge.translator.js
+++ b/app/translators/calculate_sroc_charge.translator.js
@@ -1,0 +1,158 @@
+'use strict'
+
+/**
+ * @module CalculatePresrocChargeTranslator
+ */
+
+const BaseTranslator = require('./base.translator')
+const Joi = require('joi').extend(require('@joi/date'))
+const Boom = require('@hapi/boom')
+
+class CalculatePresrocChargeTranslator extends BaseTranslator {
+  constructor (data) {
+    super(data)
+
+    this.financialYear = this._financialYear(this.periodStart)
+
+    // Additional post-getter validation to ensure periodStart and periodEnd are in the same financial year
+    this._validateFinancialYear()
+  }
+
+  _validateFinancialYear () {
+    const schema = Joi.object({
+      periodEndFinancialYear: Joi.number().equal(this.financialYear)
+    })
+
+    const data = {
+      periodEndFinancialYear: this._financialYear(this.periodEnd)
+    }
+
+    const { error } = schema.validate(data)
+
+    if (error) {
+      throw Boom.badData(error)
+    }
+  }
+
+  _schema () {
+    const rules = this._rules()
+
+    return Joi.object({
+      abatementFactor: rules.abatementFactor,
+      actualVolume: rules.actualVolume,
+      aggregateProportion: rules.aggregateProportion,
+      authorisedDays: rules.authorisedDays,
+      billableDays: rules.billableDays,
+      chargeCategoryCode: rules.chargeCategoryCode,
+      compensationCharge: rules.compensationCharge,
+      credit: rules.credit,
+      // Note that financialYear is added in constructor()
+      loss: rules.loss,
+      periodEnd: rules.periodEnd,
+      periodStart: rules.periodStart,
+      regime: rules.regime,
+      regionalChargingArea: rules.regionalChargingArea,
+      ruleset: rules.ruleset,
+      section127Agreement: rules.section127Agreement,
+      section130Agreement: rules.section130Agreement,
+      supportedSource: rules.supportedSource,
+      supportedSourceName: rules.supportedSourceName,
+      twoPartTariff: rules.twoPartTariff,
+      volume: rules.volume,
+      waterCompanyCharge: rules.waterCompanyCharge,
+      waterUndertaker: rules.waterUndertaker,
+      winterOnly: rules.winterOnly
+    })
+  }
+
+  _rules () {
+    const validDateFormats = ['DD-MMM-YYYY', 'DD-MM-YYYY', 'YYYY-MM-DD', 'DD/MM/YYYY', 'YYYY/MM/DD']
+
+    return {
+      ruleset: Joi.string().valid('sroc').required(),
+
+      abatementFactor: Joi.number().allow(null).empty(null).default(1.0),
+      aggregateProportion: Joi.number().allow(null).empty(null).default(1.0),
+      authorisedDays: Joi.number().integer().min(0).max(366).required(),
+      billableDays: Joi.number().integer().min(0).max(366).required(),
+      credit: Joi.boolean().required(),
+      periodEnd: Joi.date().format(validDateFormats).required(),
+      periodStart: Joi.date().format(validDateFormats).min('01-APR-2021').max(Joi.ref('periodEnd')).required(),
+      section127Agreement: Joi.boolean().required(),
+      section130Agreement: Joi.boolean().required(),
+      supportedSource: Joi.boolean().required(),
+      volume: Joi.number().min(0).required(),
+      waterCompanyCharge: Joi.boolean().required(),
+      winterOnly: Joi.boolean().required(),
+
+      // Dependent on `compensationCharge`
+      compensationCharge: Joi.boolean().required(),
+      regionalChargingArea: Joi.when('compensationCharge', { is: true, then: Joi.string().required() }),
+      waterUndertaker: Joi.when('compensationCharge', { is: true, then: Joi.boolean().required() }),
+
+      // Dependent on `twoPartTariff`
+      twoPartTariff: Joi.boolean().required(),
+      actualVolume: Joi.when('twoPartTariff', { is: true, then: Joi.number().greater(0).required() }),
+
+      // strings validated by the rules service
+      chargeCategoryCode: Joi.string().required(),
+      loss: Joi.string().required(),
+      supportedSourceName: Joi.when('supportedSource', { is: true, then: Joi.string().required() }),
+
+      // needed to determine which endpoints to call in the rules service
+      regime: Joi.string().required()
+    }
+  }
+
+  // TODO: Translations need to be sorted correctly to use db fields as required eg. `regimeValue5` etc. For now we simply translate to the same string as the input
+  _translations () {
+    return {
+      abatementFactor: 'abatementFactor',
+      actualVolume: 'actualVolume',
+      aggregateProportion: 'aggregateProportion',
+      authorisedDays: 'authorisedDays',
+      billableDays: 'billableDays',
+      chargeCategoryCode: 'chargeCategoryCode',
+      financialYear: 'financialYear', // this field is added in `constructor()`
+      compensationCharge: 'compensationCharge',
+      credit: 'credit',
+      loss: 'loss',
+      periodEnd: 'periodEnd',
+      periodStart: 'periodStart',
+      regime: 'regime',
+      regionalChargingArea: 'regionalChargingArea',
+      ruleset: 'ruleset',
+      section127Agreement: 'section127Agreement',
+      section130Agreement: 'section130Agreement',
+      supportedSource: 'supportedSource',
+      supportedSourceName: 'supportedSourceName',
+      twoPartTariff: 'twoPartTariff',
+      volume: 'volume',
+      waterCompanyCharge: 'waterCompanyCharge',
+      waterUndertaker: 'waterUndertaker',
+      winterOnly: 'winterOnly'
+    }
+  }
+
+  /**
+   * Returns the calculated financial year for a given date
+   *
+   * If the date is January to March then the financial year is the previous year. Otherwise, the financial year is the
+   * current year.
+   *
+   * For example, if the date is 01-MAR-2022 then the financial year will be 2021. If the it's 01-MAY-2022 then the
+   * financial year will be 2022.
+   *
+   * @param {String} date
+   * @returns {Number} The calculated financial year
+  */
+  _financialYear (date) {
+    const periodDate = new Date(date)
+    const month = periodDate.getMonth()
+    const year = periodDate.getFullYear()
+
+    return (month <= 2 ? year - 1 : year)
+  }
+}
+
+module.exports = CalculatePresrocChargeTranslator

--- a/app/translators/index.js
+++ b/app/translators/index.js
@@ -4,6 +4,7 @@ const AuthorisedSystemTranslator = require('./authorised_system.translator')
 const BaseTranslator = require('./base.translator')
 const BillRunTranslator = require('./bill_run.translator')
 const CalculatePresrocChargeTranslator = require('./calculate_presroc_charge.translator')
+const CalculateSrocChargeTranslator = require('./calculate_sroc_charge.translator')
 const CustomerTranslator = require('./customer.translator')
 const RulesServiceTranslator = require('./rules_service.translator')
 const TransactionTranslator = require('./transaction.translator')
@@ -12,6 +13,7 @@ module.exports = {
   AuthorisedSystemTranslator,
   BaseTranslator,
   CalculatePresrocChargeTranslator,
+  CalculateSrocChargeTranslator,
   CustomerTranslator,
   BillRunTranslator,
   RulesServiceTranslator,

--- a/app/translators/index.js
+++ b/app/translators/index.js
@@ -3,7 +3,7 @@
 const AuthorisedSystemTranslator = require('./authorised_system.translator')
 const BaseTranslator = require('./base.translator')
 const BillRunTranslator = require('./bill_run.translator')
-const CalculateChargeTranslator = require('./calculate_charge.translator')
+const CalculatePresrocChargeTranslator = require('./calculate_presroc_charge.translator')
 const CustomerTranslator = require('./customer.translator')
 const RulesServiceTranslator = require('./rules_service.translator')
 const TransactionTranslator = require('./transaction.translator')
@@ -11,7 +11,7 @@ const TransactionTranslator = require('./transaction.translator')
 module.exports = {
   AuthorisedSystemTranslator,
   BaseTranslator,
-  CalculateChargeTranslator,
+  CalculatePresrocChargeTranslator,
   CustomerTranslator,
   BillRunTranslator,
   RulesServiceTranslator,

--- a/test/support/fixtures/calculate_charge/presroc/s126_prorata_credit_request.json
+++ b/test/support/fixtures/calculate_charge/presroc/s126_prorata_credit_request.json
@@ -15,5 +15,6 @@
   "regionalChargingArea": "Midlands",
   "section126Factor": 0.8,
   "section127Agreement": false,
-  "section130Agreement": false
+  "section130Agreement": false,
+  "ruleset": "presroc"
 }

--- a/test/support/fixtures/calculate_charge/presroc/section_agreements_true_request.json
+++ b/test/support/fixtures/calculate_charge/presroc/section_agreements_true_request.json
@@ -15,5 +15,6 @@
   "regionalChargingArea": "Midlands",
   "section126Factor": 1,
   "section127Agreement": true,
-  "section130Agreement": true
+  "section130Agreement": true,
+  "ruleset": "presroc"
 }

--- a/test/support/fixtures/calculate_charge/presroc/simple_request.json
+++ b/test/support/fixtures/calculate_charge/presroc/simple_request.json
@@ -15,5 +15,6 @@
   "regionalChargingArea": "Midlands",
   "section126Factor": 1,
   "section127Agreement": false,
-  "section130Agreement": false
+  "section130Agreement": false,
+  "ruleset": "presroc"
 }

--- a/test/translators/calculate_presroc_charge.translator.test.js
+++ b/test/translators/calculate_presroc_charge.translator.test.js
@@ -9,9 +9,9 @@ const { expect } = Code
 const { ValidationError } = require('joi')
 
 // Thing under test
-const { CalculateChargeTranslator } = require('../../app/translators')
+const { CalculatePresrocChargeTranslator } = require('../../app/translators')
 
-describe('Calculate Charge translator', () => {
+describe('Calculate Presroc Charge translator', () => {
   const payload = {
     periodStart: '01-APR-2020',
     periodEnd: '31-MAR-2021',
@@ -45,13 +45,13 @@ describe('Calculate Charge translator', () => {
         ...payload,
         section126Factor: null
       }
-      const testTranslator = new CalculateChargeTranslator(data(empty126FactorPayload))
+      const testTranslator = new CalculatePresrocChargeTranslator(data(empty126FactorPayload))
 
       expect(testTranslator.regimeValue11).to.be.a.number().and.equal(1.0)
     })
 
     it("defaults 'ruleset' to 'presroc'", async () => {
-      const testTranslator = new CalculateChargeTranslator(data(payload))
+      const testTranslator = new CalculatePresrocChargeTranslator(data(payload))
 
       expect(testTranslator.ruleset).to.be.a.string().and.equal('presroc')
     })
@@ -64,7 +64,7 @@ describe('Calculate Charge translator', () => {
         billableDays: 128,
         authorisedDays: 256
       }
-      const testTranslator = new CalculateChargeTranslator(data(proraratPayload))
+      const testTranslator = new CalculatePresrocChargeTranslator(data(proraratPayload))
 
       expect(testTranslator.lineAttr3).to.equal('128/256')
     })
@@ -75,7 +75,7 @@ describe('Calculate Charge translator', () => {
         billableDays: 8,
         authorisedDays: 16
       }
-      const testTranslator = new CalculateChargeTranslator(data(proraratPayload))
+      const testTranslator = new CalculatePresrocChargeTranslator(data(proraratPayload))
 
       expect(testTranslator.lineAttr3).to.equal('008/016')
     })
@@ -88,7 +88,7 @@ describe('Calculate Charge translator', () => {
         twoPartTariff: true
       }
 
-      const testTranslator = new CalculateChargeTranslator(data(proraratPayload))
+      const testTranslator = new CalculatePresrocChargeTranslator(data(proraratPayload))
 
       expect(testTranslator.lineAttr3).to.equal('000/000')
     })
@@ -101,7 +101,7 @@ describe('Calculate Charge translator', () => {
         periodStart: '01-MAR-2022',
         periodEnd: '30-MAR-2022'
       }
-      const testTranslator = new CalculateChargeTranslator(data(financialYearPayload))
+      const testTranslator = new CalculatePresrocChargeTranslator(data(financialYearPayload))
 
       expect(testTranslator.chargeFinancialYear).to.equal(2021)
     })
@@ -112,7 +112,7 @@ describe('Calculate Charge translator', () => {
         periodStart: '01-APR-2021',
         periodEnd: '01-MAY-2021'
       }
-      const testTranslator = new CalculateChargeTranslator(data(financialYearPayload))
+      const testTranslator = new CalculatePresrocChargeTranslator(data(financialYearPayload))
 
       expect(testTranslator.chargeFinancialYear).to.equal(2021)
     })
@@ -121,7 +121,7 @@ describe('Calculate Charge translator', () => {
   describe('handling of date formats', () => {
     describe("when period start and end are formatted as 'DD-MMM-YYYY'", () => {
       it('parses them correctly', async () => {
-        const result = new CalculateChargeTranslator(data(payload))
+        const result = new CalculatePresrocChargeTranslator(data(payload))
 
         expect(result.chargePeriodStart).to.be.a.date()
 
@@ -139,7 +139,7 @@ describe('Calculate Charge translator', () => {
           periodStart: '01-04-2020',
           periodEnd: '31-03-2021'
         }
-        const result = new CalculateChargeTranslator(data(dateFormatPayload))
+        const result = new CalculatePresrocChargeTranslator(data(dateFormatPayload))
 
         expect(result.chargePeriodStart).to.be.a.date()
 
@@ -157,7 +157,7 @@ describe('Calculate Charge translator', () => {
           periodStart: '2020-04-01',
           periodEnd: '2021-03-31'
         }
-        const result = new CalculateChargeTranslator(data(dateFormatPayload))
+        const result = new CalculatePresrocChargeTranslator(data(dateFormatPayload))
 
         expect(result.chargePeriodStart).to.be.a.date()
 
@@ -175,7 +175,7 @@ describe('Calculate Charge translator', () => {
           periodStart: '01/04/2020',
           periodEnd: '31/03/2021'
         }
-        const result = new CalculateChargeTranslator(data(dateFormatPayload))
+        const result = new CalculatePresrocChargeTranslator(data(dateFormatPayload))
 
         expect(result.chargePeriodStart).to.be.a.date()
 
@@ -193,7 +193,7 @@ describe('Calculate Charge translator', () => {
           periodStart: '2020/04/01',
           periodEnd: '2021/03/31'
         }
-        const result = new CalculateChargeTranslator(data(dateFormatPayload))
+        const result = new CalculatePresrocChargeTranslator(data(dateFormatPayload))
 
         expect(result.chargePeriodStart).to.be.a.date()
 
@@ -215,7 +215,7 @@ describe('Calculate Charge translator', () => {
           source: 'supPorTed'
         }
 
-        const result = new CalculateChargeTranslator(data(lowercasePayload))
+        const result = new CalculatePresrocChargeTranslator(data(lowercasePayload))
 
         expect(result.regimeValue8).to.equal('Low')
         expect(result.regimeValue7).to.equal('All Year')
@@ -227,7 +227,7 @@ describe('Calculate Charge translator', () => {
   describe('Validation', () => {
     describe('when the data is valid', () => {
       it('does not throw an error', async () => {
-        const result = new CalculateChargeTranslator(data(payload))
+        const result = new CalculatePresrocChargeTranslator(data(payload))
 
         expect(result).to.not.be.an.error()
       })
@@ -241,7 +241,7 @@ describe('Calculate Charge translator', () => {
             }
             delete validPayload.eiucSource
 
-            const result = new CalculateChargeTranslator(data(validPayload))
+            const result = new CalculatePresrocChargeTranslator(data(validPayload))
 
             expect(result).to.not.be.an.error()
           })
@@ -255,7 +255,7 @@ describe('Calculate Charge translator', () => {
             }
             delete validPayload.waterUndertaker
 
-            const result = new CalculateChargeTranslator(data(validPayload))
+            const result = new CalculatePresrocChargeTranslator(data(validPayload))
 
             expect(result).to.not.be.an.error()
           })
@@ -270,7 +270,7 @@ describe('Calculate Charge translator', () => {
             periodEnd: '01-APR-2020'
           }
 
-          const result = new CalculateChargeTranslator(data(validPayload))
+          const result = new CalculatePresrocChargeTranslator(data(validPayload))
 
           expect(result).to.not.be.an.error()
         })
@@ -285,7 +285,7 @@ describe('Calculate Charge translator', () => {
             periodStart: '01-APR-2021'
           }
 
-          expect(() => new CalculateChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+          expect(() => new CalculatePresrocChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
         })
       })
 
@@ -297,7 +297,7 @@ describe('Calculate Charge translator', () => {
             periodEnd: '01-MAR-2014'
           }
 
-          expect(() => new CalculateChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+          expect(() => new CalculatePresrocChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
         })
       })
 
@@ -309,7 +309,7 @@ describe('Calculate Charge translator', () => {
             periodEnd: '01-APR-2022'
           }
 
-          expect(() => new CalculateChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+          expect(() => new CalculatePresrocChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
         })
       })
 
@@ -322,7 +322,7 @@ describe('Calculate Charge translator', () => {
             }
             delete invalidPayload.eiucSource
 
-            expect(() => new CalculateChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+            expect(() => new CalculatePresrocChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
           })
         })
 
@@ -334,7 +334,7 @@ describe('Calculate Charge translator', () => {
             }
             delete invalidPayload.waterUndertaker
 
-            expect(() => new CalculateChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+            expect(() => new CalculatePresrocChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
           })
         })
       })
@@ -347,7 +347,7 @@ describe('Calculate Charge translator', () => {
             waterUndertaker: 'boom'
           }
 
-          expect(() => new CalculateChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+          expect(() => new CalculatePresrocChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
         })
       })
 
@@ -358,7 +358,7 @@ describe('Calculate Charge translator', () => {
             section126Factor: 1.1239
           }
 
-          expect(() => new CalculateChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+          expect(() => new CalculatePresrocChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
         })
       })
     })

--- a/test/translators/calculate_presroc_charge.translator.test.js
+++ b/test/translators/calculate_presroc_charge.translator.test.js
@@ -29,7 +29,8 @@ describe('Calculate Presroc Charge translator', () => {
     regionalChargingArea: 'Midlands',
     section126Factor: 1,
     section127Agreement: false,
-    section130Agreement: false
+    section130Agreement: false,
+    ruleset: 'presroc'
   }
 
   const data = (payload, regime = 'wrls') => {
@@ -48,12 +49,6 @@ describe('Calculate Presroc Charge translator', () => {
       const testTranslator = new CalculatePresrocChargeTranslator(data(empty126FactorPayload))
 
       expect(testTranslator.regimeValue11).to.be.a.number().and.equal(1.0)
-    })
-
-    it("defaults 'ruleset' to 'presroc'", async () => {
-      const testTranslator = new CalculatePresrocChargeTranslator(data(payload))
-
-      expect(testTranslator.ruleset).to.be.a.string().and.equal('presroc')
     })
   })
 

--- a/test/translators/calculate_presroc_charge.translator.test.js
+++ b/test/translators/calculate_presroc_charge.translator.test.js
@@ -356,6 +356,17 @@ describe('Calculate Presroc Charge translator', () => {
           expect(() => new CalculatePresrocChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
         })
       })
+
+      describe('because ruleset is not `presroc`', () => {
+        it('throws an error', async () => {
+          const invalidPayload = {
+            ...payload,
+            ruleset: 'INVALID'
+          }
+
+          expect(() => new CalculatePresrocChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+        })
+      })
     })
   })
 })

--- a/test/translators/calculate_sroc_charge.translator.test.js
+++ b/test/translators/calculate_sroc_charge.translator.test.js
@@ -1,0 +1,767 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, before, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+const { ValidationError } = require('joi')
+
+// Thing under test
+const { CalculateSrocChargeTranslator } = require('../../app/translators')
+
+describe('Calculate Sroc Charge translator', () => {
+  let validPayload
+
+  const payload = {
+    ruleset: 'sroc',
+    chargeCategoryCode: 'CHARGE', // confirm possible value
+    periodStart: '01-APR-2022',
+    periodEnd: '31-MAR-2023',
+    authorisedDays: 214,
+    billableDays: 214,
+    winterOnly: false,
+    section130Agreement: false,
+    section127Agreement: false,
+    twoPartTariff: false,
+    compensationCharge: false,
+    waterCompanyCharge: false,
+    supportedSource: false,
+    loss: 'Low',
+    volume: 1,
+    credit: false
+  }
+
+  const data = (payload, regime = 'wrls') => {
+    return {
+      regime,
+      ...payload
+    }
+  }
+
+  describe('Default values', () => {
+    it('defaults abatementFactor to `1.0`', async () => {
+      const abatementFactorPayload = {
+        ...payload,
+        abatementFactor: null
+      }
+      const testTranslator = new CalculateSrocChargeTranslator(data(abatementFactorPayload))
+
+      expect(testTranslator.abatementFactor).to.be.a.number().and.equal(1.0)
+    })
+
+    it('defaults aggregateProportion to `1.0`', async () => {
+      const aggregateProportionPayload = {
+        ...payload,
+        abatementFactor: null
+      }
+      const testTranslator = new CalculateSrocChargeTranslator(data(aggregateProportionPayload))
+
+      expect(testTranslator.aggregateProportion).to.be.a.number().and.equal(1.0)
+    })
+  })
+
+  describe('calculating the financial year', () => {
+    it("correctly determines the previous year for 'period' dates in March or earlier", async () => {
+      const financialYearPayload = {
+        ...payload,
+        periodStart: '01-MAR-2022',
+        periodEnd: '30-MAR-2022'
+      }
+      const testTranslator = new CalculateSrocChargeTranslator(data(financialYearPayload))
+
+      expect(testTranslator.financialYear).to.equal(2021)
+    })
+
+    it("correctly determines the current year for 'period' dates in April onwards", async () => {
+      const financialYearPayload = {
+        ...payload,
+        periodStart: '01-APR-2022',
+        periodEnd: '01-MAY-2022'
+      }
+      const testTranslator = new CalculateSrocChargeTranslator(data(financialYearPayload))
+
+      expect(testTranslator.financialYear).to.equal(2022)
+    })
+  })
+
+  describe('handling of date formats', () => {
+    describe("when period start and end are formatted as 'DD-MMM-YYYY'", () => {
+      it('parses them correctly', async () => {
+        const result = new CalculateSrocChargeTranslator(data(payload))
+
+        expect(result.periodStart).to.be.a.date()
+
+        expect(result.periodStart.getDate()).to.equal(1)
+        // Months are zero based, for example, January is 0 and December is 11
+        expect(result.periodStart.getMonth()).to.equal(3)
+        expect(result.periodStart.getFullYear()).to.equal(2022)
+      })
+    })
+
+    describe("when period start and end are formatted as 'DD-MM-YYYY'", () => {
+      it('parses them correctly', async () => {
+        const dateFormatPayload = {
+          ...payload,
+          periodStart: '01-04-2022',
+          periodEnd: '31-03-2023'
+        }
+        const result = new CalculateSrocChargeTranslator(data(dateFormatPayload))
+
+        expect(result.periodStart).to.be.a.date()
+
+        expect(result.periodStart.getDate()).to.equal(1)
+        // Months are zero based, for example, January is 0 and December is 11
+        expect(result.periodStart.getMonth()).to.equal(3)
+        expect(result.periodStart.getFullYear()).to.equal(2022)
+      })
+    })
+
+    describe("when period start and end are formatted as 'YYYY-MM-DD'", () => {
+      it('parses them correctly', async () => {
+        const dateFormatPayload = {
+          ...payload,
+          periodStart: '2022-04-01',
+          periodEnd: '2023-03-31'
+        }
+        const result = new CalculateSrocChargeTranslator(data(dateFormatPayload))
+
+        expect(result.periodStart).to.be.a.date()
+
+        expect(result.periodStart.getDate()).to.equal(1)
+        // Months are zero based, for example, January is 0 and December is 11
+        expect(result.periodStart.getMonth()).to.equal(3)
+        expect(result.periodStart.getFullYear()).to.equal(2022)
+      })
+    })
+
+    describe("when period start and end are formatted as 'DD/MM/YYYY'", () => {
+      it('parses them correctly', async () => {
+        const dateFormatPayload = {
+          ...payload,
+          periodStart: '01/04/2022',
+          periodEnd: '31/03/2023'
+        }
+        const result = new CalculateSrocChargeTranslator(data(dateFormatPayload))
+
+        expect(result.periodStart).to.be.a.date()
+
+        expect(result.periodStart.getDate()).to.equal(1)
+        // Months are zero based, for example, January is 0 and December is 11
+        expect(result.periodStart.getMonth()).to.equal(3)
+        expect(result.periodStart.getFullYear()).to.equal(2022)
+      })
+    })
+
+    describe("when period start and end are formatted as 'YYYY/MM/DD'", () => {
+      it('parses them correctly', async () => {
+        const dateFormatPayload = {
+          ...payload,
+          periodStart: '2022/04/01',
+          periodEnd: '2023/03/31'
+        }
+        const result = new CalculateSrocChargeTranslator(data(dateFormatPayload))
+
+        expect(result.periodStart).to.be.a.date()
+
+        expect(result.periodStart.getDate()).to.equal(1)
+        // Months are zero based, for example, January is 0 and December is 11
+        expect(result.periodStart.getMonth()).to.equal(3)
+        expect(result.periodStart.getFullYear()).to.equal(2022)
+      })
+    })
+  })
+
+  describe('Validation', () => {
+    describe('when the data is valid', () => {
+      it('does not throw an error', async () => {
+        const result = new CalculateSrocChargeTranslator(data(payload))
+
+        expect(result).to.not.be.an.error()
+      })
+
+      describe('when abatementFactor is provided', () => {
+        before(async () => {
+          validPayload = {
+            ...payload,
+            abatementFactor: 0.75
+          }
+        })
+
+        it('accepts a decimal value', async () => {
+          const testTranslator = new CalculateSrocChargeTranslator(data(validPayload))
+
+          expect(testTranslator.abatementFactor).to.be.a.number().and.equal(0.75)
+        })
+      })
+
+      describe('when aggregateProportion is provided', () => {
+        before(async () => {
+          validPayload = {
+            ...payload,
+            aggregateProportion: 0.75
+          }
+        })
+
+        it('accepts a decimal value', async () => {
+          const testTranslator = new CalculateSrocChargeTranslator(data(validPayload))
+
+          expect(testTranslator.aggregateProportion).to.be.a.number().and.equal(0.75)
+        })
+      })
+
+      describe('when volume is provided', () => {
+        before(async () => {
+          validPayload = {
+            ...payload,
+            volume: 1.75
+          }
+        })
+
+        it('accepts a decimal value', async () => {
+          const testTranslator = new CalculateSrocChargeTranslator(data(validPayload))
+
+          expect(testTranslator.volume).to.be.a.number().and.equal(1.75)
+        })
+      })
+
+      describe('when actualVolume is provided', () => {
+        before(async () => {
+          validPayload = {
+            ...payload,
+            actualVolume: 1.75
+          }
+        })
+
+        it('accepts a decimal value', async () => {
+          const testTranslator = new CalculateSrocChargeTranslator(data(validPayload))
+
+          expect(testTranslator.actualVolume).to.be.a.number().and.equal(1.75)
+        })
+      })
+
+      describe('if compensationCharge is `false`', () => {
+        describe('and regionalChargingArea is present', () => {
+          it('does not throw an error', async () => {
+            const validPayload = {
+              ...payload,
+              compensationCharge: false,
+              regionalChargingArea: 'AREA'
+            }
+
+            const result = new CalculateSrocChargeTranslator(data(validPayload))
+
+            expect(result).to.not.be.an.error()
+          })
+
+          describe('and waterUndertaker is present', () => {
+            it('does not throw an error', async () => {
+              const validPayload = {
+                ...payload,
+                compensationCharge: false,
+                waterUndertaker: true
+              }
+
+              const result = new CalculateSrocChargeTranslator(data(validPayload))
+
+              expect(result).to.not.be.an.error()
+            })
+          })
+        })
+      })
+
+      describe('when periodStartDate is the same as periodEndDate', () => {
+        it('still does not throw an error', async () => {
+          const validPayload = {
+            ...payload,
+            periodStart: '01-APR-2022',
+            periodEnd: '01-APR-2022'
+          }
+
+          const result = new CalculateSrocChargeTranslator(data(validPayload))
+
+          expect(result).to.not.be.an.error()
+        })
+      })
+
+      describe('when the data is not valid', () => {
+        describe('because ruleset', () => {
+          describe('is missing', () => {
+            it('throws an error', async () => {
+              const invalidPayload = payload
+              delete invalidPayload.ruleset
+
+              expect(() => new CalculateSrocChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+            })
+          })
+
+          describe('is not `sroc`', () => {
+            it('throws an error', async () => {
+              const invalidPayload = {
+                ...payload,
+                ruleset: 'INVALID'
+              }
+
+              expect(() => new CalculateSrocChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+            })
+          })
+        })
+
+        describe('because chargeCategoryCode', () => {
+          describe('is missing', () => {
+            it('throws an error', async () => {
+              const invalidPayload = payload
+              delete invalidPayload.chargeCategoryCode
+
+              expect(() => new CalculateSrocChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+            })
+          })
+        })
+
+        describe('because periodStart', () => {
+          describe('is missing', () => {
+            it('throws an error', async () => {
+              const invalidPayload = payload
+              delete invalidPayload.periodStart
+
+              expect(() => new CalculateSrocChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+            })
+          })
+
+          describe("is earlier than 1 April 2022'", () => {
+            it('throws an error', async () => {
+              const invalidPayload = {
+                ...payload,
+                periodStart: '31-MAR-2022'
+              }
+
+              expect(() => new CalculateSrocChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+            })
+          })
+
+          describe("is greater than periodEnd'", () => {
+            it('throws an error', async () => {
+              const invalidPayload = {
+                ...payload,
+                periodStart: '01-APR-2031'
+              }
+
+              expect(() => new CalculateSrocChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+            })
+          })
+        })
+
+        describe('because periodEnd', () => {
+          describe('is missing', () => {
+            it('throws an error', async () => {
+              const invalidPayload = payload
+              delete invalidPayload.periodEnd
+
+              expect(() => new CalculateSrocChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+            })
+          })
+
+          describe('is earlier than 01-APR-2022', () => {
+            it('throws an error', async () => {
+              const invalidPayload = {
+                ...payload,
+                periodStart: '01-FEB-2022',
+                periodEnd: '01-MAR-2022'
+              }
+
+              expect(() => new CalculateSrocChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+            })
+          })
+
+          describe('is not in the same finanal year as periodStart', () => {
+            it('throws an error', async () => {
+              const invalidPayload = {
+                ...payload,
+                periodStart: '01-FEB-2022',
+                periodEnd: '01-JUN-2024'
+              }
+
+              expect(() => new CalculateSrocChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+            })
+          })
+        })
+
+        describe('because authorisedDays', () => {
+          describe('is missing', () => {
+            it('throws an error', async () => {
+              const invalidPayload = payload
+              delete invalidPayload.authorisedDays
+
+              expect(() => new CalculateSrocChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+            })
+          })
+
+          describe('is a decimal', () => {
+            it('throws an error', async () => {
+              const invalidPayload = {
+                ...payload,
+                authorisedDays: 123.45
+              }
+
+              expect(() => new CalculateSrocChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+            })
+          })
+
+          describe('is below 0', () => {
+            it('throws an error', async () => {
+              const invalidPayload = {
+                ...payload,
+                authorisedDays: -100
+              }
+
+              expect(() => new CalculateSrocChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+            })
+          })
+
+          describe('is over 366', () => {
+            it('throws an error', async () => {
+              const invalidPayload = {
+                ...payload,
+                authorisedDays: 367
+              }
+
+              expect(() => new CalculateSrocChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+            })
+          })
+        })
+
+        describe('because billableDays', () => {
+          describe('is missing', () => {
+            it('throws an error', async () => {
+              const invalidPayload = payload
+              delete invalidPayload.billableDays
+
+              expect(() => new CalculateSrocChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+            })
+          })
+
+          describe('is below 0', () => {
+            it('throws an error', async () => {
+              const invalidPayload = {
+                ...payload,
+                billableDays: -100
+              }
+
+              expect(() => new CalculateSrocChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+            })
+          })
+
+          describe('is over 366', () => {
+            it('throws an error', async () => {
+              const invalidPayload = {
+                ...payload,
+                billableDays: 367
+              }
+
+              expect(() => new CalculateSrocChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+            })
+          })
+        })
+
+        describe('because winterOnly', () => {
+          describe('is missing', () => {
+            it('throws an error', async () => {
+              const invalidPayload = payload
+              delete invalidPayload.winterOnly
+
+              expect(() => new CalculateSrocChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+            })
+          })
+
+          describe('is not a boolean', () => {
+            it('throws an error', async () => {
+              const invalidPayload = {
+                ...payload,
+                winterOnly: 'INVALID'
+              }
+
+              expect(() => new CalculateSrocChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+            })
+          })
+        })
+
+        describe('because section130Agreement', () => {
+          describe('is missing', () => {
+            it('throws an error', async () => {
+              const invalidPayload = payload
+              delete invalidPayload.section130Agreement
+
+              expect(() => new CalculateSrocChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+            })
+          })
+
+          describe('is not a boolean', () => {
+            it('throws an error', async () => {
+              const invalidPayload = {
+                ...payload,
+                section130Agreement: 'INVALID'
+              }
+
+              expect(() => new CalculateSrocChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+            })
+          })
+        })
+
+        describe('because section127Agreement', () => {
+          describe('is missing', () => {
+            it('throws an error', async () => {
+              const invalidPayload = payload
+              delete invalidPayload.section127Agreement
+
+              expect(() => new CalculateSrocChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+            })
+          })
+
+          describe('is not a boolean', () => {
+            it('throws an error', async () => {
+              const invalidPayload = {
+                ...payload,
+                section127Agreement: 'INVALID'
+              }
+
+              expect(() => new CalculateSrocChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+            })
+          })
+        })
+
+        describe('because twoPartTariff', () => {
+          describe('is missing', () => {
+            it('throws an error', async () => {
+              const invalidPayload = payload
+              delete invalidPayload.twoPartTariff
+
+              expect(() => new CalculateSrocChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+            })
+          })
+
+          describe('is not a boolean', () => {
+            it('throws an error', async () => {
+              const invalidPayload = {
+                ...payload,
+                twoPartTariff: 'INVALID'
+              }
+
+              expect(() => new CalculateSrocChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+            })
+          })
+
+          describe('is `true`', () => {
+            let invalidPayload
+
+            beforeEach(async () => {
+              invalidPayload = {
+                ...payload,
+                twoPartTariff: true
+              }
+            })
+
+            describe('and actualVolume is missing', () => {
+              it('throws an error', async () => {
+                delete invalidPayload.actualVolume
+
+                expect(() => new CalculateSrocChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+              })
+            })
+          })
+        })
+
+        describe('because compensationCharge', () => {
+          describe('is missing', () => {
+            it('throws an error', async () => {
+              const invalidPayload = payload
+              delete invalidPayload.compensationCharge
+
+              expect(() => new CalculateSrocChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+            })
+          })
+
+          describe('is not a boolean', () => {
+            it('throws an error', async () => {
+              const invalidPayload = {
+                ...payload,
+                compensationCharge: 'INVALID'
+              }
+
+              expect(() => new CalculateSrocChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+            })
+          })
+
+          describe('is `true`', () => {
+            let invalidPayload
+
+            beforeEach(async () => {
+              invalidPayload = {
+                ...payload,
+                compensationCharge: true
+              }
+            })
+
+            describe('and regionalChargingArea is missing', () => {
+              it('throws an error', async () => {
+                delete invalidPayload.regionalChargingArea
+
+                expect(() => new CalculateSrocChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+              })
+            })
+
+            describe('and waterUndertaker is missing', () => {
+              it('throws an error', async () => {
+                delete invalidPayload.waterUndertaker
+
+                expect(() => new CalculateSrocChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+              })
+            })
+          })
+        })
+
+        describe('because waterUndertaker', () => {
+          describe('is not a boolean', () => {
+            it('throws an error', async () => {
+              const invalidPayload = {
+                ...payload,
+                waterUndertaker: 'INVALID'
+              }
+
+              expect(() => new CalculateSrocChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+            })
+          })
+        })
+
+        describe('because waterCompanyCharge', () => {
+          describe('is missing', () => {
+            it('throws an error', async () => {
+              const invalidPayload = payload
+              delete invalidPayload.waterCompanyCharge
+
+              expect(() => new CalculateSrocChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+            })
+          })
+
+          describe('is not a boolean', () => {
+            it('throws an error', async () => {
+              const invalidPayload = {
+                ...payload,
+                waterCompanyCharge: 'INVALID'
+              }
+
+              expect(() => new CalculateSrocChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+            })
+          })
+        })
+
+        describe('because supportedSource', () => {
+          describe('is missing', () => {
+            it('throws an error', async () => {
+              const invalidPayload = payload
+              delete invalidPayload.supportedSource
+
+              expect(() => new CalculateSrocChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+            })
+
+            describe('is not a boolean', () => {
+              it('throws an error', async () => {
+                const invalidPayload = {
+                  ...payload,
+                  supportedSource: 'INVALID'
+                }
+
+                expect(() => new CalculateSrocChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+              })
+            })
+          })
+
+          describe('is `true`', () => {
+            let invalidPayload
+
+            beforeEach(async () => {
+              invalidPayload = {
+                ...payload,
+                supportedSource: true
+              }
+            })
+
+            describe('and supportedSourceName is missing', () => {
+              it('throws an error', async () => {
+                delete invalidPayload.supportedSourceName
+
+                expect(() => new CalculateSrocChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+              })
+            })
+          })
+        })
+
+        describe('because loss', () => {
+          describe('is missing', () => {
+            it('throws an error', async () => {
+              const invalidPayload = payload
+              delete invalidPayload.loss
+
+              expect(() => new CalculateSrocChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+            })
+          })
+        })
+
+        describe('because volume', () => {
+          describe('is missing', () => {
+            it('throws an error', async () => {
+              const invalidPayload = payload
+              delete invalidPayload.volume
+
+              expect(() => new CalculateSrocChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+            })
+          })
+
+          describe('is 0', () => {
+            it('throws an error', async () => {
+              const invalidPayload = {
+                ...payload,
+                volume: 0
+              }
+
+              expect(() => new CalculateSrocChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+            })
+          })
+
+          describe('is less than 0', () => {
+            it('throws an error', async () => {
+              const invalidPayload = {
+                ...payload,
+                volume: -100
+              }
+
+              expect(() => new CalculateSrocChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+            })
+          })
+        })
+
+        describe('because credit', () => {
+          describe('is missing', () => {
+            it('throws an error', async () => {
+              const invalidPayload = payload
+              delete invalidPayload.credit
+
+              expect(() => new CalculateSrocChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+            })
+          })
+
+          describe('is not a boolean', () => {
+            it('throws an error', async () => {
+              const invalidPayload = {
+                ...payload,
+                credit: 'INVALID'
+              }
+
+              expect(() => new CalculateSrocChargeTranslator(data(invalidPayload))).to.throw(ValidationError)
+            })
+          })
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/projects/CMEA/boards/907?selectedIssue=CMEA-194

We validate incoming charge calculation data using `CalculateChargeTranslator`, which currently only supports pre-SRoC requests. We rename it `CalculatePresrocChargeTranslator` and create a separate `CalculateSrocChargeTranslator` to handle incoming SRoC validation.

As part of the change, we have identified several fields where the validation rules are the same. We will also be creating a separate `CalculatePresrocChargeV2Translator` at a later date to take into account some differences between v2 and v3 presroc validation (eg. we will no longer be capitalising certain strings such as `season`, in order to keep v3 sroc and presroc translation consistent). We therefore recognise the need to refactor these common rules, which will be done in a future PR.