### PR TITLE
Create `ValidateChargeService` and v3 route

### DIFF
--- a/app/controllers/calculate_charge.controller.js
+++ b/app/controllers/calculate_charge.controller.js
@@ -1,13 +1,19 @@
 'use strict'
 
-const { CalculateChargeService } = require('../services')
+const { CalculateChargeService, ValidateChargeService } = require('../services')
 
 class CalculateChargeController {
-  static async calculate (req, h) {
+  static async calculateV2 (req, h) {
     // Set v2 default
     req.payload.ruleset = 'presroc'
 
     const result = await CalculateChargeService.go(req.payload, req.app.regime)
+
+    return h.response(result).code(200)
+  }
+
+  static async calculate (req, h) {
+    const result = await ValidateChargeService.go(req.payload, req.app.regime)
 
     return h.response(result).code(200)
   }

--- a/app/routes/calculate_charge.routes.js
+++ b/app/routes/calculate_charge.routes.js
@@ -11,6 +11,11 @@ const routes = [
   {
     method: 'POST',
     path: '/v2/{regimeSlug}/calculate-charge',
+    handler: CalculateChargeController.calculateV2
+  },
+  {
+    method: 'POST',
+    path: '/v3/{regimeSlug}/calculate-charge',
     handler: CalculateChargeController.calculate
   }
 ]

--- a/app/services/charges/validate_charge.service.js
+++ b/app/services/charges/validate_charge.service.js
@@ -1,0 +1,55 @@
+'use strict'
+
+/**
+ * @module ValidateChargeService
+ */
+
+const Boom = require('@hapi/boom')
+
+const { CalculatePresrocChargeTranslator, CalculateSrocChargeTranslator } = require('../../translators')
+const { JsonPresenter } = require('../../presenters')
+
+class ValidateChargeService {
+  /**
+   * Simple service to validate incoming calculate charge requests. Intended solely for use in testing sroc validation:
+   *
+   * https://eaflood.atlassian.net/jira/software/projects/CMEA/boards/907?selectedIssue=CMEA-194
+   *
+   * @param {Object} payload The payload from the API request. payload.ruleset should be either `sroc` or `presroc`; a
+   *  Boom.badData error will be thrown if it isn't.
+   * @param {module:RegimeModel} regime Instance of `RegimeModel`, whose slug will be passed to the translator
+   *
+   * @returns {Object} The validated data.
+   */
+  static async go (payload, regime) {
+    let TranslatorToUse
+
+    switch (payload.ruleset) {
+      case 'sroc':
+        TranslatorToUse = CalculateSrocChargeTranslator
+        break
+      case 'presroc':
+        TranslatorToUse = CalculatePresrocChargeTranslator
+        break
+      default:
+        throw Boom.badData('Invalid ruleset')
+    }
+
+    const validated = this._translateRequest(TranslatorToUse, payload, regime)
+
+    return this._response(validated)
+  }
+
+  static _translateRequest (TranslatorToUse, payload, regime) {
+    return new TranslatorToUse({
+      ...payload,
+      regime: regime.slug
+    })
+  }
+
+  static _response (validated) {
+    return new JsonPresenter(validated).go()
+  }
+}
+
+module.exports = ValidateChargeService

--- a/app/services/index.js
+++ b/app/services/index.js
@@ -66,6 +66,7 @@ const TransformTableToFileService = require('./files/transform_table_to_file.ser
 const UpdateAuthorisedSystemService = require('./authorised_systems/update_authorised_system.service')
 const ValidateBillRunLicenceService = require('./licences/validate_bill_run_licence.service')
 const ValidateBillRunRegion = require('./bill_runs/validate_bill_run_region.service')
+const ValidateChargeService = require('./charges/validate_charge.service')
 const ViewAuthorisedSystemService = require('./authorised_systems/view_authorised_system.service')
 const ViewBillRunService = require('./bill_runs/view_bill_run.service')
 const ViewCustomerFileService = require('./files/customers/view_customer_file.service')
@@ -140,6 +141,7 @@ module.exports = {
   UpdateAuthorisedSystemService,
   ValidateBillRunLicenceService,
   ValidateBillRunRegion,
+  ValidateChargeService,
   ViewAuthorisedSystemService,
   ViewBillRunService,
   ViewCustomerFileService,

--- a/test/controllers/calculate_charge.controller.test.js
+++ b/test/controllers/calculate_charge.controller.test.js
@@ -26,6 +26,7 @@ const { presroc: fixtures } = require('../support/fixtures/calculate_charge')
 
 // Things we need to stub
 const JsonWebToken = require('jsonwebtoken')
+const { ValidateChargeService } = require('../../app/services')
 
 describe('Calculate charge controller', () => {
   const clientID = '1234546789'
@@ -91,6 +92,35 @@ describe('Calculate charge controller', () => {
 
         expect(response.statusCode).to.equal(422)
       })
+    })
+  })
+
+  describe('Calculating a charge: POST /v3/{regimeSlug}/calculate-charge', () => {
+    let validateStub
+
+    beforeEach(async () => {
+      validateStub = Sinon.stub(ValidateChargeService, 'go').returns({ response: true })
+    })
+
+    const options = (token, payload) => {
+      return {
+        method: 'POST',
+        url: '/v3/wrls/calculate-charge',
+        headers: { authorization: `Bearer ${token}` },
+        payload: payload
+      }
+    }
+
+    it('calls ValidateChargeService with the payload and returns its response', async () => {
+      const requestPayload = { request: true }
+      const response = await server.inject(options(authToken, requestPayload))
+      const responsePayload = JSON.parse(response.payload)
+
+      expect(validateStub.calledOnce).to.be.true()
+      expect(validateStub.firstCall.firstArg).to.equal(requestPayload)
+      expect(response.statusCode).to.equal(200)
+      expect(responsePayload.response).to.exist()
+      expect(responsePayload.response).to.be.true()
     })
   })
 })

--- a/test/services/charges/validate_charge.service.test.js
+++ b/test/services/charges/validate_charge.service.test.js
@@ -1,0 +1,69 @@
+'use strict'
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, afterEach, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Things we need to stub
+const { CalculatePresrocChargeTranslator, CalculateSrocChargeTranslator } = require('../../../app/translators')
+
+// Thing under test
+const { ValidateChargeService } = require('../../../app/services')
+
+describe('Validate Charge service', () => {
+  let translateStub
+
+  beforeEach(async () => {
+    translateStub = Sinon.stub(ValidateChargeService, '_translateRequest').returns({ success: true })
+  })
+
+  afterEach(async () => {
+    Sinon.restore()
+  })
+
+  describe('When the request is for sroc', () => {
+    it('calls CalculateSrocChargeTranslator', async () => {
+      await ValidateChargeService.go({ ruleset: 'sroc' })
+
+      expect(translateStub.calledWith(CalculateSrocChargeTranslator)).to.be.true()
+    })
+  })
+
+  describe('When the request is for presroc', () => {
+    it('calls CalculatePresrocChargeTranslator', async () => {
+      await ValidateChargeService.go({ ruleset: 'presroc' })
+
+      expect(translateStub.calledWith(CalculatePresrocChargeTranslator)).to.be.true()
+    })
+  })
+
+  describe('When a valid ruleset is given', () => {
+    it('returns the passed-in data', async () => {
+      const result = await ValidateChargeService.go({ ruleset: 'sroc' })
+
+      expect(result.success).to.exist()
+      expect(result.success).to.be.true()
+    })
+  })
+
+  describe('When an invalid ruleset is given', () => {
+    describe('because the ruleset is missing', () => {
+      it('throws an error', async () => {
+        const err = await expect(ValidateChargeService.go({ invalid: true })).to.reject()
+
+        expect(err).to.be.an.error()
+      })
+    })
+
+    describe("because the ruleset isn't `sroc` or `presroc`", () => {
+      it('throws an error', async () => {
+        const err = await expect(ValidateChargeService.go({ ruleset: 'INVALID' })).to.reject()
+
+        expect(err).to.be.an.error()
+      })
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/projects/CMEA/boards/907?selectedIssue=CMEA-194

In order to test the SRoC validation, we create a `ValidateChargeService` which passes the provided payload through the translator to validate it, then returns the translated data in the response. We create a `calculate` endpoint for this (renaming the existing endpoint to `calculateV2` as per our convention) and connect this to a `/v3/{regimeSlug}/calculate-charge` route.

Note that this will solely be used to test the validation, and will be removed once we move on to actually sending charge requests to the Rules Service.