### PR TITLE
Create transaction validation for sroc

### DIFF
--- a/app/services/transactions/create_transaction.service.js
+++ b/app/services/transactions/create_transaction.service.js
@@ -5,7 +5,7 @@
  */
 
 const { BillRunModel, InvoiceModel, LicenceModel, TransactionModel } = require('../../models')
-const { TransactionTranslator } = require('../../translators')
+const { TransactionPresrocTranslator } = require('../../translators')
 const CalculateChargeService = require('../charges/calculate_charge.service')
 const { CreateTransactionPresenter } = require('../../presenters')
 
@@ -23,7 +23,7 @@ class CreateTransactionService {
   }
 
   static _translateRequest (payload, billRunId, authorisedSystem, regime) {
-    return new TransactionTranslator({
+    return new TransactionPresrocTranslator({
       ...payload,
       billRunId,
       regimeId: regime.id,

--- a/app/translators/index.js
+++ b/app/translators/index.js
@@ -9,6 +9,7 @@ const CustomerTranslator = require('./customer.translator')
 const RulesServicePresrocTranslator = require('./rules_service_presroc.translator')
 const RulesServiceSrocTranslator = require('./rules_service_sroc.translator')
 const TransactionPresrocTranslator = require('./transaction_presroc.translator')
+const TransactionSrocTranslator = require('./transaction_sroc.translator')
 
 module.exports = {
   AuthorisedSystemTranslator,
@@ -19,5 +20,6 @@ module.exports = {
   BillRunTranslator,
   RulesServicePresrocTranslator,
   RulesServiceSrocTranslator,
-  TransactionPresrocTranslator
+  TransactionPresrocTranslator,
+  TransactionSrocTranslator
 }

--- a/app/translators/index.js
+++ b/app/translators/index.js
@@ -8,7 +8,7 @@ const CalculateChargeSrocTranslator = require('./calculate_charge_sroc.translato
 const CustomerTranslator = require('./customer.translator')
 const RulesServicePresrocTranslator = require('./rules_service_presroc.translator')
 const RulesServiceSrocTranslator = require('./rules_service_sroc.translator')
-const TransactionTranslator = require('./transaction.translator')
+const TransactionPresrocTranslator = require('./transaction_presroc.translator')
 
 module.exports = {
   AuthorisedSystemTranslator,
@@ -19,5 +19,5 @@ module.exports = {
   BillRunTranslator,
   RulesServicePresrocTranslator,
   RulesServiceSrocTranslator,
-  TransactionTranslator
+  TransactionPresrocTranslator
 }

--- a/app/translators/transaction_presroc.translator.js
+++ b/app/translators/transaction_presroc.translator.js
@@ -3,7 +3,7 @@
 const BaseTranslator = require('./base.translator')
 const Joi = require('joi')
 
-class TransactionTranslator extends BaseTranslator {
+class TransactionPresrocTranslator extends BaseTranslator {
   _schema () {
     return Joi.object({
       billRunId: Joi.string().required(),
@@ -108,4 +108,4 @@ class TransactionTranslator extends BaseTranslator {
   }
 }
 
-module.exports = TransactionTranslator
+module.exports = TransactionPresrocTranslator

--- a/app/translators/transaction_sroc.translator.js
+++ b/app/translators/transaction_sroc.translator.js
@@ -3,62 +3,92 @@
 const BaseTranslator = require('./base.translator')
 const Joi = require('joi')
 
-class TransactionPresrocTranslator extends BaseTranslator {
+class TransactionSrocTranslator extends BaseTranslator {
   _schema () {
+    const rules = this._rules()
+
     return Joi.object({
+      ruleset: rules.ruleset,
+
+      billRunId: rules.billRunId,
+      regimeId: rules.regimeId,
+      authorisedSystemId: rules.authorisedSystemId,
+      region: rules.region,
+      customerReference: rules.customerReference,
+      batchNumber: rules.batchNumber,
+      licenceNumber: rules.licenceNumber,
+      chargePeriod: rules.chargePeriod,
+      chargeElementId: rules.chargeElementId,
+      areaCode: rules.areaCode,
+      lineDescription: rules.lineDescription,
+      clientId: rules.clientId,
+      chargeCategoryDescription: rules.chargeCategoryDescription
+    })
+  }
+
+  _rules () {
+    return {
+      ruleset: Joi.string().valid('sroc').required(),
+
       billRunId: Joi.string().required(),
       regimeId: Joi.string().required(),
       authorisedSystemId: Joi.string().required(),
-      region: Joi.string().uppercase().valid(...this._validRegions()).required(),
+      region: Joi.string().uppercase().valid(...this._validRegions()).required(), // DOUBLE CHECK IF uppercase() IS NEEDED
       customerReference: Joi.string().uppercase().max(12).required(),
       batchNumber: Joi.string().allow('', null),
       licenceNumber: Joi.string().max(150).required(),
       chargePeriod: Joi.string().required(),
       chargeElementId: Joi.string().allow('', null),
-      areaCode: Joi.string().uppercase().valid(...this._validAreas()).required(),
+      areaCode: Joi.string().uppercase().valid(...this._validAreas()).required(), // DOUBLE CHECK IF uppercase() IS NEEDED
       lineDescription: Joi.string().max(240).required(),
-      subjectToMinimumCharge: Joi.boolean().default(false),
       clientId: Joi.string().allow('', null),
-      // Set a new field called ruleset. This will identify which ruleset the transaction and it's charge relates to
-      ruleset: Joi.string().default('presroc')
-    })
+      chargeCategoryDescription: Joi.string().max(150).required()
+    }
   }
 
+  // TODO: Translations need to be sorted correctly to use db fields as required eg. `regimeValue5` etc. For now we simply translate to the same string as the input
   _translations () {
     return {
+      ruleset: 'ruleset',
+
+      // Transaction-related, validated here
       billRunId: 'billRunId',
       regimeId: 'regimeId',
-      authorisedSystemId: 'createdBy',
-      ruleset: 'ruleset',
+      authorisedSystemId: 'authorisedSystemId',
       region: 'region',
       customerReference: 'customerReference',
-      periodStart: 'chargePeriodStart',
-      periodEnd: 'chargePeriodEnd',
-      subjectToMinimumCharge: 'subjectToMinimumCharge',
-      clientId: 'clientId',
-      credit: 'chargeCredit',
-      areaCode: 'lineAreaCode',
+      batchNumber: 'batchNumber',
+      licenceNumber: 'licenceNumber',
+      chargePeriod: 'chargePeriod',
+      chargeElementId: 'chargeElementId',
+      areaCode: 'areaCode',
       lineDescription: 'lineDescription',
-      licenceNumber: 'lineAttr1',
-      chargePeriod: 'lineAttr2',
-      prorataDays: 'lineAttr3',
-      volume: 'lineAttr5',
-      batchNumber: 'regimeValue1',
-      chargeElementId: 'regimeValue3',
-      billableDays: 'regimeValue4',
-      authorisedDays: 'regimeValue5',
-      source: 'regimeValue6',
-      season: 'regimeValue7',
-      loss: 'regimeValue8',
-      section130Agreement: 'regimeValue9',
-      section126Agreement: 'regimeValue10',
-      section126Factor: 'regimeValue11',
-      section127Agreement: 'regimeValue12',
-      eiucSource: 'regimeValue13',
-      waterUndertaker: 'regimeValue14',
-      regionalChargingArea: 'regimeValue15',
-      twoPartTariff: 'regimeValue16',
-      compensationCharge: 'regimeValue17'
+      clientId: 'clientId',
+      chargeCategoryDescription: 'chargeCategoryDescription',
+
+      // Charge-related, validated in CalculateChargeSrocTranslator
+      abatementFactor: 'abatementFactor',
+      actualVolume: 'actualVolume',
+      aggregateProportion: 'aggregateProportion',
+      authorisedDays: 'authorisedDays',
+      billableDays: 'billableDays',
+      chargeCategoryCode: 'chargeCategoryCode',
+      compensationCharge: 'compensationCharge',
+      credit: 'credit',
+      loss: 'loss',
+      periodEnd: 'chargePeriodEnd',
+      periodStart: 'chargePeriodStart',
+      regime: 'regime',
+      regionalChargingArea: 'regionalChargingArea',
+      section127Agreement: 'section127Agreement',
+      section130Agreement: 'section130Agreement',
+      supportedSource: 'supportedSource',
+      supportedSourceName: 'supportedSourceName',
+      twoPartTariff: 'twoPartTariff',
+      authorisedVolume: 'authorisedVolume',
+      waterCompanyCharge: 'waterCompanyCharge',
+      waterUndertaker: 'waterUndertaker',
+      winterOnly: 'winterOnly'
     }
   }
 
@@ -108,4 +138,4 @@ class TransactionPresrocTranslator extends BaseTranslator {
   }
 }
 
-module.exports = TransactionPresrocTranslator
+module.exports = TransactionSrocTranslator

--- a/app/translators/transaction_sroc.translator.js
+++ b/app/translators/transaction_sroc.translator.js
@@ -1,0 +1,111 @@
+'use strict'
+
+const BaseTranslator = require('./base.translator')
+const Joi = require('joi')
+
+class TransactionPresrocTranslator extends BaseTranslator {
+  _schema () {
+    return Joi.object({
+      billRunId: Joi.string().required(),
+      regimeId: Joi.string().required(),
+      authorisedSystemId: Joi.string().required(),
+      region: Joi.string().uppercase().valid(...this._validRegions()).required(),
+      customerReference: Joi.string().uppercase().max(12).required(),
+      batchNumber: Joi.string().allow('', null),
+      licenceNumber: Joi.string().max(150).required(),
+      chargePeriod: Joi.string().required(),
+      chargeElementId: Joi.string().allow('', null),
+      areaCode: Joi.string().uppercase().valid(...this._validAreas()).required(),
+      lineDescription: Joi.string().max(240).required(),
+      subjectToMinimumCharge: Joi.boolean().default(false),
+      clientId: Joi.string().allow('', null),
+      // Set a new field called ruleset. This will identify which ruleset the transaction and it's charge relates to
+      ruleset: Joi.string().default('presroc')
+    })
+  }
+
+  _translations () {
+    return {
+      billRunId: 'billRunId',
+      regimeId: 'regimeId',
+      authorisedSystemId: 'createdBy',
+      ruleset: 'ruleset',
+      region: 'region',
+      customerReference: 'customerReference',
+      periodStart: 'chargePeriodStart',
+      periodEnd: 'chargePeriodEnd',
+      subjectToMinimumCharge: 'subjectToMinimumCharge',
+      clientId: 'clientId',
+      credit: 'chargeCredit',
+      areaCode: 'lineAreaCode',
+      lineDescription: 'lineDescription',
+      licenceNumber: 'lineAttr1',
+      chargePeriod: 'lineAttr2',
+      prorataDays: 'lineAttr3',
+      volume: 'lineAttr5',
+      batchNumber: 'regimeValue1',
+      chargeElementId: 'regimeValue3',
+      billableDays: 'regimeValue4',
+      authorisedDays: 'regimeValue5',
+      source: 'regimeValue6',
+      season: 'regimeValue7',
+      loss: 'regimeValue8',
+      section130Agreement: 'regimeValue9',
+      section126Agreement: 'regimeValue10',
+      section126Factor: 'regimeValue11',
+      section127Agreement: 'regimeValue12',
+      eiucSource: 'regimeValue13',
+      waterUndertaker: 'regimeValue14',
+      regionalChargingArea: 'regimeValue15',
+      twoPartTariff: 'regimeValue16',
+      compensationCharge: 'regimeValue17'
+    }
+  }
+
+  _validRegions () {
+    return ['A', 'B', 'E', 'N', 'S', 'T', 'W', 'Y']
+  }
+
+  _validAreas () {
+    return [
+      'ARCA',
+      'AREA',
+      'ARNA',
+      'CASC',
+      'MIDLS',
+      'MIDLT',
+      'MIDUS',
+      'MIDUT',
+      'AACOR',
+      'AADEV',
+      'AANWX',
+      'AASWX',
+      'NWCEN',
+      'NWNTH',
+      'NWSTH',
+      'HAAR',
+      'KAEA',
+      'SAAR',
+      'AGY2N',
+      'AGY2S',
+      'AGY3',
+      'AGY3N',
+      'AGY3S',
+      'AGY4N',
+      'AGY4S',
+      'N',
+      'SE',
+      'SE1',
+      'SE2',
+      'SW',
+      'ABNRTH',
+      'DALES',
+      'NAREA',
+      'RIDIN',
+      'DEFAULT',
+      'MULTI'
+    ]
+  }
+}
+
+module.exports = TransactionPresrocTranslator

--- a/app/translators/transaction_sroc.translator.js
+++ b/app/translators/transaction_sroc.translator.js
@@ -33,13 +33,13 @@ class TransactionSrocTranslator extends BaseTranslator {
       billRunId: Joi.string().required(),
       regimeId: Joi.string().required(),
       authorisedSystemId: Joi.string().required(),
-      region: Joi.string().uppercase().valid(...this._validRegions()).required(), // DOUBLE CHECK IF uppercase() IS NEEDED
+      region: Joi.string().uppercase().valid(...this._validRegions()).required(),
       customerReference: Joi.string().uppercase().max(12).required(),
       batchNumber: Joi.string().allow('', null),
       licenceNumber: Joi.string().max(150).required(),
-      chargePeriod: Joi.string().required(),
+      chargePeriod: Joi.string().max(150).required(),
       chargeElementId: Joi.string().allow('', null),
-      areaCode: Joi.string().uppercase().valid(...this._validAreas()).required(), // DOUBLE CHECK IF uppercase() IS NEEDED
+      areaCode: Joi.string().uppercase().valid(...this._validAreas()).required(),
       lineDescription: Joi.string().max(240).required(),
       clientId: Joi.string().allow('', null),
       chargeCategoryDescription: Joi.string().max(150).required()

--- a/test/support/helpers/new_transaction.helper.js
+++ b/test/support/helpers/new_transaction.helper.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { TransactionModel } = require('../../../app/models')
-const { RulesServicePresrocTranslator, TransactionTranslator } = require('../../../app/translators')
+const { RulesServicePresrocTranslator, TransactionPresrocTranslator } = require('../../../app/translators')
 
 const { CreateTransactionTallyService } = require('../../../app/services')
 
@@ -49,7 +49,7 @@ class NewTransactionHelper {
   }
 
   static _defaultSimpleTransaction (billRunId) {
-    return new TransactionTranslator({
+    return new TransactionPresrocTranslator({
       billRunId,
       ...requestFixtures.simple,
       regimeId: GeneralHelper.uuid4(),

--- a/test/support/helpers/transaction.helper.js
+++ b/test/support/helpers/transaction.helper.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { TransactionModel } = require('../../../app/models')
-const { RulesServicePresrocTranslator, TransactionTranslator } = require('../../../app/translators')
+const { RulesServicePresrocTranslator, TransactionPresrocTranslator } = require('../../../app/translators')
 
 const GeneralHelper = require('./general.helper')
 const LicenceHelper = require('./licence.helper')
@@ -34,7 +34,7 @@ class TransactionHelper {
   }
 
   static _defaultSimpleTransaction (billRunId) {
-    return new TransactionTranslator({
+    return new TransactionPresrocTranslator({
       billRunId,
       ...requestFixtures.simple,
       regimeId: GeneralHelper.uuid4(),

--- a/test/translators/transaction_presroc.translator.test.js
+++ b/test/translators/transaction_presroc.translator.test.js
@@ -12,9 +12,9 @@ const { ValidationError } = require('joi')
 const { GeneralHelper } = require('../support/helpers')
 
 // Thing under test
-const { TransactionTranslator } = require('../../app/translators')
+const { TransactionPresrocTranslator } = require('../../app/translators')
 
-describe('Transaction translator', () => {
+describe('Transaction Presroc translator', () => {
   const payload = {
     periodStart: '01-APR-2019',
     periodEnd: '31-MAR-2020',
@@ -57,13 +57,13 @@ describe('Transaction translator', () => {
 
   describe('Default values', () => {
     it("defaults 'subjectToMinimumCharge' to 'false'", async () => {
-      const testTranslator = new TransactionTranslator(data(payload))
+      const testTranslator = new TransactionPresrocTranslator(data(payload))
 
       expect(testTranslator.subjectToMinimumCharge).to.be.a.boolean().and.equal(false)
     })
 
     it("defaults 'ruleset' to 'presroc'", async () => {
-      const testTranslator = new TransactionTranslator(data(payload))
+      const testTranslator = new TransactionPresrocTranslator(data(payload))
 
       expect(testTranslator.ruleset).to.be.a.string().and.equal('presroc')
     })
@@ -72,7 +72,7 @@ describe('Transaction translator', () => {
   describe('Validation', () => {
     describe('when the data is valid', () => {
       it('does not throw an error', async () => {
-        const result = new TransactionTranslator(data(payload))
+        const result = new TransactionPresrocTranslator(data(payload))
 
         expect(result).to.not.be.an.error()
       })
@@ -87,7 +87,7 @@ describe('Transaction translator', () => {
               region: 'INVALID_REGION'
             }
 
-            expect(() => new TransactionTranslator(data(invalidPayload))).to.throw(ValidationError)
+            expect(() => new TransactionPresrocTranslator(data(invalidPayload))).to.throw(ValidationError)
           })
         })
 
@@ -98,7 +98,7 @@ describe('Transaction translator', () => {
             }
             delete invalidPayload.region
 
-            expect(() => new TransactionTranslator(data(invalidPayload))).to.throw(ValidationError)
+            expect(() => new TransactionPresrocTranslator(data(invalidPayload))).to.throw(ValidationError)
           })
         })
       })
@@ -111,7 +111,7 @@ describe('Transaction translator', () => {
               areaCode: 'INVALID_AREA'
             }
 
-            expect(() => new TransactionTranslator(data(invalidPayload))).to.throw(ValidationError)
+            expect(() => new TransactionPresrocTranslator(data(invalidPayload))).to.throw(ValidationError)
           })
         })
 
@@ -122,7 +122,7 @@ describe('Transaction translator', () => {
             }
             delete invalidPayload.areaCode
 
-            expect(() => new TransactionTranslator(data(invalidPayload))).to.throw(ValidationError)
+            expect(() => new TransactionPresrocTranslator(data(invalidPayload))).to.throw(ValidationError)
           })
         })
       })

--- a/test/translators/transaction_sroc.translator.test.js
+++ b/test/translators/transaction_sroc.translator.test.js
@@ -171,7 +171,18 @@ describe('Transaction Sroc translator', () => {
         })
       })
 
-      describe('because licenceNumber', () => {
+      describe('because chargePeriod', () => {
+        describe('is too long', () => {
+          it('throws an error', async () => {
+            const invalidPayload = {
+              ...payload,
+              chargePeriod: 'X'.repeat(151)
+            }
+
+            expect(() => new TransactionSrocTranslator(data(invalidPayload))).to.throw(ValidationError)
+          })
+        })
+
         describe('is missing', () => {
           it('throws an error', async () => {
             const invalidPayload = {

--- a/test/translators/transaction_sroc.translator.test.js
+++ b/test/translators/transaction_sroc.translator.test.js
@@ -1,0 +1,131 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const { ValidationError } = require('joi')
+const { GeneralHelper } = require('../support/helpers')
+
+// Thing under test
+const { TransactionPresrocTranslator } = require('../../app/translators')
+
+describe('Transaction Sroc translator', () => {
+  const payload = {
+    periodStart: '01-APR-2019',
+    periodEnd: '31-MAR-2020',
+    credit: false,
+    billableDays: 310,
+    authorisedDays: 365,
+    volume: '6.22',
+    source: 'Supported',
+    season: 'Summer',
+    loss: 'Low',
+    twoPartTariff: false,
+    compensationCharge: false,
+    eiucSource: 'Tidal',
+    waterUndertaker: false,
+    regionalChargingArea: 'Anglian',
+    section127Agreement: false,
+    section130Agreement: false,
+    customerReference: 'TH230000222',
+    lineDescription: 'Well at Chigley Town Hall',
+    licenceNumber: 'TONY/TF9222/37',
+    chargePeriod: '01-APR-2018 - 31-MAR-2019',
+    chargeElementId: '',
+    batchNumber: 'TONY10',
+    region: 'W',
+    areaCode: 'ARCA'
+  }
+
+  const data = (
+    payload,
+    billRunId = GeneralHelper.uuid4(),
+    regimeId = GeneralHelper.uuid4(),
+    authorisedSystemId = GeneralHelper.uuid4()) => {
+    return {
+      billRunId,
+      regimeId,
+      authorisedSystemId,
+      ...payload
+    }
+  }
+
+  describe('Default values', () => {
+    it("defaults 'subjectToMinimumCharge' to 'false'", async () => {
+      const testTranslator = new TransactionPresrocTranslator(data(payload))
+
+      expect(testTranslator.subjectToMinimumCharge).to.be.a.boolean().and.equal(false)
+    })
+
+    it("defaults 'ruleset' to 'presroc'", async () => {
+      const testTranslator = new TransactionPresrocTranslator(data(payload))
+
+      expect(testTranslator.ruleset).to.be.a.string().and.equal('presroc')
+    })
+  })
+
+  describe('Validation', () => {
+    describe('when the data is valid', () => {
+      it('does not throw an error', async () => {
+        const result = new TransactionPresrocTranslator(data(payload))
+
+        expect(result).to.not.be.an.error()
+      })
+    })
+
+    describe('when the data is not valid', () => {
+      describe("because 'region'", () => {
+        describe('is not a valid region', () => {
+          it('throws an error', async () => {
+            const invalidPayload = {
+              ...payload,
+              region: 'INVALID_REGION'
+            }
+
+            expect(() => new TransactionPresrocTranslator(data(invalidPayload))).to.throw(ValidationError)
+          })
+        })
+
+        describe('is missing', () => {
+          it('throws an error', async () => {
+            const invalidPayload = {
+              ...payload
+            }
+            delete invalidPayload.region
+
+            expect(() => new TransactionPresrocTranslator(data(invalidPayload))).to.throw(ValidationError)
+          })
+        })
+      })
+
+      describe("because 'areaCode'", () => {
+        describe('is not a valid area', () => {
+          it('throws an error', async () => {
+            const invalidPayload = {
+              ...payload,
+              areaCode: 'INVALID_AREA'
+            }
+
+            expect(() => new TransactionPresrocTranslator(data(invalidPayload))).to.throw(ValidationError)
+          })
+        })
+
+        describe('is missing', () => {
+          it('throws an error', async () => {
+            const invalidPayload = {
+              ...payload
+            }
+            delete invalidPayload.areaCode
+
+            expect(() => new TransactionPresrocTranslator(data(invalidPayload))).to.throw(ValidationError)
+          })
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/projects/CMEA/boards/907?selectedIssue=CMEA-203

We implement the sroc-specific validation rules described in the card. Note that this PR fails SonarCloud due to code duplication between the presroc and sroc transaction validators; we won't be in a suitable place to fully refactor these until we've established the db fields to use, which will be done as part of the "create transaction" PR to follow.