### PR TITLE
Update `CreateTransactionService` to accept `ruleset`

### DIFF
--- a/app/controllers/admin/test/test_bill_runs.controller.js
+++ b/app/controllers/admin/test/test_bill_runs.controller.js
@@ -7,7 +7,10 @@ const { BillRunGenerator } = require('../../../../test/support/generators')
 class TestBillRunController {
   static async create (req, h) {
     const result = await CreateBillRunService.go(
-      { region: req.payload.region },
+      {
+        region: req.payload.region,
+        ruleset: 'presroc'
+      },
       req.auth.credentials.user,
       req.app.regime
     )

--- a/app/controllers/bill_runs_transactions.controller.js
+++ b/app/controllers/bill_runs_transactions.controller.js
@@ -7,9 +7,6 @@ const {
 
 class BillRunsTransactionsController {
   static async create (req, h) {
-    // Set default ruleset -- this controller will become the v2 controller in a future PR
-    req.payload.ruleset = 'presroc'
-
     await ValidateBillRunRegion.go(req.app.billRun, req.payload.region)
 
     const result = await CreateTransactionService.go(req.payload, req.app.billRun, req.auth.credentials.user, req.app.regime)

--- a/app/controllers/bill_runs_transactions.controller.js
+++ b/app/controllers/bill_runs_transactions.controller.js
@@ -7,6 +7,9 @@ const {
 
 class BillRunsTransactionsController {
   static async create (req, h) {
+    // Set default ruleset -- this controller will become the v2 controller in a future PR
+    req.payload.ruleset = 'presroc'
+
     await ValidateBillRunRegion.go(req.app.billRun, req.payload.region)
 
     const result = await CreateTransactionService.go(req.payload, req.app.billRun, req.auth.credentials.user, req.app.regime)

--- a/app/services/transactions/create_transaction.service.js
+++ b/app/services/transactions/create_transaction.service.js
@@ -13,7 +13,7 @@ const { CreateTransactionPresenter } = require('../../presenters')
 
 class CreateTransactionService {
   static async go (payload, billRun, authorisedSystem, regime) {
-    const transactionTranslator = this._determineTranslator(payload.ruleset)
+    const transactionTranslator = this._determineTranslator(billRun.ruleset)
 
     const translator = this._translateRequest(payload, billRun.id, authorisedSystem, regime, transactionTranslator)
 

--- a/app/services/transactions/create_transaction.service.js
+++ b/app/services/transactions/create_transaction.service.js
@@ -12,6 +12,17 @@ const CalculateChargeService = require('../charges/calculate_charge.service')
 const { CreateTransactionPresenter } = require('../../presenters')
 
 class CreateTransactionService {
+  /**
+   * Creates a new transaction on the specified bill run.
+   *
+   * @param {Object} payload The payload from the API request.
+   * @param {module:BillRunModel} billRun Instance of `BillRunModel` that the transaction is to be created on.
+   * @param {module:AuthorisedSystemModel} authorisedSystem Instance of `AuthorisedSystemModel' representing the
+   *  authenticated user.
+   * @param {module:RegimeModel} regime Instance of `RegimeModel` representing the regime we are creating the
+   *  transaction for.
+   * @returns {Object} Details of the newly-created transaction.
+   */
   static async go (payload, billRun, authorisedSystem, regime) {
     const transactionTranslator = this._determineTranslator(billRun.ruleset)
 

--- a/app/translators/transaction_presroc.translator.js
+++ b/app/translators/transaction_presroc.translator.js
@@ -20,7 +20,7 @@ class TransactionPresrocTranslator extends BaseTranslator {
       subjectToMinimumCharge: Joi.boolean().default(false),
       clientId: Joi.string().allow('', null),
       // Set a new field called ruleset. This will identify which ruleset the transaction and it's charge relates to
-      ruleset: Joi.string().default('presroc')
+      ruleset: Joi.string().allow('presroc').default('presroc')
     })
   }
 

--- a/test/services/transactions/create_transaction.service.test.js
+++ b/test/services/transactions/create_transaction.service.test.js
@@ -91,8 +91,8 @@ describe('Create Transaction service', () => {
   })
 
   describe('When the data is invalid', () => {
-    describe("because the 'payload' is invalid", () => {
-      describe("due to an item validated by the 'transaction'", () => {
+    describe('because the payload is invalid', () => {
+      describe('due to an item validated by the transaction', () => {
         it('throws an error', async () => {
           payload.customerReference = ''
 
@@ -104,13 +104,25 @@ describe('Create Transaction service', () => {
         })
       })
 
-      describe("due to an item validated by the 'charge'", () => {
+      describe('due to an item validated by the charge', () => {
         it('throws an error', async () => {
           payload.periodStart = '01-APR-2021'
 
           const err = await expect(
             CreateTransactionService.go(payload, billRun, authorisedSystem, regime)
           ).to.reject(ValidationError)
+
+          expect(err).to.be.an.error()
+        })
+      })
+
+      describe('due to an invalid ruleset', () => {
+        it('throws an error', async () => {
+          payload.ruleset = 'INVALID'
+
+          const err = await expect(
+            CreateTransactionService.go(payload, billRun, authorisedSystem, regime)
+          ).to.reject()
 
           expect(err).to.be.an.error()
         })

--- a/test/services/transactions/create_transaction.service.test.js
+++ b/test/services/transactions/create_transaction.service.test.js
@@ -14,6 +14,7 @@ const {
   BillRunHelper,
   DatabaseHelper,
   GeneralHelper,
+  NewBillRunHelper,
   RegimeHelper,
   TransactionHelper
 } = require('../../support/helpers')
@@ -39,7 +40,7 @@ describe('Create Transaction service', () => {
     await DatabaseHelper.clean()
     regime = await RegimeHelper.addRegime('wrls', 'WRLS')
     authorisedSystem = await AuthorisedSystemHelper.addSystem('1234546789', 'system1', [regime])
-    billRun = await BillRunHelper.addBillRun(authorisedSystem.id, regime.id)
+    billRun = await NewBillRunHelper.create(regime.id, authorisedSystem.id)
 
     // We clone the request fixture as our payload so we have it available for modification in the invalid tests. For
     // the valid tests we can use it straight as

--- a/test/support/fixtures/create_transaction/presroc/simple.json
+++ b/test/support/fixtures/create_transaction/presroc/simple.json
@@ -22,5 +22,6 @@
   "chargeElementId": "",
   "batchNumber": "TONY10",
   "region": "A",
-  "areaCode": "ARCA"
+  "areaCode": "ARCA",
+  "ruleset": "presroc"
 }

--- a/test/support/helpers/bill_run.helper.js
+++ b/test/support/helpers/bill_run.helper.js
@@ -14,7 +14,7 @@ class BillRunHelper {
    *
    * @returns {module:BillRunModel} The newly created instance of `BillRunModel`.
    */
-  static addBillRun (authorisedSystemId, regimeId, region = 'A', status = 'initialised', ruleset = 'sroc') {
+  static addBillRun (authorisedSystemId, regimeId, region = 'A', status = 'initialised', ruleset = 'presroc') {
     return BillRunModel.query()
       .insert({
         createdBy: authorisedSystemId,

--- a/test/support/helpers/new_bill_run.helper.js
+++ b/test/support/helpers/new_bill_run.helper.js
@@ -45,7 +45,7 @@ class NewBillRunHelper {
     return {
       region: 'A',
       status: 'initialised',
-      ruleset: 'sroc'
+      ruleset: 'presroc'
     }
   }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/projects/CMEA/boards/907?selectedIssue=CMEA-202

Ahead of our v3 route, we update `CreateTransactionService` to read `ruleset` from the bill run that the transaction is being created on. At present, we only support `presroc` bill runs; `sroc` will be added in a future PR.

Since the v2 route optionally accepts `ruleset` in the payload, we update the presroc validation to only allow `presroc`, and to default to `presroc` when not given. This means that the output of the translator contains the ruleset which is needed by `CalculateChargeService` when we pass the validated data on to it.

Note that all of this required a change to our test helpers; every test which uses a bill run helper to create a bill run followed by `CreateTransactionService` would fail as they default to creating an sroc bill run, but we don't yet support creating sroc transactions. Rather than changing every single test where this occurs, then changing it back once we are able to create sroc transactions, we simply change the default bill run the helpers create to be a presroc one. This gives us only 3 small changes to revert later:  the default ruleset in`BillRunHelper`, `NewBillRunHelper`, and `TestBillRunController`.