### PR TITLE
Align sroc translator and presenter fields

### DIFF
--- a/app/presenters/calculate_charge_sroc.presenter.js
+++ b/app/presenters/calculate_charge_sroc.presenter.js
@@ -15,13 +15,13 @@ class CalculateChargeSrocPresenter extends BasePresenter {
     return {
       calculation: {
         chargeValue: this._calculateChargeValue(data),
-        baseCharge: data.baseCharge,
-        waterCompanyChargeValue: data.waterCompanyChargeValue,
-        supportedSourceValue: data.supportedSourceValue,
-        winterOnlyFactor: data.winterOnlyFactor,
-        section130Factor: data.section130Factor,
-        section127Factor: data.section127Factor,
-        compensationChargePercent: data.compensationChargePercent
+        baseCharge: data.headerAttr9,
+        waterCompanyChargeValue: data.headerAttr10,
+        supportedSourceValue: data.lineAttr11,
+        winterOnlyFactor: data.lineAttr12,
+        section130Factor: data.lineAttr9,
+        section127Factor: data.lineAttr15,
+        compensationChargePercent: data.regimeValue2
       }
     }
   }

--- a/app/presenters/rules_service_sroc.presenter.js
+++ b/app/presenters/rules_service_sroc.presenter.js
@@ -17,24 +17,26 @@ class RulesServiceSrocPresenter extends BasePresenter {
       financialYear: data.chargeFinancialYear,
       chargeParams: {
         WRLSChargingRequest: {
-          abatementAdjustment: data.abatementFactor,
-          abstractableDays: data.authorisedDays,
-          actualVolume: data.actualVolume,
-          aggregateProportion: data.aggregateProportion,
-          authorisedVolume: data.authorisedVolume,
-          billableDays: data.billableDays,
-          chargeCategory: data.chargeCategoryCode,
-          compensationCharge: data.compensationCharge,
-          loss: data.loss,
-          regionalChargingArea: data.regionalChargingArea,
-          s127Agreement: data.section127Agreement,
-          s130Agreement: data.section130Agreement,
-          secondPartCharge: data.twoPartTariff,
-          supportedSourceName: data.supportedSourceName,
-          supportedSourceChargeFlag: data.supportedSource,
-          waterCompanyChargeFlag: data.waterCompany,
-          waterUndertaker: data.waterUndertaker,
-          winterOnly: data.winterOnly
+          // Some field names differ from their use elsewhere, eg. CalculateChargeSrocTranslator. Their alternate names
+          // are commented below.
+          abatementAdjustment: data.regimeValue19,
+          abstractableDays: data.regimeValue5, // authorisedDays
+          actualVolume: data.regimeValue20,
+          aggregateProportion: data.headerAttr2,
+          authorisedVolume: data.headerAttr3,
+          billableDays: data.regimeValue4,
+          chargeCategory: data.headerAttr4,
+          compensationCharge: data.regimeValue17,
+          loss: data.regimeValue8,
+          regionalChargingArea: data.regimeValue15,
+          s127Agreement: data.regimeValue12, // section127Agreement
+          s130Agreement: data.regimeValue9, // section130Agreement
+          secondPartCharge: data.regimeValue16, // twoPartTariff
+          supportedSourceName: data.headerAttr6,
+          supportedSourceChargeFlag: data.headerAttr5, // supportedSource
+          waterCompanyChargeFlag: data.headerAttr7, // waterCompanyCharge
+          waterUndertaker: data.regimeValue14,
+          winterOnly: data.headerAttr8
         }
       }
     }

--- a/app/translators/rules_service_presroc.translator.js
+++ b/app/translators/rules_service_presroc.translator.js
@@ -39,7 +39,6 @@ class RulesServicePresrocTranslator extends BaseTranslator {
 
   _translations () {
     return {
-      chargeValue: 'chargeValue',
       sourceFactor: 'lineAttr6',
       seasonFactor: 'lineAttr7',
       lossFactor: 'lineAttr8',

--- a/app/translators/rules_service_sroc.translator.js
+++ b/app/translators/rules_service_sroc.translator.js
@@ -16,17 +16,17 @@ class RulesServiceSrocTranslator extends BaseTranslator {
     this.chargeCalculation = JSON.stringify(data)
 
     this.chargeValue = this._convertToPence(this._data.chargeValue)
-    this.baseCharge = this._convertToPence(this._data.baselineCharge)
-    this.waterCompanyChargeValue = this._convertToPence(this._data.waterCompanyCharge)
-    this.supportedSourceValue = this._convertToPence(this._data.supportedSourceCharge)
+    this.headerAttr9 = this._convertToPence(this._data.baselineCharge)
+    this.headerAttr10 = this._convertToPence(this._data.waterCompanyCharge)
+    this.lineAttr11 = this._convertToPence(this._data.supportedSourceCharge)
 
     // Extract factor value from strings
-    this.winterOnlyFactor = this._extractFactor(this._data.winterOnlyAdjustment)
-    this.section130Factor = this._extractFactor(this._data.s130Agreement)
-    this.section127Factor = this._extractFactor(this._data.s127Agreement)
+    this.lineAttr12 = this._extractFactor(this._data.winterOnlyAdjustment)
+    this.lineAttr9 = this._extractFactor(this._data.s130Agreement)
+    this.lineAttr15 = this._extractFactor(this._data.s127Agreement)
 
     // Convert percentage string to value
-    this.compensationChargePercent = this._convertPercentage(this._data.compensationChargePercentage)
+    this.regimeValue2 = this._convertPercentage(this._data.compensationChargePercentage)
   }
 
   _schema () {
@@ -42,17 +42,9 @@ class RulesServiceSrocTranslator extends BaseTranslator {
     }).options({ stripUnknown: true })
   }
 
+  // All items in the response require conversion, which is done in constructor(). Therefore no translations are needed.
   _translations () {
-    return {
-      chargeValue: 'chargeValue',
-      baselineCharge: 'baseCharge',
-      waterCompanyCharge: 'waterCompanyChargeValue',
-      supportedSourceCharge: 'supportedSourceValue',
-      winterOnlyAdjustment: 'winterOnlyFactor',
-      s130Agreement: 'section130Factor',
-      s127Agreement: 'section127Factor',
-      compensationChargePercentage: 'compensationChargePercent'
-    }
+    return { }
   }
 
   _convertToPence (value) {

--- a/test/translators/rules_service_sroc.translator.test.js
+++ b/test/translators/rules_service_sroc.translator.test.js
@@ -31,43 +31,43 @@ describe('Rules Service Sroc translator', () => {
     })
   })
 
-  describe('the baseCharge property', () => {
+  describe('the headerAttr9 property', () => {
     it('is translated to pence instead of pounds and pence', async () => {
       data.WRLSChargingResponse.baselineCharge = 123.45
 
       const testTranslator = new RulesServiceSrocTranslator(data)
 
-      expect(testTranslator.baseCharge).to.equal(12345)
+      expect(testTranslator.headerAttr9).to.equal(12345)
     })
   })
 
-  describe('the waterCompanyChargeValue property', () => {
+  describe('the headerAttr10 property', () => {
     it('is translated to pence instead of pounds and pence', async () => {
       data.WRLSChargingResponse.waterCompanyCharge = 123.45
 
       const testTranslator = new RulesServiceSrocTranslator(data)
 
-      expect(testTranslator.waterCompanyChargeValue).to.equal(12345)
+      expect(testTranslator.headerAttr10).to.equal(12345)
     })
   })
 
-  describe('the supportedSourceValue property', () => {
+  describe('the lineAttr11 property', () => {
     it('is translated to pence instead of pounds and pence', async () => {
       data.WRLSChargingResponse.supportedSourceCharge = 123.45
 
       const testTranslator = new RulesServiceSrocTranslator(data)
 
-      expect(testTranslator.supportedSourceValue).to.equal(12345)
+      expect(testTranslator.lineAttr11).to.equal(12345)
     })
   })
 
-  describe('the winterOnlyFactor property', () => {
+  describe('the lineAttr12 property', () => {
     it('returns the factor value when specified', async () => {
       data.WRLSChargingResponse.winterOnlyAdjustment = 'Winter Only Discount 0.5'
 
       const testTranslator = new RulesServiceSrocTranslator(data)
 
-      expect(testTranslator.winterOnlyFactor).to.equal(0.5)
+      expect(testTranslator.lineAttr12).to.equal(0.5)
     })
 
     it('returns `null` if the Rules Service returned `null`', async () => {
@@ -75,17 +75,17 @@ describe('Rules Service Sroc translator', () => {
 
       const testTranslator = new RulesServiceSrocTranslator(data)
 
-      expect(testTranslator.winterOnlyFactor).to.equal(null)
+      expect(testTranslator.lineAttr12).to.equal(null)
     })
   })
 
-  describe('the section130Factor property', () => {
+  describe('the lineAttr9 property', () => {
     it('returns the factor value when specified', async () => {
       data.WRLSChargingResponse.s130Agreement = 'CRT 0.5'
 
       const testTranslator = new RulesServiceSrocTranslator(data)
 
-      expect(testTranslator.section130Factor).to.equal(0.5)
+      expect(testTranslator.lineAttr9).to.equal(0.5)
     })
 
     it('returns `null` if the Rules Service returned `null`', async () => {
@@ -93,17 +93,17 @@ describe('Rules Service Sroc translator', () => {
 
       const testTranslator = new RulesServiceSrocTranslator(data)
 
-      expect(testTranslator.section130Factor).to.equal(null)
+      expect(testTranslator.lineAttr9).to.equal(null)
     })
   })
 
-  describe('the section127Factor property', () => {
+  describe('the lineAttr15 property', () => {
     it('returns the factor value when specified', async () => {
       data.WRLSChargingResponse.s127Agreement = 'Two-Part tariff 0.5'
 
       const testTranslator = new RulesServiceSrocTranslator(data)
 
-      expect(testTranslator.section127Factor).to.equal(0.5)
+      expect(testTranslator.lineAttr15).to.equal(0.5)
     })
 
     it('returns `null` if the Rules Service returned `null`', async () => {
@@ -111,17 +111,17 @@ describe('Rules Service Sroc translator', () => {
 
       const testTranslator = new RulesServiceSrocTranslator(data)
 
-      expect(testTranslator.section127Factor).to.equal(null)
+      expect(testTranslator.lineAttr15).to.equal(null)
     })
   })
 
-  describe('the compensationChargePercent property', () => {
+  describe('the regimeValue2 property', () => {
     it('returns the percentage as a number', async () => {
       data.WRLSChargingResponse.compensationChargePercentage = '50%'
 
       const testTranslator = new RulesServiceSrocTranslator(data)
 
-      expect(testTranslator.compensationChargePercent).to.equal(50)
+      expect(testTranslator.regimeValue2).to.equal(50)
     })
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/projects/CMEA/boards/907?selectedIssue=CMEA-202

While working on Create Transaction, we realised that the various translators and presenters used in the create transaction flow aren't quite aligned in terms of their input and outputs. This PR seeks to align them by ensuring that leftover placeholder translation/presentation is replaced with the actual db fields to be used.

We found that none of the `_translations()` in `RulesServiceSrocTranslator` were needed, as all the data items returned by the translator are set in `constructor()`. We therefore remove them so that `_translations()` returns an empty object. Following this, we checked `RulesServicePresrocTranslator` and spotted the `chargeValue` was similarly unneeded, as we set it in `constructor()`. This too was removed from `_translations()`.