### PR TITLE
Handle undefined `compensationChargePercentage` in Rules Service response

### DIFF
--- a/app/translators/rules_service_sroc.translator.js
+++ b/app/translators/rules_service_sroc.translator.js
@@ -25,7 +25,7 @@ class RulesServiceSrocTranslator extends BaseTranslator {
     this.lineAttr9 = this._extractFactor(this._data.s130Agreement)
     this.lineAttr15 = this._extractFactor(this._data.s127Agreement)
 
-    // Convert percentage string to value
+    // Convert percentage string to value. Note that this will be `null` if the Rules Service did not return a value
     this.regimeValue2 = this._convertPercentage(this._data.compensationChargePercentage)
   }
 
@@ -38,7 +38,9 @@ class RulesServiceSrocTranslator extends BaseTranslator {
       winterOnlyAdjustment: Joi.required(),
       s130Agreement: Joi.required(),
       s127Agreement: Joi.required(),
-      compensationChargePercentage: Joi.string().required()
+      // compensationChargePercentage is only returned if this was a compensation charge. If it isn't returned then we
+      // default it to `null`
+      compensationChargePercentage: Joi.string().default(null)
     }).options({ stripUnknown: true })
   }
 
@@ -76,9 +78,15 @@ class RulesServiceSrocTranslator extends BaseTranslator {
   /**
    * Converts a string percentage into a value.
    *
-   * The Rules Service returns a percentage as a string in the form `50%`. We convert this to a number `50`.
+   * The Rules Service returns a percentage as a string in the form `50%`. We convert this to a number `50`. In some
+   * situations the Rules Service does not return any value. In this situation we will have previously defaulted it to
+   * `null` during validation, and we therefore return `null` from here.
    */
   _convertPercentage (percentageString) {
+    if (!percentageString) {
+      return null
+    }
+
     // parseFloat() will parse the passed-in string up to the first non-number character so this will give us the number
     // part of the percentage string.
     const percentageFloat = parseFloat(percentageString)

--- a/test/translators/rules_service_sroc.translator.test.js
+++ b/test/translators/rules_service_sroc.translator.test.js
@@ -123,5 +123,13 @@ describe('Rules Service Sroc translator', () => {
 
       expect(testTranslator.regimeValue2).to.equal(50)
     })
+
+    it('returns `null` if the Rules Service did not include it in the response', async () => {
+      data.WRLSChargingResponse.compensationChargePercentage = undefined
+
+      const testTranslator = new RulesServiceSrocTranslator(data)
+
+      expect(testTranslator.regimeValue2).to.equal(null)
+    })
   })
 })


### PR DESCRIPTION
We observed during testing that the Rules Service only returns a value for `compensationChargePercentage` if the charge request was for a compensation charge. If it wasn't a compensation charge, `compensationChargePercentage` is not included in the response, causing problems as we have set this as a required field.

We fix this by changing it from being a required field to one that defaults to `null`, and updating the translator to leave the percentage value as `null` in this situation instead of trying to convert it to a number.