### PR TITLE
Handle null `compensationChargePercentage` in Rules Service response

### DIFF
--- a/app/translators/rules_service_sroc.translator.js
+++ b/app/translators/rules_service_sroc.translator.js
@@ -40,7 +40,7 @@ class RulesServiceSrocTranslator extends BaseTranslator {
       s127Agreement: Joi.required(),
       // compensationChargePercentage is only returned if this was a compensation charge. If it isn't returned then we
       // default it to `null`
-      compensationChargePercentage: Joi.string().default(null)
+      compensationChargePercentage: Joi.string().allow(null)
     }).options({ stripUnknown: true })
   }
 

--- a/test/translators/rules_service_sroc.translator.test.js
+++ b/test/translators/rules_service_sroc.translator.test.js
@@ -124,8 +124,8 @@ describe('Rules Service Sroc translator', () => {
       expect(testTranslator.regimeValue2).to.equal(50)
     })
 
-    it('returns `null` if the Rules Service did not include it in the response', async () => {
-      data.WRLSChargingResponse.compensationChargePercentage = undefined
+    it('returns `null` if the Rules Service returned `null`', async () => {
+      data.WRLSChargingResponse.compensationChargePercentage = null
 
       const testTranslator = new RulesServiceSrocTranslator(data)
 


### PR DESCRIPTION
[Our previous fix](https://github.com/DEFRA/sroc-charging-module-api/pull/617) for the SRoC Rules Service response unfortunately failed in test -- we had misunderstood the cause of the problem, which wasn't that `compensationChargePercentage` was missing from the Rules Service response, but rather it was present but had a value of `null`. This PR fixes this.