### PR TITLE
Update deminimis to support SRoC

### DIFF
--- a/app/lib/static_lookup.lib.js
+++ b/app/lib/static_lookup.lib.js
@@ -16,7 +16,7 @@ class StaticLookupLib {
     return ['presroc', 'sroc']
   }
 
-  static get deminimisValues () {
+  static get deminimisLimits () {
     return {
       presroc: 500,
       sroc: 1000

--- a/app/lib/static_lookup.lib.js
+++ b/app/lib/static_lookup.lib.js
@@ -15,6 +15,13 @@ class StaticLookupLib {
   static get rulesets () {
     return ['presroc', 'sroc']
   }
+
+  static get deminimisValues () {
+    return {
+      presroc: 5000,
+      sroc: 10000
+    }
+  }
 }
 
 module.exports = StaticLookupLib

--- a/app/lib/static_lookup.lib.js
+++ b/app/lib/static_lookup.lib.js
@@ -18,8 +18,8 @@ class StaticLookupLib {
 
   static get deminimisValues () {
     return {
-      presroc: 5000,
-      sroc: 10000
+      presroc: 500,
+      sroc: 1000
     }
   }
 }

--- a/app/models/bill_run.model.js
+++ b/app/models/bill_run.model.js
@@ -7,6 +7,8 @@
 const { Model } = require('objection')
 const BaseModel = require('./base.model')
 
+const StaticLookupLib = require('../lib/static_lookup.lib')
+
 class BillRunModel extends BaseModel {
   static get tableName () {
     return 'billRuns'
@@ -223,6 +225,13 @@ class BillRunModel extends BaseModel {
    */
   $billable () {
     return Boolean(this.fileReference)
+  }
+
+  /**
+   * Returns the deminimis value of the bill run's ruleset
+   */
+  $deminimisValue (ruleset) {
+    return StaticLookupLib.deminimisValues[this.ruleset]
   }
 }
 

--- a/app/models/bill_run.model.js
+++ b/app/models/bill_run.model.js
@@ -241,6 +241,7 @@ class BillRunModel extends BaseModel {
     return this.$relatedQuery('invoices', trx)
       .whereRaw('debit_line_value - credit_line_value > 0')
       .whereRaw('debit_line_value - credit_line_value < ?', this.$deminimisLimit())
+      .modify('originalInvoice')
   }
 }
 

--- a/app/models/bill_run.model.js
+++ b/app/models/bill_run.model.js
@@ -230,8 +230,17 @@ class BillRunModel extends BaseModel {
   /**
    * Returns the deminimis value of the bill run's ruleset
    */
-  $deminimisValue (ruleset) {
+  $deminimisValue () {
     return StaticLookupLib.deminimisValues[this.ruleset]
+  }
+
+  /**
+   * Returns all invoices on the bill run which are deminimis
+   */
+  async $deminimisInvoices (trx = null) {
+    return this.$relatedQuery('invoices', trx)
+      .whereRaw('debit_line_value - credit_line_value > 0')
+      .whereRaw('debit_line_value - credit_line_value < ?', this.$deminimisValue())
   }
 }
 

--- a/app/models/bill_run.model.js
+++ b/app/models/bill_run.model.js
@@ -228,10 +228,10 @@ class BillRunModel extends BaseModel {
   }
 
   /**
-   * Returns the deminimis value of the bill run's ruleset
+   * Returns the deminimis limit of the bill run's ruleset
    */
-  $deminimisValue () {
-    return StaticLookupLib.deminimisValues[this.ruleset]
+  $deminimisLimit () {
+    return StaticLookupLib.deminimisLimits[this.ruleset]
   }
 
   /**
@@ -240,7 +240,7 @@ class BillRunModel extends BaseModel {
   $deminimisInvoices (trx = null) {
     return this.$relatedQuery('invoices', trx)
       .whereRaw('debit_line_value - credit_line_value > 0')
-      .whereRaw('debit_line_value - credit_line_value < ?', this.$deminimisValue())
+      .whereRaw('debit_line_value - credit_line_value < ?', this.$deminimisLimit())
   }
 }
 

--- a/app/models/bill_run.model.js
+++ b/app/models/bill_run.model.js
@@ -235,7 +235,7 @@ class BillRunModel extends BaseModel {
   }
 
   /**
-   * Returns all invoices on the bill run which are deminimis
+   * Returns a query which will fetch all deminimis invoices on the bill run
    */
   $deminimisInvoices (trx = null) {
     return this.$relatedQuery('invoices', trx)

--- a/app/models/bill_run.model.js
+++ b/app/models/bill_run.model.js
@@ -237,7 +237,7 @@ class BillRunModel extends BaseModel {
   /**
    * Returns all invoices on the bill run which are deminimis
    */
-  async $deminimisInvoices (trx = null) {
+  $deminimisInvoices (trx = null) {
     return this.$relatedQuery('invoices', trx)
       .whereRaw('debit_line_value - credit_line_value > 0')
       .whereRaw('debit_line_value - credit_line_value < ?', this.$deminimisValue())

--- a/app/models/invoice.model.js
+++ b/app/models/invoice.model.js
@@ -7,7 +7,6 @@
 const { Model } = require('objection')
 const BaseUpsertModel = require('./base_upsert.model')
 
-const DEMINIMIS_LIMIT = 500
 // This is the value used for new invoices. Reason? To allow us to accept multiple rebill invoices with the same
 // customer reference and financial year in the same bill run. It ensures the invoices table constraint works for new
 // invoices, but when we rebill and actually have a rebill ID, the constraint doesn't trigger.
@@ -189,12 +188,12 @@ class InvoiceModel extends BaseUpsertModel {
   }
 
   /**
-   * deminimisInvoice method returns true if this is a deminimis invoice
+   * deminimisInvoice method receives the deminimis limit for this invoice and returns true if it is a deminimis invoice
    */
-  $deminimisInvoice () {
+  $deminimisInvoice (deminimisLimit) {
     return (
       this.debitLineValue - this.creditLineValue > 0 &&
-      this.debitLineValue - this.creditLineValue < DEMINIMIS_LIMIT &&
+      this.debitLineValue - this.creditLineValue < deminimisLimit &&
       this.$originalInvoice()
     )
   }

--- a/app/models/invoice.model.js
+++ b/app/models/invoice.model.js
@@ -66,16 +66,6 @@ class InvoiceModel extends BaseUpsertModel {
       },
 
       /**
-       * deminimis modifier selects all invoices which are deminimis.
-       */
-      deminimis (query) {
-        query
-          .whereRaw('debit_line_value - credit_line_value > 0')
-          .whereRaw('debit_line_value - credit_line_value < ?', DEMINIMIS_LIMIT)
-          .modify('originalInvoice')
-      },
-
-      /**
        * minimum charge modifier selects all invoices where minimum charge applies.
        */
       minimumCharge (query) {

--- a/app/services/bill_runs/generate_bill_run.service.js
+++ b/app/services/bill_runs/generate_bill_run.service.js
@@ -145,8 +145,7 @@ class GenerateBillRunService {
   }
 
   static async _setDeminimisInvoiceFlags (billRun, trx) {
-    return billRun.$relatedQuery('invoices', trx)
-      .modify('deminimis')
+    return billRun.$deminimisInvoices(trx)
       .patch({ deminimisInvoice: true })
   }
 

--- a/app/services/licences/delete_licence.service.js
+++ b/app/services/licences/delete_licence.service.js
@@ -93,7 +93,7 @@ class DeleteLicenceService {
   static async _handleInvoice (billRun, invoice, licence, trx) {
     this._updateInstance(invoice, licence)
     const minimumChargeInvoice = await this._determineMinimumChargeInvoice(billRun, invoice, trx)
-    const invoicePatch = this._invoicePatch(invoice, minimumChargeInvoice)
+    const invoicePatch = this._invoicePatch(invoice, minimumChargeInvoice, billRun.$deminimisValue())
     await invoice.$query(trx).patch(invoicePatch)
   }
 
@@ -117,11 +117,12 @@ class DeleteLicenceService {
    * Creates a patch for the invoice using the fields in _entityPatch (which are common to both invoice and bill run),
    * and then adds in additional fields based on the invoice's static methods.
    */
-  static _invoicePatch (invoice, minimumChargeInvoice) {
+  static _invoicePatch (invoice, minimumChargeInvoice, deminimisValue) {
+    console.log(invoice.$deminimisInvoice(deminimisValue))
     return {
       ...this._entityPatch(invoice),
       zeroValueInvoice: invoice.$zeroValueInvoice(),
-      deminimisInvoice: invoice.$deminimisInvoice(),
+      deminimisInvoice: invoice.$deminimisInvoice(deminimisValue),
       minimumChargeInvoice
     }
   }
@@ -218,8 +219,10 @@ class DeleteLicenceService {
     const previousTransactionType = this._transactionType(previousInvoice)
     const currentTransactionType = this._transactionType(updatedInvoice)
 
+    const deminimisValue = billRun.$deminimisValue()
+
     // If the old invoice isn't deminimis, remove its value from the appropriate bill run field and adjust the count
-    if (!previousInvoice.$deminimisInvoice()) {
+    if (!previousInvoice.$deminimisInvoice(deminimisValue)) {
       if (previousTransactionType === 'C') {
         billRun.creditNoteCount -= 1
         billRun.creditNoteValue -= previousInvoice.$absoluteNetTotal()
@@ -231,7 +234,7 @@ class DeleteLicenceService {
     }
 
     // If the updated invoice isn't deminimis, add its value to the appropriate bill run field and adjust the count
-    if (!updatedInvoice.$deminimisInvoice()) {
+    if (!updatedInvoice.$deminimisInvoice(deminimisValue)) {
       if (currentTransactionType === 'C') {
         billRun.creditNoteCount += 1
         billRun.creditNoteValue += updatedInvoice.$absoluteNetTotal()

--- a/app/services/licences/delete_licence.service.js
+++ b/app/services/licences/delete_licence.service.js
@@ -93,7 +93,7 @@ class DeleteLicenceService {
   static async _handleInvoice (billRun, invoice, licence, trx) {
     this._updateInstance(invoice, licence)
     const minimumChargeInvoice = await this._determineMinimumChargeInvoice(billRun, invoice, trx)
-    const invoicePatch = this._invoicePatch(invoice, minimumChargeInvoice, billRun.$deminimisValue())
+    const invoicePatch = this._invoicePatch(invoice, minimumChargeInvoice, billRun.$deminimisLimit())
     await invoice.$query(trx).patch(invoicePatch)
   }
 
@@ -117,12 +117,12 @@ class DeleteLicenceService {
    * Creates a patch for the invoice using the fields in _entityPatch (which are common to both invoice and bill run),
    * and then adds in additional fields based on the invoice's static methods.
    */
-  static _invoicePatch (invoice, minimumChargeInvoice, deminimisValue) {
-    console.log(invoice.$deminimisInvoice(deminimisValue))
+  static _invoicePatch (invoice, minimumChargeInvoice, deminimisLimit) {
+    console.log(invoice.$deminimisInvoice(deminimisLimit))
     return {
       ...this._entityPatch(invoice),
       zeroValueInvoice: invoice.$zeroValueInvoice(),
-      deminimisInvoice: invoice.$deminimisInvoice(deminimisValue),
+      deminimisInvoice: invoice.$deminimisInvoice(deminimisLimit),
       minimumChargeInvoice
     }
   }
@@ -219,10 +219,10 @@ class DeleteLicenceService {
     const previousTransactionType = this._transactionType(previousInvoice)
     const currentTransactionType = this._transactionType(updatedInvoice)
 
-    const deminimisValue = billRun.$deminimisValue()
+    const deminimisLimit = billRun.$deminimisLimit()
 
     // If the old invoice isn't deminimis, remove its value from the appropriate bill run field and adjust the count
-    if (!previousInvoice.$deminimisInvoice(deminimisValue)) {
+    if (!previousInvoice.$deminimisInvoice(deminimisLimit)) {
       if (previousTransactionType === 'C') {
         billRun.creditNoteCount -= 1
         billRun.creditNoteValue -= previousInvoice.$absoluteNetTotal()
@@ -234,7 +234,7 @@ class DeleteLicenceService {
     }
 
     // If the updated invoice isn't deminimis, add its value to the appropriate bill run field and adjust the count
-    if (!updatedInvoice.$deminimisInvoice(deminimisValue)) {
+    if (!updatedInvoice.$deminimisInvoice(deminimisLimit)) {
       if (currentTransactionType === 'C') {
         billRun.creditNoteCount += 1
         billRun.creditNoteValue += updatedInvoice.$absoluteNetTotal()

--- a/app/services/licences/delete_licence.service.js
+++ b/app/services/licences/delete_licence.service.js
@@ -118,7 +118,6 @@ class DeleteLicenceService {
    * and then adds in additional fields based on the invoice's static methods.
    */
   static _invoicePatch (invoice, minimumChargeInvoice, deminimisLimit) {
-    console.log(invoice.$deminimisInvoice(deminimisLimit))
     return {
       ...this._entityPatch(invoice),
       zeroValueInvoice: invoice.$zeroValueInvoice(),

--- a/test/models/bill_run.model.test.js
+++ b/test/models/bill_run.model.test.js
@@ -174,10 +174,11 @@ describe('Bill Run Model', () => {
       beforeEach(async () => {
         deminimisBillRun = await NewBillRunHelper.create(null, null, { ruleset: 'presroc' })
 
-        // Add one presroc deminimis and two non-deminimis invoices to the bill run
+        // Add one presroc deminimis and three non-deminimis invoices to the bill run
         await NewInvoiceHelper.create(deminimisBillRun, { customerReference: 'DEM', debitLineValue: 500, creditLineValue: 100 })
         await NewInvoiceHelper.create(deminimisBillRun, { customerReference: 'NOT_DEM_1', debitLineValue: 1000, creditLineValue: 100 })
         await NewInvoiceHelper.create(deminimisBillRun, { customerReference: 'NOT_DEM_2', debitLineValue: 1500 })
+        await NewInvoiceHelper.create(deminimisBillRun, { customerReference: 'NOT_DEM_3', debitLineValue: 500, creditLineValue: 100, rebilledType: 'R' })
       })
 
       it('returns all invoices which are deminimis', async () => {
@@ -191,10 +192,11 @@ describe('Bill Run Model', () => {
       beforeEach(async () => {
         deminimisBillRun = await NewBillRunHelper.create(null, null, { ruleset: 'sroc' })
 
-        // Add two sroc deminimis and one non-deminimis invoices to the bill run
+        // Add two sroc deminimis and two non-deminimis invoices to the bill run
         await NewInvoiceHelper.create(deminimisBillRun, { customerReference: 'DEM_1', debitLineValue: 500, creditLineValue: 100 })
         await NewInvoiceHelper.create(deminimisBillRun, { customerReference: 'DEM_2', debitLineValue: 1000, creditLineValue: 100 })
         await NewInvoiceHelper.create(deminimisBillRun, { customerReference: 'NOT_DEM', debitLineValue: 1500 })
+        await NewInvoiceHelper.create(deminimisBillRun, { customerReference: 'NOT_DEM_2', debitLineValue: 500, creditLineValue: 100, rebilledType: 'R' })
       })
 
       it('returns all invoices which are deminimis', async () => {

--- a/test/models/bill_run.model.test.js
+++ b/test/models/bill_run.model.test.js
@@ -159,11 +159,11 @@ describe('Bill Run Model', () => {
     })
   })
 
-  describe('the $deminimisValue() method', () => {
-    it("returns the deminimis value for the bill run's ruleset", async () => {
+  describe('the $deminimisLimit() method', () => {
+    it("returns the deminimis limit for the bill run's ruleset", async () => {
       const instance = BillRunModel.fromJson({ ruleset: 'presroc' })
 
-      expect(instance.$deminimisValue()).to.equal(500)
+      expect(instance.$deminimisLimit()).to.equal(500)
     })
   })
 

--- a/test/models/bill_run.model.test.js
+++ b/test/models/bill_run.model.test.js
@@ -154,4 +154,12 @@ describe('Bill Run Model', () => {
       expect(instance.$approved()).to.be.false()
     })
   })
+
+  describe('the $deminimisValue() method', () => {
+    it("returns the deminimis value for the bill run's ruleset", async () => {
+      const instance = BillRunModel.fromJson({ ruleset: 'presroc' })
+
+      expect(instance.$deminimisValue()).to.equal(5000)
+    })
+  })
 })

--- a/test/models/bill_run.model.test.js
+++ b/test/models/bill_run.model.test.js
@@ -163,7 +163,7 @@ describe('Bill Run Model', () => {
     it("returns the deminimis value for the bill run's ruleset", async () => {
       const instance = BillRunModel.fromJson({ ruleset: 'presroc' })
 
-      expect(instance.$deminimisValue()).to.equal(5000)
+      expect(instance.$deminimisValue()).to.equal(500)
     })
   })
 
@@ -175,9 +175,9 @@ describe('Bill Run Model', () => {
         deminimisBillRun = await NewBillRunHelper.create(null, null, { ruleset: 'presroc' })
 
         // Add one presroc deminimis and two non-deminimis invoices to the bill run
-        await NewInvoiceHelper.create(deminimisBillRun, { customerReference: 'DEM', debitLineValue: 5000, creditLineValue: 100 })
-        await NewInvoiceHelper.create(deminimisBillRun, { customerReference: 'NOT_DEM_1', debitLineValue: 10000, creditLineValue: 100 })
-        await NewInvoiceHelper.create(deminimisBillRun, { customerReference: 'NOT_DEM_2', debitLineValue: 15000 })
+        await NewInvoiceHelper.create(deminimisBillRun, { customerReference: 'DEM', debitLineValue: 500, creditLineValue: 100 })
+        await NewInvoiceHelper.create(deminimisBillRun, { customerReference: 'NOT_DEM_1', debitLineValue: 1000, creditLineValue: 100 })
+        await NewInvoiceHelper.create(deminimisBillRun, { customerReference: 'NOT_DEM_2', debitLineValue: 1500 })
       })
 
       it('returns all invoices which are deminimis', async () => {
@@ -192,9 +192,9 @@ describe('Bill Run Model', () => {
         deminimisBillRun = await NewBillRunHelper.create(null, null, { ruleset: 'sroc' })
 
         // Add two sroc deminimis and one non-deminimis invoices to the bill run
-        await NewInvoiceHelper.create(deminimisBillRun, { customerReference: 'DEM_1', debitLineValue: 5000, creditLineValue: 100 })
-        await NewInvoiceHelper.create(deminimisBillRun, { customerReference: 'DEM_2', debitLineValue: 10000, creditLineValue: 100 })
-        await NewInvoiceHelper.create(deminimisBillRun, { customerReference: 'NOT_DEM', debitLineValue: 15000 })
+        await NewInvoiceHelper.create(deminimisBillRun, { customerReference: 'DEM_1', debitLineValue: 500, creditLineValue: 100 })
+        await NewInvoiceHelper.create(deminimisBillRun, { customerReference: 'DEM_2', debitLineValue: 1000, creditLineValue: 100 })
+        await NewInvoiceHelper.create(deminimisBillRun, { customerReference: 'NOT_DEM', debitLineValue: 1500 })
       })
 
       it('returns all invoices which are deminimis', async () => {

--- a/test/models/invoice.model.test.js
+++ b/test/models/invoice.model.test.js
@@ -28,66 +28,6 @@ describe('Invoice Model', () => {
   })
 
   describe('Query modifiers', () => {
-    describe('#deminimis', () => {
-      describe('when there is a mix of invoices', () => {
-        let deminimisInvoice
-
-        beforeEach(async () => {
-          deminimisInvoice = await InvoiceHelper.addInvoice(billRun.id, 'CMA0000001', 2020, 0, 0, 1, 350, 0)
-          await InvoiceHelper.addInvoice(billRun.id, 'CMA0000002', 2020, 0, 0, 1, 501, 0) // debit more than 500
-          await InvoiceHelper.addInvoice(billRun.id, 'CMA0000003', 2020, 1, 350, 0, 0, 0) // credit less than 500
-          await InvoiceHelper.addInvoice(billRun.id, 'CMA0000004', 2020, 1, 501, 0, 0, 0) // credit more than 500
-          await InvoiceHelper.addInvoice(billRun.id, 'CMA0000005', 2020, 0, 0, 0, 0, 1) // zero value
-          await InvoiceHelper.addInvoice(billRun.id, 'CMA0000006', 2020, 0, 0, 1, 2499, 0, 1, 0, 2499) // minimum charge
-          await InvoiceHelper.addInvoice(
-            billRun.id, 'CMA0000007', 2020, 0, 0, 1, 350, 0, 0, 0, 0, GeneralHelper.uuid4(), 'R'
-          ) // rebill invoice
-        })
-
-        it("only returns those which are 'deminimis'", async () => {
-          const results = await InvoiceModel.query().modify('deminimis')
-
-          expect(results.length).to.equal(1)
-          expect(results[0].id).to.equal(deminimisInvoice.id)
-        })
-      })
-
-      describe('when there no matching invoices', () => {
-        beforeEach(async () => {
-          await InvoiceHelper.addInvoice(billRun.id, 'CMA0000002', 2020, 0, 0, 1, 501, 0) // debit more than 500
-          await InvoiceHelper.addInvoice(billRun.id, 'CMA0000003', 2020, 1, 350, 0, 0, 0) // credit less than 500
-          await InvoiceHelper.addInvoice(billRun.id, 'CMA0000004', 2020, 1, 501, 0, 0, 0) // credit more than 500
-          await InvoiceHelper.addInvoice(billRun.id, 'CMA0000005', 2020, 0, 0, 0, 0, 1) // zero value
-          await InvoiceHelper.addInvoice(billRun.id, 'CMA0000006', 2020, 0, 0, 1, 2499, 0, 1, 0, 2499) // minimum charge
-          await InvoiceHelper.addInvoice(
-            billRun.id, 'CMA0000007', 2020, 0, 0, 1, 350, 0, 0, 0, 0, GeneralHelper.uuid4(), 'R'
-          ) // rebill invoice
-        })
-
-        it('returns nothing', async () => {
-          const results = await InvoiceModel.query().modify('deminimis')
-
-          expect(results.length).to.equal(0)
-        })
-      })
-
-      describe("when there are only 'minimum charge' invoices", () => {
-        beforeEach(async () => {
-          // Minimum charge debit invoice
-          await InvoiceHelper.addInvoice(billRun.id, 'CMA0000001', 2020, 0, 0, 1, 2499, 0, 1, 0, 2499)
-
-          // Minimum charge credit invoice
-          await InvoiceHelper.addInvoice(billRun.id, 'CMA0000002', 2020, 1, 2499, 0, 0, 0, 1, 2499, 0)
-        })
-
-        it('returns nothing', async () => {
-          const results = await InvoiceModel.query().modify('deminimis')
-
-          expect(results.length).to.equal(0)
-        })
-      })
-    })
-
     describe('#minimumCharge', () => {
       describe('when there is a mix of invoices', () => {
         let minimumChargeInvoice

--- a/test/models/invoice.model.test.js
+++ b/test/models/invoice.model.test.js
@@ -214,7 +214,7 @@ describe('Invoice Model', () => {
     it('returns `true` if this is a deminimis invoice', async () => {
       const invoice = await InvoiceHelper.addInvoice(billRun.id, 'DEM0000001', 2021, 1, 750, 1, 1000)
 
-      const result = invoice.$deminimisInvoice()
+      const result = invoice.$deminimisInvoice(500)
 
       expect(result).to.be.true()
     })
@@ -223,7 +223,7 @@ describe('Invoice Model', () => {
       it('because the value is above the deminimis limit', async () => {
         const invoice = await InvoiceHelper.addInvoice(billRun.id, 'NDM0000001', 2021, 1, 750, 1, 10000)
 
-        const result = invoice.$deminimisInvoice()
+        const result = invoice.$deminimisInvoice(500)
 
         expect(result).to.be.false()
       })
@@ -233,7 +233,7 @@ describe('Invoice Model', () => {
           billRun.id, 'DEM0000001', 2021, 1, 750, 1, 1000, 0, 0, 0, 0, GeneralHelper.uuid4(), 'R'
         )
 
-        const result = invoice.$deminimisInvoice()
+        const result = invoice.$deminimisInvoice(500)
 
         expect(result).to.be.false()
       })


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/projects/CMEA/boards/907?selectedIssue=CMEA-211

SRoC invoices will have a different deminimis limit to pre-SRoC invoices. We therefore need to be able to support a different deminimis limit where required.

We initially wanted to update the `deminimis` modifier on `InvoiceModel` to take the ruleset from the parent bill run and apply the appropriate value. However this proved difficult to implement, due to the way Objection translated the query to SQL; we ran into problems when trying to apply a patch to the selected invoices.

We therefore took a fresh look at how we were using this modifier. After checking the code we saw that we only used it once, in `GenerateBillRunService`. And since we had the bill run there, we realised it made more sense to add a function to `BillRunModel` to return all the deminimis invoices on it, rather than taking the bill run and executing a `relatedQuery` which then had to join back to the parent bill run, etc. (note that strictly speaking, this method returns a _query_ which can be run to retrieve the deminimis invoices, rather than the invoices themselves).

While doing this, we implemented a `$deminimisLimit()` method on `BillRunModel` which takes the bill run's ruleset and returns the appropriate deminimis limit value (which we store in `StaticLookupLib`).

Finally, we update the `InvoiceModel.$deminimisInvoice()` method to accept the value of the deminimis limit.

With all these in place, we are able to update our deminimis functionality to work for both presroc and sroc bill runs, which different deminimis limits applying to each.