### PR TITLE
Add caret/circumflex to `InvalidCharactersPlugin`

### DIFF
--- a/app/plugins/invalid_characters.plugin.js
+++ b/app/plugins/invalid_characters.plugin.js
@@ -7,6 +7,7 @@ const Boom = require('@hapi/boom')
  *
  * - {@link https://unicode-table.com/en/00A3| £ Pound Sign}
  * - {@link https://unicode-table.com/en/003F| ? Question Mark}
+ * - {@link https://unicode-table.com/en/005E| ^ Circumflex (aka caret)}
  * - {@link https://unicode-table.com/en/2014| — Em dash}
  * - {@link https://unicode-table.com/en/2264| ≤ Less-Than or Equal To}
  * - {@link https://unicode-table.com/en/2265| ≥ Greater-Than or Equal To}
@@ -20,7 +21,7 @@ const Boom = require('@hapi/boom')
 const invalidCharacters = obj => {
   const jsonObj = JSON.stringify(obj)
 
-  if (jsonObj.match(/[?£\u2014\u2264\u2265\u201C\u201D]/)) {
+  if (jsonObj.match(/[?£^\u2014\u2264\u2265\u201C\u201D]/)) {
     return true
   }
 
@@ -36,7 +37,7 @@ const InvalidCharactersPlugin = {
       }
 
       if (invalidCharacters(request.payload)) {
-        throw Boom.badData('We cannot accept any request that contains the following characters: ? £ — ≤ ≥ “ ”')
+        throw Boom.badData('We cannot accept any request that contains the following characters: ? £ ^ — ≤ ≥ “ ”')
       }
 
       return h.continue

--- a/test/features/invalid_characters.test.js
+++ b/test/features/invalid_characters.test.js
@@ -57,7 +57,7 @@ describe('Reject requests with invalid characters', () => {
         expect(response.statusCode).to.equal(422)
         expect(responsePayload.message)
           .to
-          .equal('We cannot accept any request that contains the following characters: ? £ — ≤ ≥ “ ”')
+          .equal('We cannot accept any request that contains the following characters: ? £ ^ — ≤ ≥ “ ”')
       })
     })
 
@@ -74,7 +74,24 @@ describe('Reject requests with invalid characters', () => {
         expect(response.statusCode).to.equal(422)
         expect(responsePayload.message)
           .to
-          .equal('We cannot accept any request that contains the following characters: ? £ — ≤ ≥ “ ”')
+          .equal('We cannot accept any request that contains the following characters: ? £ ^ — ≤ ≥ “ ”')
+      })
+    })
+
+    describe('for example a caret/circumflex', () => {
+      it('rejects the request with the appropriate error message', async () => {
+        const requestPayload = {
+          reference: 'BESESAME001',
+          customerName: 'Bert ^ Ernie Ltd'
+        }
+
+        const response = await server.inject(options(requestPayload))
+        const responsePayload = JSON.parse(response.payload)
+
+        expect(response.statusCode).to.equal(422)
+        expect(responsePayload.message)
+          .to
+          .equal('We cannot accept any request that contains the following characters: ? £ ^ — ≤ ≥ “ ”')
       })
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/projects/CMEA/boards/907?selectedIssue=CMEA-203

We overlooked the caret/circumflex character `^` when building the list of invalid characters to be rejected by `InvalidCharactersPlugin`. We therefore add it to the list.