### PR TITLE
View SRoC Bill Run and v3 route

### DIFF
--- a/app/presenters/view_bill_run.presenter.js
+++ b/app/presenters/view_bill_run.presenter.js
@@ -8,7 +8,7 @@ const BasePresenter = require('./base.presenter')
 const ViewBillRunInvoicePresenter = require('./view_bill_run_invoice.presenter')
 
 /**
- * Formats the data into the response we send after a view bill run request
+ * Formats the data into the response we send after a view bill run request.
  */
 class ViewBillRunPresenter extends BasePresenter {
   _presentation (data) {
@@ -16,6 +16,7 @@ class ViewBillRunPresenter extends BasePresenter {
       billRun: {
         id: data.id,
         billRunNumber: data.billRunNumber,
+        ruleset: data.ruleset,
         region: data.region,
         status: data.status,
         creditNoteCount: data.creditNoteCount,
@@ -25,7 +26,8 @@ class ViewBillRunPresenter extends BasePresenter {
         netTotal: data.netTotal,
         transactionFileReference: data.fileReference,
         invoices: data.invoices.map(invoice => {
-          const presenter = new ViewBillRunInvoicePresenter(invoice)
+          // We have to add ruleset to the invoice passed to the presenter as presenters can only accept one argument
+          const presenter = new ViewBillRunInvoicePresenter({ ...invoice, ruleset: data.ruleset })
           return presenter.go()
         })
       }

--- a/app/presenters/view_bill_run_invoice.presenter.js
+++ b/app/presenters/view_bill_run_invoice.presenter.js
@@ -12,13 +12,14 @@ const BasePresenter = require('./base.presenter')
  */
 class ViewBillRunInvoicePresenter extends BasePresenter {
   _presentation (data) {
-    const response = {
+    return {
       id: data.id,
       customerReference: data.customerReference,
       financialYear: data.financialYear,
       deminimisInvoice: data.deminimisInvoice,
       zeroValueInvoice: data.zeroValueInvoice,
-      minimumChargeInvoice: data.minimumChargeInvoice,
+      // We only include minimumChargeInvoice if the ruleset is `presroc`
+      ...(data.ruleset === 'presroc') && { minimumChargeInvoice: data.minimumChargeInvoice },
       transactionReference: data.transactionReference,
       creditLineValue: data.creditLineValue,
       debitLineValue: data.debitLineValue,
@@ -27,13 +28,6 @@ class ViewBillRunInvoicePresenter extends BasePresenter {
       rebilledInvoiceId: data.rebilledInvoiceId,
       licences: data.licences
     }
-
-    // minimumChargeInvoice is only to be included in presroc requests
-    if (data.ruleset !== 'presroc') {
-      delete response.minimumChargeInvoice
-    }
-
-    return response
   }
 }
 

--- a/app/presenters/view_bill_run_invoice.presenter.js
+++ b/app/presenters/view_bill_run_invoice.presenter.js
@@ -12,7 +12,7 @@ const BasePresenter = require('./base.presenter')
  */
 class ViewBillRunInvoicePresenter extends BasePresenter {
   _presentation (data) {
-    return {
+    const response = {
       id: data.id,
       customerReference: data.customerReference,
       financialYear: data.financialYear,
@@ -27,6 +27,13 @@ class ViewBillRunInvoicePresenter extends BasePresenter {
       rebilledInvoiceId: data.rebilledInvoiceId,
       licences: data.licences
     }
+
+    // minimumChargeInvoice is only to be included in presroc requests
+    if (data.ruleset !== 'presroc') {
+      delete response.minimumChargeInvoice
+    }
+
+    return response
   }
 }
 

--- a/app/routes/bill_run.routes.js
+++ b/app/routes/bill_run.routes.js
@@ -60,6 +60,11 @@ const routes = [
     handler: BillRunsController.view
   },
   {
+    method: 'GET',
+    path: '/v3/{regimeSlug}/bill-runs/{billRunId}',
+    handler: BillRunsController.view
+  },
+  {
     method: 'DELETE',
     path: '/v2/{regimeSlug}/bill-runs/{billRunId}',
     handler: BillRunsController.delete

--- a/app/services/bill_runs/view_bill_run.service.js
+++ b/app/services/bill_runs/view_bill_run.service.js
@@ -45,7 +45,8 @@ class ViewBillRunService {
         'creditNoteValue',
         'invoiceCount',
         'invoiceValue',
-        'fileReference'
+        'fileReference',
+        'ruleset'
       )
       .withGraphFetched('invoices.licences')
       .modifyGraph('invoices', builder => {

--- a/test/controllers/bill_runs.controller.test.js
+++ b/test/controllers/bill_runs.controller.test.js
@@ -239,40 +239,42 @@ describe('Bill Runs controller', () => {
     })
   })
 
-  describe('View bill run: GET /v2/{regimeSlug}/bill-runs/{billRunId}', () => {
-    const options = (token, billRunId) => {
-      return {
-        method: 'GET',
-        url: `/v2/wrls/bill-runs/${billRunId}`,
-        headers: { authorization: `Bearer ${token}` }
+  for (const version of ['v2', 'v3']) {
+    describe(`View bill run: GET /${version}/{regimeSlug}/bill-runs/{billRunId}`, () => {
+      const options = (token, billRunId) => {
+        return {
+          method: 'GET',
+          url: `/${version}/wrls/bill-runs/${billRunId}`,
+          headers: { authorization: `Bearer ${token}` }
+        }
       }
-    }
 
-    describe('When the request is valid', () => {
-      it('returns success status 200', async () => {
-        billRun = await NewBillRunHelper.create(authorisedSystem.id, regime.id)
+      describe('When the request is valid', () => {
+        it('returns success status 200', async () => {
+          billRun = await NewBillRunHelper.create(authorisedSystem.id, regime.id)
 
-        const response = await server.inject(options(authToken, billRun.id))
-        const responsePayload = JSON.parse(response.payload)
-
-        expect(response.statusCode).to.equal(200)
-        expect(responsePayload.billRun.id).to.equal(billRun.id)
-      })
-    })
-
-    describe('When the request is invalid', () => {
-      describe('because the bill run does not exist', () => {
-        it('returns error status 404', async () => {
-          const unknownBillRunId = GeneralHelper.uuid4()
-          const response = await server.inject(options(authToken, unknownBillRunId))
+          const response = await server.inject(options(authToken, billRun.id))
           const responsePayload = JSON.parse(response.payload)
 
-          expect(response.statusCode).to.equal(404)
-          expect(responsePayload.message).to.equal(`Bill run ${unknownBillRunId} is unknown.`)
+          expect(response.statusCode).to.equal(200)
+          expect(responsePayload.billRun.id).to.equal(billRun.id)
+        })
+      })
+
+      describe('When the request is invalid', () => {
+        describe('because the bill run does not exist', () => {
+          it('returns error status 404', async () => {
+            const unknownBillRunId = GeneralHelper.uuid4()
+            const response = await server.inject(options(authToken, unknownBillRunId))
+            const responsePayload = JSON.parse(response.payload)
+
+            expect(response.statusCode).to.equal(404)
+            expect(responsePayload.message).to.equal(`Bill run ${unknownBillRunId} is unknown.`)
+          })
         })
       })
     })
-  })
+  }
 
   describe('Approve bill run: PATCH /v2/{regimeSlug}/bill-runs/{billRunId}/approve', () => {
     const options = (token, billRunId) => {

--- a/test/presenters/view_bill_run.presenter.test.js
+++ b/test/presenters/view_bill_run.presenter.test.js
@@ -25,6 +25,7 @@ describe('View Bill Run Presenter', () => {
     invoiceValue: 2093,
     netTotal: 2093,
     transactionFileReference: null,
+    ruleset: 'presroc',
     invoices: [
       {
         id: GeneralHelper.uuid4(),
@@ -66,7 +67,8 @@ describe('View Bill Run Presenter', () => {
       'invoiceCount',
       'invoiceValue',
       'netTotal',
-      'transactionFileReference'
+      'transactionFileReference',
+      'ruleset'
     ])
   })
 
@@ -81,7 +83,6 @@ describe('View Bill Run Presenter', () => {
       'financialYear',
       'deminimisInvoice',
       'zeroValueInvoice',
-      'minimumChargeInvoice',
       'transactionReference',
       'creditLineValue',
       'debitLineValue',
@@ -89,6 +90,22 @@ describe('View Bill Run Presenter', () => {
       'rebilledType',
       'rebilledInvoiceId'
     ])
+  })
+
+  describe('for a presroc bill run', () => {
+    it('returns the minimumChargeInvoice flag in the invoice', () => {
+      const presenter = new ViewBillRunPresenter(data)
+      const result = presenter.go()
+      expect(result.billRun.invoices[0]).to.include('minimumChargeInvoice')
+    })
+  })
+
+  describe('for an sroc bill run', () => {
+    it('does not return the minimumChargeInvoice flag in the invoice', () => {
+      const presenter = new ViewBillRunPresenter({ ...data, ruleset: 'sroc' })
+      const result = presenter.go()
+      expect(result.billRun.invoices[0]).to.not.include('minimumChargeInvoice')
+    })
   })
 
   it("returns the 'licences' linked to the 'invoices' linked to the 'bill run", () => {

--- a/test/services/bill_runs/view_bill_run.service.test.js
+++ b/test/services/bill_runs/view_bill_run.service.test.js
@@ -68,6 +68,7 @@ describe('View Bill Run service', () => {
       expect(result.billRun.id).to.equal(billRun.id)
       expect(result.billRun.region).to.equal(billRun.region)
       expect(result.billRun.status).to.equal(billRun.status)
+      expect(result.billRun.ruleset).to.equal(billRun.ruleset)
     })
 
     describe('when transactions are added to the bill run', () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/projects/CMEA/boards/907?selectedIssue=CMEA-215

The key difference between presroc and sroc for View Bill Run is that `minimumChargeInvoice` is only included in the output when viewing a presroc bill run. We do this by updating `ViewBillRunService` to pass `ruleset` to `ViewBillRunPresenter`. In turn, this passes it to `ViewBillRunInvoicePresenter` (note that presenters can only accept a single `data` parameter so we need to add this to the data object we pass in). Finally, the invoice presenter only includes `minimumChargeInvoice` in the output if the ruleset is `presroc`.

Once this is done, we add a v3 route and unit test. Note that we do not see the changes made here to be a breaking change, so the v2 and v3 routes both use the same controller and therefore have the same functionality.