### PR TITLE
View SRoC Invoice and v3 route

### DIFF
--- a/app/presenters/view_invoice.presenter.js
+++ b/app/presenters/view_invoice.presenter.js
@@ -16,6 +16,7 @@ class ViewInvoicePresenter extends BasePresenter {
       invoice: {
         id: data.id,
         billRunId: data.billRunId,
+        ruleset: data.billRun.ruleset,
         customerReference: data.customerReference,
         financialYear: data.financialYear,
         deminimisInvoice: data.deminimisInvoice,

--- a/app/presenters/view_invoice.presenter.js
+++ b/app/presenters/view_invoice.presenter.js
@@ -21,7 +21,8 @@ class ViewInvoicePresenter extends BasePresenter {
         financialYear: data.financialYear,
         deminimisInvoice: data.deminimisInvoice,
         zeroValueInvoice: data.zeroValueInvoice,
-        minimumChargeInvoice: data.minimumChargeInvoice,
+        // We only include minimumChargeInvoice if the ruleset is `presroc`
+        ...(data.billRun.ruleset === 'presroc') && { minimumChargeInvoice: data.minimumChargeInvoice },
         transactionReference: data.transactionReference,
         creditLineValue: data.creditLineValue,
         debitLineValue: data.debitLineValue,

--- a/app/presenters/view_invoice.presenter.js
+++ b/app/presenters/view_invoice.presenter.js
@@ -8,7 +8,8 @@ const BasePresenter = require('./base.presenter')
 const ViewLicencePresenter = require('./view_licence.presenter')
 
 /**
- * Handles formatting the data into the response we send to clients after a request to view an invoice
+ * Handles formatting the data into the response we send to clients after a request to view an invoice. Note that we
+ * expect billRun.ruleset to be passed in on top of the regular invoice data.
  */
 class ViewInvoicePresenter extends BasePresenter {
   _presentation (data) {
@@ -30,7 +31,7 @@ class ViewInvoicePresenter extends BasePresenter {
         rebilledType: data.rebilledType,
         rebilledInvoiceId: data.rebilledInvoiceId,
         licences: data.licences.map(licence => {
-          const presenter = new ViewLicencePresenter(licence)
+          const presenter = new ViewLicencePresenter({ ...licence, ruleset: data.billRun.ruleset })
           return presenter.go()
         })
       }

--- a/app/presenters/view_licence.presenter.js
+++ b/app/presenters/view_licence.presenter.js
@@ -8,7 +8,8 @@ const BasePresenter = require('./base.presenter')
 const ViewTransactionPresenter = require('./view_transaction.presenter')
 
 /**
- * Handles formatting the licence data into the response we send to clients when a GET request is received
+ * Handles formatting the licence data into the response we send to clients when a GET request is received. Note that we
+ * expect ruleset to be passed in on top of the regular licenec data.
  */
 class ViewLicencePresenter extends BasePresenter {
   _presentation (data) {
@@ -17,7 +18,7 @@ class ViewLicencePresenter extends BasePresenter {
       licenceNumber: data.licenceNumber,
       netTotal: data.netTotal,
       transactions: data.transactions.map(transaction => {
-        const presenter = new ViewTransactionPresenter(transaction)
+        const presenter = new ViewTransactionPresenter({ ...transaction, ruleset: data.ruleset })
         return presenter.go()
       })
     }

--- a/app/presenters/view_transaction.presenter.js
+++ b/app/presenters/view_transaction.presenter.js
@@ -7,7 +7,8 @@
 const BasePresenter = require('./base.presenter')
 
 /**
- * Handles formatting the transaction data into the response we send to clients when a GET request is received
+ * Handles formatting the transaction data into the response we send to clients when a GET request is received. Note
+ * that we expect ruleset to be passed in on top of the regular transaction data.
  */
 class ViewTransactionPresenter extends BasePresenter {
   _presentation (data) {
@@ -16,7 +17,8 @@ class ViewTransactionPresenter extends BasePresenter {
       clientId: data.clientId,
       chargeValue: data.chargeValue,
       credit: data.chargeCredit,
-      subjectToMinimumCharge: data.subjectToMinimumCharge,
+      // We only include subjectToMinimumCharge if the ruleset is `presroc`
+      ...(data.ruleset === 'presroc') && { subjectToMinimumCharge: data.subjectToMinimumCharge },
       minimumChargeAdjustment: data.minimumChargeAdjustment,
       lineDescription: data.lineDescription,
       periodStart: data.chargePeriodStart,

--- a/app/presenters/view_transaction.presenter.js
+++ b/app/presenters/view_transaction.presenter.js
@@ -19,7 +19,8 @@ class ViewTransactionPresenter extends BasePresenter {
       credit: data.chargeCredit,
       // We only include subjectToMinimumCharge if the ruleset is `presroc`
       ...(data.ruleset === 'presroc') && { subjectToMinimumCharge: data.subjectToMinimumCharge },
-      minimumChargeAdjustment: data.minimumChargeAdjustment,
+      // We only include minimumChargeAdjustment if the ruleset is `presroc`
+      ...(data.ruleset === 'presroc') && { minimumChargeAdjustment: data.minimumChargeAdjustment },
       lineDescription: data.lineDescription,
       periodStart: data.chargePeriodStart,
       periodEnd: data.chargePeriodEnd,

--- a/app/routes/bill_run_invoice.routes.js
+++ b/app/routes/bill_run_invoice.routes.js
@@ -14,6 +14,11 @@ const routes = [
     handler: BillRunsInvoicesController.view
   },
   {
+    method: 'GET',
+    path: '/v3/{regimeSlug}/bill-runs/{billRunId}/invoices/{invoiceId}',
+    handler: BillRunsInvoicesController.view
+  },
+  {
     method: 'PATCH',
     path: '/v2/{regimeSlug}/bill-runs/{billRunId}/invoices/{invoiceId}/rebill',
     handler: BillRunsInvoicesController.rebill

--- a/app/services/invoices/view_invoice.service.js
+++ b/app/services/invoices/view_invoice.service.js
@@ -66,6 +66,12 @@ class ViewInvoiceService {
           'chargeCalculation'
         )
       })
+      .withGraphFetched('billRun')
+      .modifyGraph('billRun', builder => {
+        builder.select(
+          'ruleset'
+        )
+      })
 
     return {
       ...responseData,

--- a/test/presenters/view_invoice.presenter.test.js
+++ b/test/presenters/view_invoice.presenter.test.js
@@ -113,4 +113,20 @@ describe('View Invoice Presenter', () => {
       'calculation'
     ])
   })
+
+  it('returns `minimumChargeInvoice` if the bill run ruleset is `presroc`', () => {
+    const presenter = new ViewInvoicePresenter(data)
+    const result = presenter.go()
+
+    expect(result.invoice).to.include('minimumChargeInvoice')
+  })
+
+  it("doesn't return `minimumChargeInvoice` if the bill run ruleset is `sroc`", () => {
+    const srocData = { ...Object.assign(data), billRun: { ruleset: 'sroc' } }
+
+    const presenter = new ViewInvoicePresenter(srocData)
+    const result = presenter.go()
+
+    expect(result.invoice).to.not.include('minimumChargeInvoice')
+  })
 })

--- a/test/presenters/view_invoice.presenter.test.js
+++ b/test/presenters/view_invoice.presenter.test.js
@@ -122,8 +122,7 @@ describe('View Invoice Presenter', () => {
   })
 
   it("doesn't return `minimumChargeInvoice` if the bill run ruleset is `sroc`", () => {
-    const srocData = { ...Object.assign(data), billRun: { ruleset: 'sroc' } }
-
+    const srocData = Object.assign({ ...data, billRun: { ruleset: 'sroc' } })
     const presenter = new ViewInvoicePresenter(srocData)
     const result = presenter.go()
 

--- a/test/presenters/view_invoice.presenter.test.js
+++ b/test/presenters/view_invoice.presenter.test.js
@@ -31,6 +31,7 @@ describe('View Invoice Presenter', () => {
     netTotal: 2093,
     rebilledType: 'R',
     rebilledInvoiceId: GeneralHelper.uuid4(),
+    billRun: { ruleset: 'presroc' },
     licences: [
       {
         id: GeneralHelper.uuid4(),
@@ -79,7 +80,8 @@ describe('View Invoice Presenter', () => {
       'debitLineValue',
       'netTotal',
       'rebilledType',
-      'rebilledInvoiceId'
+      'rebilledInvoiceId',
+      'ruleset'
     ])
   })
 

--- a/test/presenters/view_transaction.presenter.test.js
+++ b/test/presenters/view_transaction.presenter.test.js
@@ -40,7 +40,6 @@ describe('View Transaction Presenter', () => {
       'clientId',
       'chargeValue',
       'credit',
-      'subjectToMinimumCharge',
       'lineDescription',
       'periodStart',
       'periodEnd',
@@ -63,6 +62,21 @@ describe('View Transaction Presenter', () => {
     const result = presenter.go()
 
     expect(result).to.not.include('subjectToMinimumCharge')
+  })
+
+  it('returns `minimumChargeAdjustment` if the ruleset is `presroc`', () => {
+    const presenter = new ViewTransactionPresenter(data)
+    const result = presenter.go()
+
+    expect(result).to.include('minimumChargeAdjustment')
+  })
+
+  it('does not return `minimumChargeAdjustment` if the ruleset is `sroc`', () => {
+    const srocData = Object.assign({ ...data, ruleset: 'sroc' })
+    const presenter = new ViewTransactionPresenter(srocData)
+    const result = presenter.go()
+
+    expect(result).to.not.include('minimumChargeAdjustment')
   })
 
   it('correctly presents the data', () => {

--- a/test/presenters/view_transaction.presenter.test.js
+++ b/test/presenters/view_transaction.presenter.test.js
@@ -26,7 +26,9 @@ describe('View Transaction Presenter', () => {
     chargePeriodEnd: '2020-03-31',
     regimeValue17: 'true',
     rebilledTransactionId: GeneralHelper.uuid4(),
-    chargeCalculation: '{"__DecisionID__":"91a711c1-2dbb-47fe-ae8e-505da38432d70","WRLSChargingResponse":{"chargeValue":7.72,"decisionPoints":{"sourceFactor":10.7595,"seasonFactor":17.2152,"lossFactor":0.5164559999999999,"volumeFactor":3.5865,"abatementAdjustment":7.721017199999999,"s127Agreement":7.721017199999999,"s130Agreement":7.721017199999999,"secondPartCharge":false,"waterUndertaker":false,"eiucFactor":0,"compensationCharge":false,"eiucSourceFactor":0,"sucFactor":7.721017199999999},"messages":[],"sucFactor":14.95,"volumeFactor":3.5865,"sourceFactor":3,"seasonFactor":1.6,"lossFactor":0.03,"abatementAdjustment":"S126 x 1.0","s127Agreement":null,"s130Agreement":null,"eiucSourceFactor":0,"eiucFactor":0}}'
+    chargeCalculation: '{"__DecisionID__":"91a711c1-2dbb-47fe-ae8e-505da38432d70","WRLSChargingResponse":{"chargeValue":7.72,"decisionPoints":{"sourceFactor":10.7595,"seasonFactor":17.2152,"lossFactor":0.5164559999999999,"volumeFactor":3.5865,"abatementAdjustment":7.721017199999999,"s127Agreement":7.721017199999999,"s130Agreement":7.721017199999999,"secondPartCharge":false,"waterUndertaker":false,"eiucFactor":0,"compensationCharge":false,"eiucSourceFactor":0,"sucFactor":7.721017199999999},"messages":[],"sucFactor":14.95,"volumeFactor":3.5865,"sourceFactor":3,"seasonFactor":1.6,"lossFactor":0.03,"abatementAdjustment":"S126 x 1.0","s127Agreement":null,"s130Agreement":null,"eiucSourceFactor":0,"eiucFactor":0}}',
+    // Ruleset is not normally part of the transaction record but we expect it to be passed in to the presenter
+    ruleset: 'presroc'
   }
 
   it('returns the required columns', () => {
@@ -39,7 +41,6 @@ describe('View Transaction Presenter', () => {
       'chargeValue',
       'credit',
       'subjectToMinimumCharge',
-      'minimumChargeAdjustment',
       'lineDescription',
       'periodStart',
       'periodEnd',
@@ -47,6 +48,21 @@ describe('View Transaction Presenter', () => {
       'rebilledTransactionId',
       'calculation'
     ])
+  })
+
+  it('returns `subjectToMinimumCharge` if the ruleset is `presroc`', () => {
+    const presenter = new ViewTransactionPresenter(data)
+    const result = presenter.go()
+
+    expect(result).to.include('subjectToMinimumCharge')
+  })
+
+  it('does not return `subjectToMinimumCharge` if the ruleset is `sroc`', () => {
+    const srocData = Object.assign({ ...data, ruleset: 'sroc' })
+    const presenter = new ViewTransactionPresenter(srocData)
+    const result = presenter.go()
+
+    expect(result).to.not.include('subjectToMinimumCharge')
   })
 
   it('correctly presents the data', () => {

--- a/test/services/invoices/view_invoice.service.test.js
+++ b/test/services/invoices/view_invoice.service.test.js
@@ -41,6 +41,7 @@ describe('View Invoice service', () => {
 
         expect(result.invoice.id).to.equal(invoiceId)
         expect(result.invoice.netTotal).to.equal(0)
+        expect(result.invoice.ruleset).to.equal('presroc')
 
         expect(result.invoice.licences).to.be.an.array()
         expect(result.invoice.licences[0].transactions).to.be.an.array()


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/projects/CMEA/boards/907?selectedIssue=CMEA-216

We create a `GET /v3/{regimeSlug}/bill-runs/{billRunId}/invoices/{invoiceId}` route and point it to the same `ViewInvoiceService` as the v2 route. We don't touch the v2 route as the changes implemented here are not considered to be breaking changes, so we can leave v2 as-is. Then we update the service and its associated presenters to handle SRoC invoices:
- `ruleset` is added to the invoice-level view
- the invoice-level `minimumChargeInvoice` flag is hidden for SRoC invoices
- the transaction-level `subjectToMinimumCharge` & `minimumChargeAdjustment` flags are also hidden when viewing an SRoC invoice

Applying the deminimis limit (as referred to in the ACs) is handled when the bill run summary is generated, so no additional work is required here.