### PR TITLE
Fix invoice flags not correctly reflecting state change

### DIFF
--- a/app/services/bill_runs/generate_bill_run.service.js
+++ b/app/services/bill_runs/generate_bill_run.service.js
@@ -139,12 +139,20 @@ class GenerateBillRunService {
   }
 
   static async _setZeroValueInvoiceFlags (billRun, trx) {
+    // We reset all zero value flags to false, then set the flag to true where it now applies
+    await billRun.$relatedQuery('invoices', trx)
+      .patch({ zeroValueInvoice: false })
+
     return billRun.$relatedQuery('invoices', trx)
       .modify('zeroValue')
       .patch({ zeroValueInvoice: true })
   }
 
   static async _setDeminimisInvoiceFlags (billRun, trx) {
+    // We reset all deminimis flags to false, then set the flag to true where it now applies
+    await billRun.$relatedQuery('invoices', trx)
+      .patch({ deminimisInvoice: false })
+
     return billRun.$deminimisInvoices(trx)
       .patch({ deminimisInvoice: true })
   }


### PR DESCRIPTION
We discovered a defect during development, where the `deminimisInvoice` and `zeroValueInvoice` flags would not always be correct if the invoice had changed state after the bill run was generated. For example:
- A bill run is created and has a deminimis transaction added to it
- The bill run is generated; the `deminimisInvoice` flag for the invoice is correctly set to `true`, and the invoice is not included in the bill run summary stats
- An additional transaction is added to the invoice, taking the invoice value over the deminimis limit
- The bill run is generated again; the `deminimisInvoice` flag is still `true` when it should have changed to `false`, and the invoice is still not included in the bill run summary stats

This was caused by the way we set the `deminimisInvoice` flag during bill run generation. We were getting all the invoices that meet the deminimis criteria and setting their flags to `true`; however we were not doing anything to the invoices that do not meet the deminimis criteria, leading to the flag being "stuck" as `true`. The same goes for `zeroValueInvoice`

We fix this by simply resetting `deminimisInvoice` to `false` for all invoices before we then get all the deminimis invoices and set their flags to `true`; and we do the same with `zeroValueInvoice`.