### PR TITLE
Amend send bill run statuses

### DIFF
--- a/app/models/bill_run.model.js
+++ b/app/models/bill_run.model.js
@@ -221,6 +221,13 @@ class BillRunModel extends BaseModel {
   }
 
   /**
+   * Returns true if the bill run status is 'sending'
+   */
+  $sending () {
+    return this.status === 'sending'
+  }
+
+  /**
    * Returns true if the bill run has a file reference
    */
   $billable () {

--- a/app/services/bill_runs/send_bill_run_reference.service.js
+++ b/app/services/bill_runs/send_bill_run_reference.service.js
@@ -13,7 +13,9 @@ const NextTransactionReferenceService = require('../next_references/next_transac
 class SendBillRunReferenceService {
   /**
    * Prepare a 'bill run' to be ready for billing by generating transaction references for its billable invoices and
-   * generating an export file reference for it
+   * generating an export file reference for it.
+   *
+   * We start by setting the bill run status to `pending` to flag that the bill run is being updated.
    *
    * Before we export the invoices for a bill run to SSCL for billing we are required to generate a transaction
    * reference for each one.
@@ -22,7 +24,7 @@ class SendBillRunReferenceService {
    * billed. We don't want the files we send to SSCL to appear to have a gap in their reference so no one gets worried
    * something has gotten lost or missed.
    *
-   * Either way, the bill run status is updated to 'pending' to flag it ready to be exported.
+   * Either way, the bill run status is updated to `sending` to flag it ready to be exported.
    *
    * @param {@module RegimeModel} regime An instance of `RegimeModel` which matches the requested regime
    * @param {@module:BillRunModel} billRun The 'bill run' to send for billing

--- a/app/services/files/transactions/send_transaction_file.service.js
+++ b/app/services/files/transactions/send_transaction_file.service.js
@@ -49,8 +49,8 @@ class SendTransactionFileService {
   }
 
   static _validate (billRun) {
-    if (!billRun.$pending()) {
-      throw new Error(`Bill run ${billRun.id} does not have a status of 'pending'.`)
+    if (!billRun.$sending()) {
+      throw new Error(`Bill run ${billRun.id} does not have a status of 'sending'.`)
     }
   }
 

--- a/test/services/files/transactions/send_transaction_file.service.test.js
+++ b/test/services/files/transactions/send_transaction_file.service.test.js
@@ -50,7 +50,7 @@ describe('Send Transaction File service', () => {
 
   describe('When a valid bill run is specified', () => {
     beforeEach(async () => {
-      billRun.status = 'pending'
+      billRun.status = 'sending'
     })
 
     describe('and a transaction file is required', () => {
@@ -112,7 +112,7 @@ describe('Send Transaction File service', () => {
   })
 
   describe('When an invalid bill run is specified', () => {
-    describe("because the status is not 'pending'", () => {
+    describe("because the status is not 'sending'", () => {
       it('throws an error', async () => {
         await SendTransactionFileService.go(regime, billRun, notifierFake)
 
@@ -120,7 +120,7 @@ describe('Send Transaction File service', () => {
 
         expect(notifierFake.omfg.firstArg).to.equal('Error sending transaction file')
         expect(notifierFake.omfg.lastArg.filename).to.be.undefined()
-        expect(notifierFake.omfg.lastArg.error.message).to.equal(`Bill run ${billRun.id} does not have a status of 'pending'.`)
+        expect(notifierFake.omfg.lastArg.error.message).to.equal(`Bill run ${billRun.id} does not have a status of 'sending'.`)
       })
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/projects/CMEA/boards/907?selectedIssue=CMEA-225

As part of our drive to standardise bill run statuses, we amend the send bill run process as follows:
- At the start of the process, the bill run status is set to `pending` to show that the details are being updated and therefore subject to change;
- Once this is done, the status is set to `sending` and the process continues to the transaction file creation stage.
- After the file is created, the status is set to either `billed` or `billing_not_required` (as is currently the case).