### PR TITLE
CMEA-226 Make use of pending status consistent

### DIFF
--- a/app/models/bill_run.model.js
+++ b/app/models/bill_run.model.js
@@ -153,7 +153,7 @@ class BillRunModel extends BaseModel {
    * a transaction to be added.
    *
    * This also protects against trying to make changes when the bill run is being processed. So interim states like
-   * `generating`, `pending`, and `deleting` are also not classed as 'editable'.
+   * `pending` and `deleting` are also not classed as 'editable'.
    */
   $editable () {
     return ['initialised', 'generated'].includes(this.status)
@@ -176,13 +176,6 @@ class BillRunModel extends BaseModel {
    */
   $patchable () {
     return ['initialised', 'generated', 'approved'].includes(this.status)
-  }
-
-  /**
-   * Returns true if the bill run summary is being generated
-   */
-  $generating () {
-    return this.status === 'generating'
   }
 
   /**

--- a/app/models/bill_run.model.js
+++ b/app/models/bill_run.model.js
@@ -175,7 +175,7 @@ class BillRunModel extends BaseModel {
   }
 
   /**
-   * Returns true if the bill run status is being 'generated'
+   * Returns true if the bill run status is 'generated'
    */
   $generated () {
     return this.status === 'generated'

--- a/app/models/bill_run.model.js
+++ b/app/models/bill_run.model.js
@@ -152,8 +152,8 @@ class BillRunModel extends BaseModel {
    * with processing the bill run. Once `approved` we want to be able to `/send` a bill run but we don't want to allow
    * a transaction to be added.
    *
-   * This also protects against trying to make changes when the bill run is being processed. So interim states like
-   * `pending` and `deleting` are also not classed as 'editable'.
+   * This also protects against trying to make changes when the bill run is being processed. So the interim `pending`
+   * state is also not classed as 'editable'.
    */
   $editable () {
     return ['initialised', 'generated'].includes(this.status)
@@ -167,12 +167,8 @@ class BillRunModel extends BaseModel {
    *
    * Once a bill run has been 'sent', which means the transaction file is generated, it cannot be further 'patched'.
    *
-   * A bill run is also unpatchable if it's in the middle of something, for example, generating its summary or sending
-   * the transaction file.
-   *
-   * Finally, a bill run is unpatchable if the status is `deleting`. This gets set when a `DELETE` request is received.
-   * We don't expect client systems to ever see this but large bill runs can take some seconds to finish deleting. So,
-   * we set the `deleting` status just in case someone tries to interact with the bill run during this time.
+   * A bill run is also unpatchable if its status is `pending` which signifies that it's in the middle of something, for
+   * example, generating its summary or sending the transaction file.
    */
   $patchable () {
     return ['initialised', 'generated', 'approved'].includes(this.status)

--- a/app/services/bill_runs/delete_bill_run.service.js
+++ b/app/services/bill_runs/delete_bill_run.service.js
@@ -10,7 +10,7 @@ class DeleteBillRunService {
   /**
    * Deletes a bill run along with its invoices, licences and transactions
    *
-   * Because deleting large bill runs can take some time, the service first updates the bill runs status to `deleting`
+   * Because deleting large bill runs can take some time, the service first updates the bill runs status to `pending`
    * just in case someone else attempts to view the bill run at the same time. It then tells PostgreSQL to delete the
    * bill run. Invoices, licences and transactions are all automatically handled because the DB is configured to cascade
    * delete them.
@@ -25,7 +25,7 @@ class DeleteBillRunService {
    */
   static async go (billRun, notifier) {
     try {
-      await this._setDeletingStatus(billRun)
+      await this._setPendingStatus(billRun)
 
       await this._deleteBillRun(billRun)
     } catch (error) {
@@ -33,9 +33,9 @@ class DeleteBillRunService {
     }
   }
 
-  static _setDeletingStatus (billRun) {
+  static _setPendingStatus (billRun) {
     return billRun.$query()
-      .patch({ status: 'deleting' })
+      .patch({ status: 'pending' })
   }
 
   static _deleteBillRun (billRun) {

--- a/app/services/bill_runs/generate_bill_run.service.js
+++ b/app/services/bill_runs/generate_bill_run.service.js
@@ -34,7 +34,7 @@ class GenerateBillRunService {
   }
 
   static async _generateBillRun (billRun) {
-    await this._setGeneratingStatus(billRun)
+    await this._setPendingStatus(billRun)
 
     const minimumChargeAdjustments = await CalculateMinimumChargeForBillRunService.go(billRun)
 
@@ -44,9 +44,9 @@ class GenerateBillRunService {
     })
   }
 
-  static async _setGeneratingStatus (billRun) {
+  static async _setPendingStatus (billRun) {
     await billRun.$query()
-      .patch({ status: 'generating' })
+      .patch({ status: 'pending' })
   }
 
   static _calculateInvoices (invoices) {

--- a/app/services/bill_runs/generate_bill_run_validation.service.js
+++ b/app/services/bill_runs/generate_bill_run_validation.service.js
@@ -19,8 +19,8 @@ class GenerateBillRunValidationService {
   }
 
   static _validateBillRun (billRun) {
-    if (billRun.$generating()) {
-      throw Boom.conflict(`Summary for bill run ${billRun.id} is already being generated`)
+    if (billRun.$pending()) {
+      throw Boom.conflict(`Summary for bill run ${billRun.id} is being updated`)
     }
 
     if (billRun.$generated()) {

--- a/test/models/bill_run.model.test.js
+++ b/test/models/bill_run.model.test.js
@@ -81,12 +81,6 @@ describe('Bill Run Model', () => {
 
       expect(instance.$editable()).to.be.false()
     })
-
-    it("returns 'false' when the status is 'deleting'", async () => {
-      const instance = BillRunModel.fromJson({ status: 'deleting' })
-
-      expect(instance.$editable()).to.be.false()
-    })
   })
 
   describe('the $patchable() method', () => {
@@ -122,12 +116,6 @@ describe('Bill Run Model', () => {
 
     it("returns 'false' when the status is 'billing_not_required'", async () => {
       const instance = BillRunModel.fromJson({ status: 'billing_not_required' })
-
-      expect(instance.$patchable()).to.be.false()
-    })
-
-    it("returns 'false' when the status is 'deleting'", async () => {
-      const instance = BillRunModel.fromJson({ status: 'deleting' })
 
       expect(instance.$patchable()).to.be.false()
     })

--- a/test/models/bill_run.model.test.js
+++ b/test/models/bill_run.model.test.js
@@ -52,12 +52,6 @@ describe('Bill Run Model', () => {
       expect(instance.$editable()).to.be.true()
     })
 
-    it("returns 'false' when the status is 'generating'", async () => {
-      const instance = BillRunModel.fromJson({ status: 'generating' })
-
-      expect(instance.$editable()).to.be.false()
-    })
-
     it("returns 'true' when the status is 'generated'", async () => {
       const instance = BillRunModel.fromJson({ status: 'generated' })
 
@@ -100,12 +94,6 @@ describe('Bill Run Model', () => {
       const instance = BillRunModel.fromJson({ status: 'initialised' })
 
       expect(instance.$patchable()).to.be.true()
-    })
-
-    it("returns 'false' when the status is 'generating'", async () => {
-      const instance = BillRunModel.fromJson({ status: 'generating' })
-
-      expect(instance.$patchable()).to.be.false()
     })
 
     it("returns 'true' when the status is 'generated'", async () => {

--- a/test/services/bill_runs/delete_bill_run.service.test.js
+++ b/test/services/bill_runs/delete_bill_run.service.test.js
@@ -39,7 +39,7 @@ describe('Delete Bill Run service', () => {
   })
 
   describe('When a valid bill run is supplied', () => {
-    it("sets the bill run status to 'deleting'", async () => {
+    it("sets the bill run status to 'pending'", async () => {
       // We stub the part that actually deletes the bill run for this test so we can confirm the bill run status is
       // updated
       Sinon.stub(DeleteBillRunService, '_deleteBillRun')
@@ -47,7 +47,7 @@ describe('Delete Bill Run service', () => {
 
       const refreshedBillRun = await billRun.$query()
 
-      expect(refreshedBillRun.status).to.equal('deleting')
+      expect(refreshedBillRun.status).to.equal('pending')
     })
 
     it('deletes the bill run', async () => {

--- a/test/services/bill_runs/generate_bill_run.service.test.js
+++ b/test/services/bill_runs/generate_bill_run.service.test.js
@@ -68,7 +68,7 @@ describe('Generate Bill Run service', () => {
       billRun = await BillRunHelper.addBillRun(authorisedSystem.id, regime.id)
     })
 
-    it("sets the bill run status to 'generating'", async () => {
+    it("sets the bill run status to 'pending'", async () => {
       const spy = Sinon.spy(BillRunModel, 'query')
       await CreateTransactionService.go(payload, billRun, authorisedSystem, regime)
       await GenerateBillRunService.go(billRun)
@@ -80,12 +80,12 @@ describe('Generate Bill Run service', () => {
        *   .toKnexQuery() gives us the underlying Knex query
        *   .toString() gives us the SQL query as a string
        *
-       * Finally, we push query strings to the queries array if they set the status to 'generating'.
+       * Finally, we push query strings to the queries array if they set the status to 'pending'.
        */
       const queries = []
       for (let call = 0; call < spy.callCount; call++) {
         const queryString = spy.getCall(call).returnValue.toKnexQuery().toString()
-        if (queryString.includes('set "status" = \'generating\'')) {
+        if (queryString.includes('set "status" = \'pending\'')) {
           queries.push(queryString)
         }
       }

--- a/test/services/bill_runs/generate_bill_run_validation.service.test.js
+++ b/test/services/bill_runs/generate_bill_run_validation.service.test.js
@@ -46,17 +46,17 @@ describe('Generate Bill Run Validation service', () => {
   })
 
   describe('When an invalid bill run ID is supplied', () => {
-    describe('because the bill run is already generating', () => {
+    describe('because the bill run status is `pending`', () => {
       it('throws an error', async () => {
-        const generatingBillRun = await BillRunHelper.addBillRun(authorisedSystem.id, regime.id, 'A', 'generating')
+        const generatingBillRun = await BillRunHelper.addBillRun(authorisedSystem.id, regime.id, 'A', 'pending')
         const err = await expect(GenerateBillRunValidationService.go(generatingBillRun)).to.reject()
 
         expect(err).to.be.an.error()
-        expect(err.output.payload.message).to.equal(`Summary for bill run ${generatingBillRun.id} is already being generated`)
+        expect(err.output.payload.message).to.equal(`Summary for bill run ${generatingBillRun.id} is being updated`)
       })
     })
 
-    describe("because the bill run has already been 'generated'", () => {
+    describe('because the bill run has already been generated', () => {
       it('throws an error', async () => {
         const generatingBillRun = await BillRunHelper.addBillRun(authorisedSystem.id, regime.id, 'A', 'generated')
         const err = await expect(GenerateBillRunValidationService.go(generatingBillRun)).to.reject()


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/projects/CMEA/boards/907?selectedIssue=CMEA-226

We are moving to using `pending` as our standard status meaning "bill run is being updated, check back later". This change replaces the specific statuses `generating` and `deleting` with our general status `pending`.