### PR TITLE
CMEA-232 Add new V3 delete invoice endpoint

### DIFF
--- a/app/routes/bill_run_invoice.routes.js
+++ b/app/routes/bill_run_invoice.routes.js
@@ -9,6 +9,11 @@ const routes = [
     handler: BillRunsInvoicesController.delete
   },
   {
+    method: 'DELETE',
+    path: '/v3/{regimeSlug}/bill-runs/{billRunId}/invoices/{invoiceId}',
+    handler: BillRunsInvoicesController.delete
+  },
+  {
     method: 'GET',
     path: '/v2/{regimeSlug}/bill-runs/{billRunId}/invoices/{invoiceId}',
     handler: BillRunsInvoicesController.view


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/CMEA-232

Since there is no change in behaviour between v2 and v3 we simply create a v3 route `/v3/{regimeSlug}/bill-runs/{billRunId}/invoices/{invoiceId}` and point it to the existing controller.

N.B. We are creating a series of `/v3` routes even where no change is required to give a clear distinction between a workflow that supports both SROC and PRESROC (v3) and one that only supports PRESROC (v2).