### PR TITLE
Remove unneeded validation

### DIFF
--- a/app/translators/calculate_charge_sroc.translator.js
+++ b/app/translators/calculate_charge_sroc.translator.js
@@ -41,10 +41,7 @@ class CalculateChargeSrocTranslator extends CalculateChargeBaseTranslator {
         .when('compensationCharge', { is: true, then: Joi.equal(false) }),
       actualVolume: Joi.number().greater(0)
         .when('twoPartTariff', { is: true, then: Joi.required() }),
-
-      // Dependent on both `compensationCharge` and `twoPartTariff`
       section127Agreement: Joi.boolean().required()
-        .when('compensationCharge', { is: true, then: Joi.equal(false) })
         .when('twoPartTariff', { is: true, then: Joi.equal(true) }),
 
       // Dependent on `supportedSource`

--- a/test/translators/calculate_charge_sroc.translator.test.js
+++ b/test/translators/calculate_charge_sroc.translator.test.js
@@ -752,14 +752,6 @@ describe('Calculate Charge Sroc translator', () => {
               expect(() => new CalculateChargeSrocTranslator(data(invalidPayload))).to.throw(ValidationError)
             })
           })
-
-          describe('and section127Agreement is `true`', () => {
-            it('throws an error', async () => {
-              invalidPayload.section127Agreement = true
-
-              expect(() => new CalculateChargeSrocTranslator(data(invalidPayload))).to.throw(ValidationError)
-            })
-          })
         })
       })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/projects/CMEA/boards/907?selectedIssue=CMEA-240

We have agreed with WRLS that we will remove one of our validation checks on an incoming charge -- we will no longer be validating that `section127Agreement` is `false` if `compensationCharge` is `true`. We therefore remove this validation rule. (This PR labelled as `bug` as it was a "bug" in our requirements)