### PR TITLE
Add additional presroc validation

### DIFF
--- a/app/translators/calculate_charge_base.translator.js
+++ b/app/translators/calculate_charge_base.translator.js
@@ -35,7 +35,10 @@ class CalculateChargeBaseTranslator extends BaseTranslator {
         .when('twoPartTariff', { is: true, then: Joi.equal(true) }),
 
       // Needed to determine which endpoints to call in the rules service
-      regime: Joi.string().required()
+      regime: Joi.string().required(),
+
+      // Case-insensitive validation matches and returns the correctly-capitalised string
+      loss: Joi.string().valid(...this._validLosses()).insensitive().required()
     }
   }
 
@@ -57,6 +60,10 @@ class CalculateChargeBaseTranslator extends BaseTranslator {
     if (error) {
       throw Boom.badData(error)
     }
+  }
+
+  _validLosses () {
+    throw new Error("Extending class must implement '_validLosses()'")
   }
 
   /**

--- a/app/translators/calculate_charge_base.translator.js
+++ b/app/translators/calculate_charge_base.translator.js
@@ -28,6 +28,10 @@ class CalculateChargeBaseTranslator extends BaseTranslator {
       waterUndertaker: Joi.boolean()
         .when('compensationCharge', { is: true, then: Joi.required() }),
 
+      // Dependent on `twoPartTariff`
+      section127Agreement: Joi.boolean().required()
+        .when('twoPartTariff', { is: true, then: Joi.equal(true) }),
+
       // Needed to determine which endpoints to call in the rules service
       regime: Joi.string().required()
     }

--- a/app/translators/calculate_charge_base.translator.js
+++ b/app/translators/calculate_charge_base.translator.js
@@ -27,6 +27,8 @@ class CalculateChargeBaseTranslator extends BaseTranslator {
       // Dependent on `compensationCharge`
       waterUndertaker: Joi.boolean()
         .when('compensationCharge', { is: true, then: Joi.required() }),
+      twoPartTariff: Joi.boolean().required()
+        .when('compensationCharge', { is: true, then: Joi.equal(false) }),
 
       // Dependent on `twoPartTariff`
       section127Agreement: Joi.boolean().required()

--- a/app/translators/calculate_charge_base.translator.js
+++ b/app/translators/calculate_charge_base.translator.js
@@ -38,7 +38,7 @@ class CalculateChargeBaseTranslator extends BaseTranslator {
       regime: Joi.string().required(),
 
       // Case-insensitive validation matches and returns the correctly-capitalised string
-      loss: Joi.string().valid(...this._validLosses()).insensitive().required()
+      loss: this._validateStringAgainstList(this._validLosses()).required()
     }
   }
 
@@ -60,6 +60,13 @@ class CalculateChargeBaseTranslator extends BaseTranslator {
     if (error) {
       throw Boom.badData(error)
     }
+  }
+
+  /**
+   * Perorming a case-insensitive validation against a provided list will match and return the correct capitalisation
+   */
+  _validateStringAgainstList (list) {
+    return Joi.string().valid(...list).insensitive()
   }
 
   _validLosses () {

--- a/app/translators/calculate_charge_presroc.translator.js
+++ b/app/translators/calculate_charge_presroc.translator.js
@@ -33,8 +33,8 @@ class CalculateChargePresrocTranslator extends CalculateChargeBaseTranslator {
       volume: Joi.number().min(0).required(),
 
       // Dependent on `compensationCharge` and case-insensitive to return the correctly-capitalised string
-      eiucSource: Joi
-        .when('compensationCharge', { is: true, then: Joi.string().valid(...this._validSources()).insensitive().required() }),
+      eiucSource: Joi.string().valid(...this._validSources()).insensitive()
+        .when('compensationCharge', { is: true, then: Joi.required() }),
 
       // Case-insensitive validation matches and returns the correctly-capitalised string
       source: Joi.string().valid(...this._validSources()).insensitive().required(),

--- a/app/translators/calculate_charge_presroc.translator.js
+++ b/app/translators/calculate_charge_presroc.translator.js
@@ -21,10 +21,9 @@ class CalculateChargePresrocTranslator extends CalculateChargeBaseTranslator {
     // Additional post-getter validation to ensure section126Factor has no more than 3 decimal places
     this._validateSection126Factor()
 
-    // Additional post-getter parser to ensure that loss, season and source are all in the right 'case'
-    this.regimeValue6 = this._titleCaseStringValue(this.regimeValue6)
-    this.regimeValue7 = this._titleCaseStringValue(this.regimeValue7)
-    this.regimeValue8 = this._titleCaseStringValue(this.regimeValue8)
+    // Additional post-getter parser to ensure that season and source are all in the right 'case'
+    this.regimeValue6 = this._titleCaseStringValue(this.regimeValue6) // source
+    this.regimeValue7 = this._titleCaseStringValue(this.regimeValue7) // season
   }
 
   _rules () {
@@ -42,7 +41,6 @@ class CalculateChargePresrocTranslator extends CalculateChargeBaseTranslator {
         .when('compensationCharge', { is: true, then: Joi.string().required() }),
 
       // validated in the rules service
-      loss: Joi.string().required(),
       regionalChargingArea: Joi.string().required(),
       season: Joi.string().required(),
       source: Joi.string().required()
@@ -71,6 +69,10 @@ class CalculateChargePresrocTranslator extends CalculateChargeBaseTranslator {
       waterUndertaker: 'regimeValue14',
       regime: 'regime'
     }
+  }
+
+  _validLosses () {
+    return ['Very Low', 'Low', 'Medium', 'High']
   }
 
   /**
@@ -110,9 +112,8 @@ class CalculateChargePresrocTranslator extends CalculateChargeBaseTranslator {
    * Use to title case a string value
    *
    * Title case is where the first character of each word is a capital and the rest is lower case. Our testing of the
-   * rules service has highlighted that it will only calculate the charge correctly if the values for the `loss`,
-   * `season`, and `source` in the request are in title case. Anything else and it fails to match them to resulting in a
-   * 0 charge.
+   * rules service has highlighted that it will only calculate the charge correctly if the values for `season` and
+   * `source` in the request are in title case. Anything else and it fails to match them to resulting in a 0 charge.
    *
    * This works for single-word strings (`summer` to `Summer`) and multi-word strings (`all year` to `All Year`).
    *

--- a/app/translators/calculate_charge_presroc.translator.js
+++ b/app/translators/calculate_charge_presroc.translator.js
@@ -32,9 +32,9 @@ class CalculateChargePresrocTranslator extends CalculateChargeBaseTranslator {
       twoPartTariff: Joi.boolean().required(),
       volume: Joi.number().min(0).required(),
 
-      // Dependent on `compensationCharge` and validated in the rules service
+      // Dependent on `compensationCharge` and case-insensitive to return the correctly-capitalised string
       eiucSource: Joi
-        .when('compensationCharge', { is: true, then: Joi.string().required() }),
+        .when('compensationCharge', { is: true, then: Joi.string().valid(...this._validSources()).insensitive().required() }),
 
       // validated in the rules service
       regionalChargingArea: Joi.string().required(),

--- a/app/translators/calculate_charge_presroc.translator.js
+++ b/app/translators/calculate_charge_presroc.translator.js
@@ -36,11 +36,9 @@ class CalculateChargePresrocTranslator extends CalculateChargeBaseTranslator {
       eiucSource: Joi
         .when('compensationCharge', { is: true, then: Joi.string().valid(...this._validSources()).insensitive().required() }),
 
-      // validated in the rules service
-      regionalChargingArea: Joi.string().required(),
-
       // Case-insensitive validation matches and returns the correctly-capitalised string
       source: Joi.string().valid(...this._validSources()).insensitive().required(),
+      regionalChargingArea: Joi.string().valid(...this._validRegionalChargingAreas()).insensitive().required(),
       season: Joi.string().valid(...this._validSeasons()).insensitive().required()
     }
   }
@@ -71,6 +69,21 @@ class CalculateChargePresrocTranslator extends CalculateChargeBaseTranslator {
 
   _validLosses () {
     return ['Very Low', 'Low', 'Medium', 'High']
+  }
+
+  _validRegionalChargingAreas () {
+    return [
+      'Anglian',
+      'Dee',
+      'Midlands',
+      'North West',
+      'Northumbria',
+      'South West (including Wessex)',
+      'Southern',
+      'Thames',
+      'Wye',
+      'Yorkshire'
+    ]
   }
 
   _validSources () {

--- a/app/translators/calculate_charge_presroc.translator.js
+++ b/app/translators/calculate_charge_presroc.translator.js
@@ -20,9 +20,6 @@ class CalculateChargePresrocTranslator extends CalculateChargeBaseTranslator {
 
     // Additional post-getter validation to ensure section126Factor has no more than 3 decimal places
     this._validateSection126Factor()
-
-    // Additional post-getter parser to ensure that season is in the right 'case'
-    this.regimeValue7 = this._titleCaseStringValue(this.regimeValue7)
   }
 
   _rules () {
@@ -41,10 +38,10 @@ class CalculateChargePresrocTranslator extends CalculateChargeBaseTranslator {
 
       // validated in the rules service
       regionalChargingArea: Joi.string().required(),
-      season: Joi.string().required(),
 
       // Case-insensitive validation matches and returns the correctly-capitalised string
-      source: Joi.string().valid(...this._validSources()).insensitive().required()
+      source: Joi.string().valid(...this._validSources()).insensitive().required(),
+      season: Joi.string().valid(...this._validSeasons()).insensitive().required()
     }
   }
 
@@ -80,6 +77,10 @@ class CalculateChargePresrocTranslator extends CalculateChargeBaseTranslator {
     return ['Supported', 'Kielder', 'Unsupported', 'Tidal']
   }
 
+  _validSeasons () {
+    return ['Summer', 'Winter', 'All Year']
+  }
+
   /**
    * Validate `section126Factor` precision is no more than 3 decimal places
    *
@@ -111,27 +112,6 @@ class CalculateChargePresrocTranslator extends CalculateChargeBaseTranslator {
     if (error) {
       throw Boom.badData(error)
     }
-  }
-
-  /**
-   * Use to title case a string value
-   *
-   * Title case is where the first character of each word is a capital and the rest is lower case. Our testing of the
-   * rules service has highlighted that it will only calculate the charge correctly if the value for `season` in the
-   * request is in title case. Anything else and it fails to match them to resulting in a 0 charge.
-   *
-   * This works for single-word strings (`summer` to `Summer`) and multi-word strings (`all year` to `All Year`).
-   *
-   * @param {string} value String value to be converted to title case
-   *
-   * @returns {string} The string value converted to title case
-   */
-  _titleCaseStringValue (value) {
-    return value
-      .toLowerCase()
-      .split(' ')
-      .map(word => word[0].toUpperCase() + word.substring(1))
-      .join(' ')
   }
 
   /**

--- a/app/translators/calculate_charge_presroc.translator.js
+++ b/app/translators/calculate_charge_presroc.translator.js
@@ -21,9 +21,8 @@ class CalculateChargePresrocTranslator extends CalculateChargeBaseTranslator {
     // Additional post-getter validation to ensure section126Factor has no more than 3 decimal places
     this._validateSection126Factor()
 
-    // Additional post-getter parser to ensure that season and source are all in the right 'case'
-    this.regimeValue6 = this._titleCaseStringValue(this.regimeValue6) // source
-    this.regimeValue7 = this._titleCaseStringValue(this.regimeValue7) // season
+    // Additional post-getter parser to ensure that season is in the right 'case'
+    this.regimeValue7 = this._titleCaseStringValue(this.regimeValue7)
   }
 
   _rules () {
@@ -43,7 +42,9 @@ class CalculateChargePresrocTranslator extends CalculateChargeBaseTranslator {
       // validated in the rules service
       regionalChargingArea: Joi.string().required(),
       season: Joi.string().required(),
-      source: Joi.string().required()
+
+      // Case-insensitive validation matches and returns the correctly-capitalised string
+      source: Joi.string().valid(...this._validSources()).insensitive().required()
     }
   }
 
@@ -73,6 +74,10 @@ class CalculateChargePresrocTranslator extends CalculateChargeBaseTranslator {
 
   _validLosses () {
     return ['Very Low', 'Low', 'Medium', 'High']
+  }
+
+  _validSources () {
+    return ['Supported', 'Kielder', 'Unsupported', 'Tidal']
   }
 
   /**
@@ -112,8 +117,8 @@ class CalculateChargePresrocTranslator extends CalculateChargeBaseTranslator {
    * Use to title case a string value
    *
    * Title case is where the first character of each word is a capital and the rest is lower case. Our testing of the
-   * rules service has highlighted that it will only calculate the charge correctly if the values for `season` and
-   * `source` in the request are in title case. Anything else and it fails to match them to resulting in a 0 charge.
+   * rules service has highlighted that it will only calculate the charge correctly if the value for `season` in the
+   * request is in title case. Anything else and it fails to match them to resulting in a 0 charge.
    *
    * This works for single-word strings (`summer` to `Summer`) and multi-word strings (`all year` to `All Year`).
    *

--- a/app/translators/calculate_charge_presroc.translator.js
+++ b/app/translators/calculate_charge_presroc.translator.js
@@ -33,13 +33,13 @@ class CalculateChargePresrocTranslator extends CalculateChargeBaseTranslator {
       volume: Joi.number().min(0).required(),
 
       // Dependent on `compensationCharge` and case-insensitive to return the correctly-capitalised string
-      eiucSource: Joi.string().valid(...this._validSources()).insensitive()
+      eiucSource: this._validateStringAgainstList(this._validSources())
         .when('compensationCharge', { is: true, then: Joi.required() }),
 
       // Case-insensitive validation matches and returns the correctly-capitalised string
-      source: Joi.string().valid(...this._validSources()).insensitive().required(),
-      regionalChargingArea: Joi.string().valid(...this._validRegionalChargingAreas()).insensitive().required(),
-      season: Joi.string().valid(...this._validSeasons()).insensitive().required()
+      source: this._validateStringAgainstList(this._validSources()).required(),
+      regionalChargingArea: this._validateStringAgainstList(this._validRegionalChargingAreas()).required(),
+      season: this._validateStringAgainstList(this._validSeasons()).required()
     }
   }
 

--- a/app/translators/calculate_charge_presroc.translator.js
+++ b/app/translators/calculate_charge_presroc.translator.js
@@ -34,7 +34,6 @@ class CalculateChargePresrocTranslator extends CalculateChargeBaseTranslator {
 
       periodStart: Joi.date().format(this._validDateFormats()).max(Joi.ref('periodEnd')).min('01-APR-2014').required(),
       section126Factor: Joi.number().allow(null).empty(null).default(1.0),
-      section127Agreement: Joi.boolean().required(),
       twoPartTariff: Joi.boolean().required(),
       volume: Joi.number().min(0).required(),
 

--- a/app/translators/calculate_charge_sroc.translator.js
+++ b/app/translators/calculate_charge_sroc.translator.js
@@ -30,8 +30,7 @@ class CalculateChargeSrocTranslator extends CalculateChargeBaseTranslator {
       winterOnly: Joi.boolean().required(),
 
       // Dependent on `compensationCharge`
-      // Case-insensitive validation matches and returns the correctly-capitalised string
-      regionalChargingArea: Joi.string().valid(...this._validRegionalChargingAreas()).insensitive()
+      regionalChargingArea: this._validateStringAgainstList(this._validRegionalChargingAreas())
         .when('compensationCharge', { is: true, then: Joi.required() }),
 
       // Dependent on `twoPartTariff`
@@ -42,7 +41,7 @@ class CalculateChargeSrocTranslator extends CalculateChargeBaseTranslator {
       supportedSource: Joi.boolean().required(),
       supportedSourceName: Joi
         // If `true` then we match and return the correctly-capitalised string
-        .when('supportedSource', { is: true, then: Joi.string().valid(...this._validSupportedSourceNames()).insensitive().required() })
+        .when('supportedSource', { is: true, then: this._validateStringAgainstList(this._validSupportedSourceNames()).required() })
         // If `false` then this should be undefined (ie. not present) and we set the value as `Not Applicable`
         .when('supportedSource', { is: false, then: Joi.forbidden().default('Not Applicable') }),
 

--- a/app/translators/calculate_charge_sroc.translator.js
+++ b/app/translators/calculate_charge_sroc.translator.js
@@ -37,8 +37,6 @@ class CalculateChargeSrocTranslator extends CalculateChargeBaseTranslator {
         .when('compensationCharge', { is: true, then: Joi.required() }),
 
       // Dependent on `twoPartTariff`
-      twoPartTariff: Joi.boolean().required()
-        .when('compensationCharge', { is: true, then: Joi.equal(false) }),
       actualVolume: Joi.number().greater(0)
         .when('twoPartTariff', { is: true, then: Joi.required() }),
 

--- a/app/translators/calculate_charge_sroc.translator.js
+++ b/app/translators/calculate_charge_sroc.translator.js
@@ -24,8 +24,6 @@ class CalculateChargeSrocTranslator extends CalculateChargeBaseTranslator {
 
       abatementFactor: Joi.number().allow(null).empty(null).default(1.0),
       aggregateProportion: Joi.number().allow(null).empty(null).default(1.0),
-      // Case-insensitive validation matches and returns the correctly-capitalised string
-      loss: Joi.string().valid(...this._validLosses()).insensitive().required(),
       periodStart: Joi.date().format(this._validDateFormats()).min('01-APR-2021').max(Joi.ref('periodEnd')).required(),
       authorisedVolume: Joi.number().greater(0).required(),
       waterCompanyCharge: Joi.boolean().required(),

--- a/app/translators/calculate_charge_sroc.translator.js
+++ b/app/translators/calculate_charge_sroc.translator.js
@@ -41,8 +41,6 @@ class CalculateChargeSrocTranslator extends CalculateChargeBaseTranslator {
         .when('compensationCharge', { is: true, then: Joi.equal(false) }),
       actualVolume: Joi.number().greater(0)
         .when('twoPartTariff', { is: true, then: Joi.required() }),
-      section127Agreement: Joi.boolean().required()
-        .when('twoPartTariff', { is: true, then: Joi.equal(true) }),
 
       // Dependent on `supportedSource`
       supportedSource: Joi.boolean().required(),

--- a/app/translators/transaction_base.translator.js
+++ b/app/translators/transaction_base.translator.js
@@ -26,7 +26,8 @@ class TransactionBaseTranslator extends BaseTranslator {
       chargeElementId: Joi.string().allow('', null),
       areaCode: Joi.string().uppercase().valid(...this._validAreas()).required(),
       lineDescription: Joi.string().max(240).required(),
-      clientId: Joi.string().allow('', null)
+      clientId: Joi.string().allow('', null),
+      chargePeriod: Joi.string().max(150).required()
     }
   }
 

--- a/app/translators/transaction_presroc.translator.js
+++ b/app/translators/transaction_presroc.translator.js
@@ -12,7 +12,6 @@ class TransactionPresrocTranslator extends TransactionBaseTranslator {
     return {
       ...this._baseRules(),
       ruleset: Joi.string().allow('presroc').default('presroc'),
-      chargePeriod: Joi.string().required(),
       subjectToMinimumCharge: Joi.boolean().default(false)
     }
   }

--- a/app/translators/transaction_sroc.translator.js
+++ b/app/translators/transaction_sroc.translator.js
@@ -12,7 +12,6 @@ class TransactionSrocTranslator extends TransactionBaseTranslator {
     return {
       ...this._baseRules(),
       ruleset: Joi.string().valid('sroc').required(),
-      chargePeriod: Joi.string().max(150).required(),
       chargeCategoryDescription: Joi.string().max(150).required()
     }
   }

--- a/test/translators/calculate_charge_presroc.translator.test.js
+++ b/test/translators/calculate_charge_presroc.translator.test.js
@@ -80,6 +80,7 @@ describe('Calculate Charge Presroc translator', () => {
         ...payload,
         billableDays: 8,
         authorisedDays: 16,
+        section127Agreement: true,
         twoPartTariff: true
       }
 

--- a/test/translators/calculate_charge_presroc.translator.test.js
+++ b/test/translators/calculate_charge_presroc.translator.test.js
@@ -394,6 +394,17 @@ describe('Calculate Charge Presroc translator', () => {
           expect(() => new CalculateChargePresrocTranslator(data(invalidPayload))).to.throw(ValidationError)
         })
       })
+
+      describe('because regionalChargingArea is not valid', () => {
+        it('throws an error', async () => {
+          const invalidPayload = {
+            ...payload,
+            regionalChargingArea: 'INVALID'
+          }
+
+          expect(() => new CalculateChargePresrocTranslator(data(invalidPayload))).to.throw(ValidationError)
+        })
+      })
     })
   })
 })

--- a/test/translators/calculate_charge_presroc.translator.test.js
+++ b/test/translators/calculate_charge_presroc.translator.test.js
@@ -209,7 +209,7 @@ describe('Calculate Charge Presroc translator', () => {
         expect(result).to.not.be.an.error()
       })
 
-      describe("if 'compensationCharge' is true", () => {
+      describe("if 'compensationCharge' is false", () => {
         describe("and 'eiucSource' is missing", () => {
           it('still does not throw an error', async () => {
             const validPayload = {
@@ -298,6 +298,18 @@ describe('Calculate Charge Presroc translator', () => {
               compensationCharge: true
             }
             delete invalidPayload.eiucSource
+
+            expect(() => new CalculateChargePresrocTranslator(data(invalidPayload))).to.throw(ValidationError)
+          })
+        })
+
+        describe("and 'eiucSource' is invalid", () => {
+          it('throws an error', async () => {
+            const invalidPayload = {
+              ...payload,
+              compensationCharge: true,
+              eiucSource: 'INVALID'
+            }
 
             expect(() => new CalculateChargePresrocTranslator(data(invalidPayload))).to.throw(ValidationError)
           })

--- a/test/translators/calculate_charge_presroc.translator.test.js
+++ b/test/translators/calculate_charge_presroc.translator.test.js
@@ -202,12 +202,11 @@ describe('Calculate Charge Presroc translator', () => {
   })
 
   describe('handling of strings not in correct case', () => {
-    describe("when 'season' and 'source' are not sent as title case", () => {
+    describe("when 'season' is not sent as title case", () => {
       it('automatically converts them to title case', () => {
         const lowercasePayload = {
           ...payload,
-          season: 'aLl yeAr',
-          source: 'supPorTed'
+          season: 'aLl yeAr'
         }
 
         const result = new CalculateChargePresrocTranslator(data(lowercasePayload))
@@ -372,6 +371,17 @@ describe('Calculate Charge Presroc translator', () => {
           const invalidPayload = {
             ...payload,
             loss: 'INVALID'
+          }
+
+          expect(() => new CalculateChargePresrocTranslator(data(invalidPayload))).to.throw(ValidationError)
+        })
+      })
+
+      describe('because source is not valid', () => {
+        it('throws an error', async () => {
+          const invalidPayload = {
+            ...payload,
+            source: 'INVALID'
           }
 
           expect(() => new CalculateChargePresrocTranslator(data(invalidPayload))).to.throw(ValidationError)

--- a/test/translators/calculate_charge_presroc.translator.test.js
+++ b/test/translators/calculate_charge_presroc.translator.test.js
@@ -202,18 +202,16 @@ describe('Calculate Charge Presroc translator', () => {
   })
 
   describe('handling of strings not in correct case', () => {
-    describe("when 'loss', 'season' and 'source' are not sent as title case", () => {
+    describe("when 'season' and 'source' are not sent as title case", () => {
       it('automatically converts them to title case', () => {
         const lowercasePayload = {
           ...payload,
-          loss: 'lOw',
           season: 'aLl yeAr',
           source: 'supPorTed'
         }
 
         const result = new CalculateChargePresrocTranslator(data(lowercasePayload))
 
-        expect(result.regimeValue8).to.equal('Low')
         expect(result.regimeValue7).to.equal('All Year')
         expect(result.regimeValue6).to.equal('Supported')
       })
@@ -363,6 +361,17 @@ describe('Calculate Charge Presroc translator', () => {
           const invalidPayload = {
             ...payload,
             ruleset: 'INVALID'
+          }
+
+          expect(() => new CalculateChargePresrocTranslator(data(invalidPayload))).to.throw(ValidationError)
+        })
+      })
+
+      describe('because loss is not valid', () => {
+        it('throws an error', async () => {
+          const invalidPayload = {
+            ...payload,
+            loss: 'INVALID'
           }
 
           expect(() => new CalculateChargePresrocTranslator(data(invalidPayload))).to.throw(ValidationError)

--- a/test/translators/calculate_charge_presroc.translator.test.js
+++ b/test/translators/calculate_charge_presroc.translator.test.js
@@ -201,6 +201,28 @@ describe('Calculate Charge Presroc translator', () => {
     })
   })
 
+  describe('handling of strings', () => {
+    describe('when a valid string is passed to a field that validates against a list', () => {
+      it('returns the correct capitalisation of the string', async () => {
+        const validPayload = {
+          ...payload,
+          loss: 'very low',
+          source: 'tidAl',
+          season: 'ALL YEAR',
+          eiucSource: 'kIeLdEr',
+          regionalChargingArea: 'sOUTH wEST (Including wESSEX)'
+        }
+        const result = new CalculateChargePresrocTranslator(data(validPayload))
+
+        expect(result.regimeValue8).to.equal('Very Low')
+        expect(result.regimeValue6).to.equal('Tidal')
+        expect(result.regimeValue7).to.equal('All Year')
+        expect(result.regimeValue13).to.equal('Kielder')
+        expect(result.regimeValue15).to.equal('South West (including Wessex)')
+      })
+    })
+  })
+
   describe('Validation', () => {
     describe('when the data is valid', () => {
       it('does not throw an error', async () => {

--- a/test/translators/calculate_charge_presroc.translator.test.js
+++ b/test/translators/calculate_charge_presroc.translator.test.js
@@ -201,22 +201,6 @@ describe('Calculate Charge Presroc translator', () => {
     })
   })
 
-  describe('handling of strings not in correct case', () => {
-    describe("when 'season' is not sent as title case", () => {
-      it('automatically converts them to title case', () => {
-        const lowercasePayload = {
-          ...payload,
-          season: 'aLl yeAr'
-        }
-
-        const result = new CalculateChargePresrocTranslator(data(lowercasePayload))
-
-        expect(result.regimeValue7).to.equal('All Year')
-        expect(result.regimeValue6).to.equal('Supported')
-      })
-    })
-  })
-
   describe('Validation', () => {
     describe('when the data is valid', () => {
       it('does not throw an error', async () => {
@@ -382,6 +366,17 @@ describe('Calculate Charge Presroc translator', () => {
           const invalidPayload = {
             ...payload,
             source: 'INVALID'
+          }
+
+          expect(() => new CalculateChargePresrocTranslator(data(invalidPayload))).to.throw(ValidationError)
+        })
+      })
+
+      describe('because season is not valid', () => {
+        it('throws an error', async () => {
+          const invalidPayload = {
+            ...payload,
+            season: 'INVALID'
           }
 
           expect(() => new CalculateChargePresrocTranslator(data(invalidPayload))).to.throw(ValidationError)


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/projects/CMEA/boards/907?selectedIssue=CMEA-214

When we were implementing sroc charge validation, we realised that we could validate some fields in a better way than we were validating them for presroc. This change therefore updates the transaction translators so that this improved validation is also applied to the presroc ruleset, by moving the validation to the base class:
- We validate that if `twoPartTariff` is `true` then `section127Agreement` is also `true`
- We validate that `twoPartTariff` and `compensationCharge` are not both set to `true`
- We validate that the max length of `chargePeriod` is 150 chars. Note that this change is made to the transaction translator, rather than the charge translator.

For sroc fields where text has to be precisely capitalised to be accepted by the Rules Service, we performed a case-insensitive match against a list of possible values, which gives the exact capitalisation as well as allowing us to reject invalid input early instead of passing it to the Rules Service for it to reject. This is an improvement over the presroc validation, which simply capitalises each word. We therefore implement this for presroc (refactoring so that it is done by a function on the base class) and expand it to cover all such fields:
- `loss`
- `source`
- `season`
- `eiucSource`
- `regionalChargingArea`
