### PR TITLE
Amend presroc validation lists

### DIFF
--- a/app/translators/calculate_charge_presroc.translator.js
+++ b/app/translators/calculate_charge_presroc.translator.js
@@ -33,7 +33,7 @@ class CalculateChargePresrocTranslator extends CalculateChargeBaseTranslator {
       volume: Joi.number().min(0).required(),
 
       // Dependent on `compensationCharge` and case-insensitive to return the correctly-capitalised string
-      eiucSource: this._validateStringAgainstList(this._validSources())
+      eiucSource: this._validateStringAgainstList(this._validEiucSources())
         .when('compensationCharge', { is: true, then: Joi.required() }),
 
       // Case-insensitive validation matches and returns the correctly-capitalised string
@@ -68,13 +68,12 @@ class CalculateChargePresrocTranslator extends CalculateChargeBaseTranslator {
   }
 
   _validLosses () {
-    return ['Very Low', 'Low', 'Medium', 'High']
+    return ['High', 'Medium', 'Low', 'Very Low']
   }
 
   _validRegionalChargingAreas () {
     return [
       'Anglian',
-      'Dee',
       'Midlands',
       'North West',
       'Northumbria',
@@ -88,6 +87,10 @@ class CalculateChargePresrocTranslator extends CalculateChargeBaseTranslator {
 
   _validSources () {
     return ['Supported', 'Kielder', 'Unsupported', 'Tidal']
+  }
+
+  _validEiucSources () {
+    return ['Unsupported', 'Kielder', 'Supported', 'Tidal', 'Other']
   }
 
   _validSeasons () {

--- a/test/translators/calculate_charge_presroc.translator.test.js
+++ b/test/translators/calculate_charge_presroc.translator.test.js
@@ -209,7 +209,7 @@ describe('Calculate Charge Presroc translator', () => {
           loss: 'very low',
           source: 'tidAl',
           season: 'ALL YEAR',
-          eiucSource: 'kIeLdEr',
+          eiucSource: 'oThEr',
           regionalChargingArea: 'sOUTH wEST (Including wESSEX)'
         }
         const result = new CalculateChargePresrocTranslator(data(validPayload))
@@ -217,7 +217,7 @@ describe('Calculate Charge Presroc translator', () => {
         expect(result.regimeValue8).to.equal('Very Low')
         expect(result.regimeValue6).to.equal('Tidal')
         expect(result.regimeValue7).to.equal('All Year')
-        expect(result.regimeValue13).to.equal('Kielder')
+        expect(result.regimeValue13).to.equal('Other')
         expect(result.regimeValue15).to.equal('South West (including Wessex)')
       })
     })


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/projects/CMEA/boards/907

After merging the previous validation work, we realised we had used an outdated spreadsheet to compile the lists of strings to be validated against. We fix this here.