### PR TITLE
Create v3 view bill run status route

### DIFF
--- a/app/routes/bill_run.routes.js
+++ b/app/routes/bill_run.routes.js
@@ -56,6 +56,11 @@ const routes = [
   },
   {
     method: 'GET',
+    path: '/v3/{regimeSlug}/bill-runs/{billRunId}/status',
+    handler: BillRunsController.status
+  },
+  {
+    method: 'GET',
     path: '/v2/{regimeSlug}/bill-runs/{billRunId}',
     handler: BillRunsController.view
   },

--- a/test/controllers/bill_runs.controller.test.js
+++ b/test/controllers/bill_runs.controller.test.js
@@ -204,40 +204,42 @@ describe('Bill Runs controller', () => {
     })
   }
 
-  describe('Get bill run status: GET /v2/{regimeSlug}/bill-runs/{billRunId}/status', () => {
-    const options = (token, billRunId) => {
-      return {
-        method: 'GET',
-        url: `/v2/wrls/bill-runs/${billRunId}/status`,
-        headers: { authorization: `Bearer ${token}` }
+  for (const version of ['v2', 'v3']) {
+    describe(`Get bill run status: GET /${version}/{regimeSlug}/bill-runs/{billRunId}/status`, () => {
+      const options = (token, billRunId) => {
+        return {
+          method: 'GET',
+          url: `/${version}/wrls/bill-runs/${billRunId}/status`,
+          headers: { authorization: `Bearer ${token}` }
+        }
       }
-    }
 
-    describe('When the request is valid', () => {
-      it('returns success status 200', async () => {
-        billRun = await NewBillRunHelper.create(authorisedSystem.id, regime.id)
+      describe('When the request is valid', () => {
+        it('returns success status 200', async () => {
+          billRun = await NewBillRunHelper.create(authorisedSystem.id, regime.id)
 
-        const response = await server.inject(options(authToken, billRun.id))
-        const responsePayload = JSON.parse(response.payload)
-
-        expect(response.statusCode).to.equal(200)
-        expect(responsePayload.status).to.equal(billRun.status)
-      })
-    })
-
-    describe('When the request is invalid', () => {
-      describe('because the bill run does not exist', () => {
-        it('returns error status 404', async () => {
-          const unknownBillRunId = GeneralHelper.uuid4()
-          const response = await server.inject(options(authToken, unknownBillRunId))
+          const response = await server.inject(options(authToken, billRun.id))
           const responsePayload = JSON.parse(response.payload)
 
-          expect(response.statusCode).to.equal(404)
-          expect(responsePayload.message).to.equal(`Bill run ${unknownBillRunId} is unknown.`)
+          expect(response.statusCode).to.equal(200)
+          expect(responsePayload.status).to.equal(billRun.status)
+        })
+      })
+
+      describe('When the request is invalid', () => {
+        describe('because the bill run does not exist', () => {
+          it('returns error status 404', async () => {
+            const unknownBillRunId = GeneralHelper.uuid4()
+            const response = await server.inject(options(authToken, unknownBillRunId))
+            const responsePayload = JSON.parse(response.payload)
+
+            expect(response.statusCode).to.equal(404)
+            expect(responsePayload.message).to.equal(`Bill run ${unknownBillRunId} is unknown.`)
+          })
         })
       })
     })
-  })
+  }
 
   for (const version of ['v2', 'v3']) {
     describe(`View bill run: GET /${version}/{regimeSlug}/bill-runs/{billRunId}`, () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/projects/CMEA/boards/907?selectedIssue=CMEA-229

Since we are not changing the behaviour of the view bill run status endpoint, we simply create a new route `/v3/{regimeSlug}/bill-runs/{billRunId}/status` and point it to the existing controller.