### PR TITLE
Align presroc and sroc `regionalChargingArea` validation

### DIFF
--- a/app/translators/calculate_charge_base.translator.js
+++ b/app/translators/calculate_charge_base.translator.js
@@ -29,6 +29,9 @@ class CalculateChargeBaseTranslator extends BaseTranslator {
         .when('compensationCharge', { is: true, then: Joi.required() }),
       twoPartTariff: Joi.boolean().required()
         .when('compensationCharge', { is: true, then: Joi.equal(false) }),
+      // Case-insensitive validation matches and returns the correctly-capitalised string
+      regionalChargingArea: this._validateStringAgainstList(this._validRegionalChargingAreas())
+        .when('compensationCharge', { is: true, then: Joi.required() }),
 
       // Dependent on `twoPartTariff`
       section127Agreement: Joi.boolean().required()

--- a/app/translators/calculate_charge_base.translator.js
+++ b/app/translators/calculate_charge_base.translator.js
@@ -73,6 +73,24 @@ class CalculateChargeBaseTranslator extends BaseTranslator {
     throw new Error("Extending class must implement '_validLosses()'")
   }
 
+  _validRegionalChargingAreas () {
+    return [
+      'Anglian',
+      'Midlands',
+      'Northumbria',
+      'North West',
+      'Southern',
+      'South West (incl Wessex)',
+      'Devon and Cornwall (South West)',
+      'North and South Wessex',
+      'Thames',
+      'Yorkshire',
+      'Dee',
+      'Wye',
+      'Wales'
+    ]
+  }
+
   /**
    * Returns the calculated financial year for a given date
    *

--- a/app/translators/calculate_charge_presroc.translator.js
+++ b/app/translators/calculate_charge_presroc.translator.js
@@ -71,20 +71,6 @@ class CalculateChargePresrocTranslator extends CalculateChargeBaseTranslator {
     return ['High', 'Medium', 'Low', 'Very Low']
   }
 
-  _validRegionalChargingAreas () {
-    return [
-      'Anglian',
-      'Midlands',
-      'North West',
-      'Northumbria',
-      'South West (including Wessex)',
-      'Southern',
-      'Thames',
-      'Wye',
-      'Yorkshire'
-    ]
-  }
-
   _validSources () {
     return ['Supported', 'Kielder', 'Unsupported', 'Tidal']
   }

--- a/app/translators/calculate_charge_presroc.translator.js
+++ b/app/translators/calculate_charge_presroc.translator.js
@@ -38,7 +38,6 @@ class CalculateChargePresrocTranslator extends CalculateChargeBaseTranslator {
 
       // Case-insensitive validation matches and returns the correctly-capitalised string
       source: this._validateStringAgainstList(this._validSources()).required(),
-      regionalChargingArea: this._validateStringAgainstList(this._validRegionalChargingAreas()).required(),
       season: this._validateStringAgainstList(this._validSeasons()).required()
     }
   }

--- a/app/translators/calculate_charge_sroc.translator.js
+++ b/app/translators/calculate_charge_sroc.translator.js
@@ -29,10 +29,6 @@ class CalculateChargeSrocTranslator extends CalculateChargeBaseTranslator {
       waterCompanyCharge: Joi.boolean().required(),
       winterOnly: Joi.boolean().required(),
 
-      // Dependent on `compensationCharge`
-      regionalChargingArea: this._validateStringAgainstList(this._validRegionalChargingAreas())
-        .when('compensationCharge', { is: true, then: Joi.required() }),
-
       // Dependent on `twoPartTariff`
       actualVolume: Joi.number().greater(0)
         .when('twoPartTariff', { is: true, then: Joi.required() }),

--- a/app/translators/calculate_charge_sroc.translator.js
+++ b/app/translators/calculate_charge_sroc.translator.js
@@ -82,24 +82,6 @@ class CalculateChargeSrocTranslator extends CalculateChargeBaseTranslator {
     return ['Low', 'Medium', 'High']
   }
 
-  _validRegionalChargingAreas () {
-    return [
-      'Anglian',
-      'Midlands',
-      'Northumbria',
-      'North West',
-      'Southern',
-      'South West (incl Wessex)',
-      'Devon and Cornwall (South West)',
-      'North and South Wessex',
-      'Thames',
-      'Yorkshire',
-      'Dee',
-      'Wye',
-      'Wales'
-    ]
-  }
-
   _validSupportedSourceNames () {
     return [
       'Candover',

--- a/test/translators/calculate_charge_presroc.translator.test.js
+++ b/test/translators/calculate_charge_presroc.translator.test.js
@@ -210,7 +210,7 @@ describe('Calculate Charge Presroc translator', () => {
           source: 'tidAl',
           season: 'ALL YEAR',
           eiucSource: 'oThEr',
-          regionalChargingArea: 'sOUTH wEST (Including wESSEX)'
+          regionalChargingArea: 'sOUTH wEST (Incl wESSEX)'
         }
         const result = new CalculateChargePresrocTranslator(data(validPayload))
 
@@ -218,7 +218,7 @@ describe('Calculate Charge Presroc translator', () => {
         expect(result.regimeValue6).to.equal('Tidal')
         expect(result.regimeValue7).to.equal('All Year')
         expect(result.regimeValue13).to.equal('Other')
-        expect(result.regimeValue15).to.equal('South West (including Wessex)')
+        expect(result.regimeValue15).to.equal('South West (incl Wessex)')
       })
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/projects/CMEA/boards/907?selectedIssue=CMEA-214

Previously, presroc and sroc had a different list of valid values for `regionalChargingArea`. However we have had confirmation that these lists can be the same; therefore, we delete the lists from the individual translators, and put the single list we want to use on the base translator, so they both validate against the same list.

We also move the validation rule to the base validator, as we have agreed that the behaviour should be the same for both. This means a slight change in how the field is validated for presroc to bring it in line with sroc: previously, the field was always required for presroc, whereas now it is only required if `compensationCharge` is `true`. In practice, `regionalChargingArea` has always been sent through to us anyway but this change makes it clear in the code what the expected behaviour is.