### PR TITLE
Remove `twoPartTariff` validation from presroc translator

### DIFF
--- a/app/translators/calculate_charge_presroc.translator.js
+++ b/app/translators/calculate_charge_presroc.translator.js
@@ -29,7 +29,6 @@ class CalculateChargePresrocTranslator extends CalculateChargeBaseTranslator {
 
       periodStart: Joi.date().format(this._validDateFormats()).max(Joi.ref('periodEnd')).min('01-APR-2014').required(),
       section126Factor: Joi.number().allow(null).empty(null).default(1.0),
-      twoPartTariff: Joi.boolean().required(),
       volume: Joi.number().min(0).required(),
 
       // Dependent on `compensationCharge` and case-insensitive to return the correctly-capitalised string

--- a/test/translators/calculate_charge_presroc.translator.test.js
+++ b/test/translators/calculate_charge_presroc.translator.test.js
@@ -427,6 +427,18 @@ describe('Calculate Charge Presroc translator', () => {
           expect(() => new CalculateChargePresrocTranslator(data(invalidPayload))).to.throw(ValidationError)
         })
       })
+
+      describe('because twoPartTariff and compensationCharge are both true', () => {
+        it('throws an error', async () => {
+          const invalidPayload = {
+            ...payload,
+            twoPartTariff: true,
+            compensationCharge: true
+          }
+
+          expect(() => new CalculateChargePresrocTranslator(data(invalidPayload))).to.throw(ValidationError)
+        })
+      })
     })
   })
 })


### PR DESCRIPTION
We previously refactored our presroc and sroc charge validation so that any validation we want to apply to both rulesets is placed in a shared base translator. We did this with our sroc validation which ensures that both `twoPartTariff` and `compensationCharge` aren't both true, as we wanted this to also apply to presroc. However, we overlooked removing the existing `twoPartTariff` validation from the presroc translator, which meant that the specific conditional validation was then being overwritten with the basic "ensure this field is present" validation we had for presroc. We therefore remove this from the presroc translator to ensure that the conditional validation applies to both rulesets.