### PR TITLE
CMEA-220 Add SROC transaction number sequence

### DIFF
--- a/app/services/bill_runs/send_bill_run_reference.service.js
+++ b/app/services/bill_runs/send_bill_run_reference.service.js
@@ -79,6 +79,7 @@ class SendBillRunReferenceService {
       const reference = await NextTransactionReferenceService.go(
         regime.id,
         billRun.region,
+        billRun.ruleset,
         invoice.$transactionType(),
         trx
       )

--- a/app/services/next_references/next_transaction_reference.service.js
+++ b/app/services/next_references/next_transaction_reference.service.js
@@ -64,9 +64,9 @@ class NextTransactionReferenceService {
   static _response (region, ruleset, transactionType, transactionNumber) {
     if (ruleset === 'presroc') {
       return this._presrocResponse(region, transactionType, transactionNumber)
-    } else {
-      return this._srocResponse(region, transactionType, transactionNumber)
     }
+
+    return this._srocResponse(region, transactionType, transactionNumber)
   }
 
   /**

--- a/app/services/next_references/next_transaction_reference.service.js
+++ b/app/services/next_references/next_transaction_reference.service.js
@@ -8,27 +8,18 @@ const { SequenceCounterModel } = require('../../models')
 
 class NextTransactionReferenceService {
   /**
-   * Returns the next transaction reference for the given region and regime and whether it's for a credit note or
-   * invoice
+   * Returns the next transaction reference for the given region, regime and ruleset and whether it's for a credit note
+   * or invoice
    *
    * The transaction number in the sequence_counters table is the last number issued. Therefore, we increment it by 1
    * and get the new number. We then take that value and format it as a **transaction reference**.
    *
-   * The format is `RAX1999999` where
-   *
-   * - `R` is the region indicator
-   * - `A` is a fixed digit "A", ("Z" for draft type)
-   * - `X` is the transaction type (C or I)
-   * - `1` is a fixed digit "1"
-   * - `999999` is our sequential transaction number padded to a 6-digit numeric string
-   *
-   * For example, if the region was 'R', the next transaction number was 3, and it was for a credit note the reference
-   * would be `RAC1000003`.
-   *
-   * If an invalid region & regime pair is supplied, an Objection `NotFoundError` is thrown
+   * If an invalid region & regime pair is supplied, an Objection `NotFoundError` is thrown. If an unvalid ruleset is
+   * supplied a `TypeError` is thrown.
    *
    * @param {string} regimeId Id of the regime to get the next reference for
    * @param {string} region The region to get the next reference for
+   * @param {string} ruleset The ruleset to get the next reference for
    * @param {string} transactionType Either a `'C'` or an `'I'` which denotes whether the invoice the reference is for
    * is an invoice or a credit note.
    * @param {Object} [trx] Optional Objection database `transaction` object to be used in the update to
@@ -36,38 +27,96 @@ class NextTransactionReferenceService {
    *
    * @returns {string} the generated transaction reference
    */
-  static async go (regimeId, region, transactionType, trx = null) {
-    const result = await this._updateSequenceCounter(regimeId, region, trx)
+  static async go (regimeId, region, ruleset, transactionType, trx = null) {
+    const result = await this._updateSequenceCounter(regimeId, region, ruleset, trx)
 
-    return this._response(region, result.transactionNumber, transactionType)
+    return this._response(region, ruleset, transactionType, result)
   }
 
-  static async _updateSequenceCounter (regimeId, region, trx) {
-    return SequenceCounterModel.query(trx)
+  static async _updateSequenceCounter (regimeId, region, ruleset, trx) {
+    const rulesetColumnNames = this._rulesetColumnNames()[ruleset]
+
+    const result = await SequenceCounterModel.query(trx)
       .findOne({
         regime_id: regimeId,
         region
       })
-      .increment('transaction_number', 1)
-      .returning('transaction_number')
+      .increment(rulesetColumnNames.raw, 1)
+      .returning(rulesetColumnNames.raw)
       .throwIfNotFound({
         message: 'Invalid combination of regime and region'
       })
+
+    return result[rulesetColumnNames.camel]
   }
 
-  static _response (region, transactionNumber, transactionType) {
-    return `${region}A${transactionType}1${this._padNumber(transactionNumber)}`
+  static _rulesetColumnNames () {
+    return {
+      presroc: {
+        raw: 'transaction_number_presroc', camel: 'transactionNumberPresroc'
+      },
+      sroc: {
+        raw: 'transaction_number_sroc', camel: 'transactionNumberSroc'
+      }
+    }
+  }
+
+  static _response (region, ruleset, transactionType, transactionNumber) {
+    if (ruleset === 'presroc') {
+      return this._presrocResponse(region, transactionType, transactionNumber)
+    } else {
+      return this._srocResponse(region, transactionType, transactionNumber)
+    }
   }
 
   /**
-   * Return a number as a string, padded to 6 digits with leading zeroes
+   * Returns a presroc formatted transaction reference for the specificed region and transaction type
    *
-   * For example, `_padNumber(3)` will return `000003`.
+   * * The format for presroc is `RAX1999999` where
+   *
+   * - `R` is the region indicator
+   * - `A` is a fixed digit "A", ("Z" for draft type)
+   * - `X` is the transaction type (C or I)
+   * - `1` is a fixed digit "1"
+   * - `999999` is our sequential transaction number padded to a 6-digit numeric string
+   *
+   * For example, if the region was 'R', the next transaction number was 3 and it was for a credit note the reference
+   * would be `RAC1000003`.
+   */
+  static _presrocResponse (region, transactionType, transactionNumber) {
+    return `${region}A${transactionType}1${this._padNumber(transactionNumber, 6)}`
+  }
+
+  /**
+   * Returns an sroc formatted transaction reference for the specificed region and transaction type
+   *
+   * * The format for sroc is `RAX9999999T` where
+   *
+   * - `R` is the region indicator
+   * - `A` is a fixed digit "A", ("Z" for draft type)
+   * - `X` is the transaction type (C or I)
+   * - `9999999` is our sequential transaction number padded to a 7-digit numeric string
+   * - `T` is a fixed digit "T"
+   *
+   * For example, if the region was 'R', the next transaction number was 3 and it was for a credit note the reference
+   * would be `RAC0000003T`.
+   */
+  static _srocResponse (region, transactionType, transactionNumber) {
+    return `${region}A${transactionType}${this._padNumber(transactionNumber, 7)}T`
+  }
+
+  /**
+   * Return a number as a string, padded with leading zeroes to meet the specified length
+   *
+   * For example, `_padNumber(3, 6)` will return `000003`.
+   *
+   * @param {Number} number the number to pad with zeroes
+   * @param {Number} length the overall length required
    *
    * @returns {Number} the number padded with leading zeroes
    */
-  static _padNumber (number) {
-    return number.toString().padStart(6, '0')
+  static _padNumber (number, length) {
+    return number.toString().padStart(length, '0')
   }
 }
 

--- a/db/migrations/20220112115027_alter_sequence_counters.js
+++ b/db/migrations/20220112115027_alter_sequence_counters.js
@@ -1,0 +1,21 @@
+'use strict'
+
+const tableName = 'sequence_counters'
+
+exports.up = async function (knex) {
+  await knex
+    .schema
+    .alterTable(tableName, table => {
+      table.integer('transaction_number_sroc').notNullable().defaultTo(0)
+      table.renameColumn('transaction_number', 'transaction_number_presroc')
+    })
+}
+
+exports.down = async function (knex) {
+  await knex
+    .schema
+    .alterTable(tableName, table => {
+      table.dropColumns('transaction_number_sroc')
+      table.renameColumn('transaction_number_presroc', 'transaction_number')
+    })
+}

--- a/test/services/next_references/next_transaction_reference.service.test.js
+++ b/test/services/next_references/next_transaction_reference.service.test.js
@@ -25,42 +25,83 @@ describe('Next Transaction Reference service', () => {
   })
 
   describe('When a valid region and regime are specified', () => {
-    describe("and the reference is needed for a 'credit note'", () => {
-      it('returns a correctly formatted transaction reference', async () => {
-        const result = await NextTransactionReferenceService.go(regime.id, 'R', 'C')
+    describe("and the ruleset provided is 'presroc'", () => {
+      describe("and the reference is needed for a 'credit note'", () => {
+        it('returns a correctly formatted transaction reference', async () => {
+          const result = await NextTransactionReferenceService.go(regime.id, 'R', 'presroc', 'C')
 
-        expect(result).to.equal('RAC1000001')
+          expect(result).to.equal('RAC1000001')
+        })
+      })
+
+      describe("and the reference is needed for an 'invoice'", () => {
+        it('returns a correctly formatted transaction reference', async () => {
+          const result = await NextTransactionReferenceService.go(regime.id, 'R', 'presroc', 'I')
+
+          expect(result).to.equal('RAI1000001')
+        })
+      })
+
+      describe('the transaction reference generated', () => {
+        it('increments with each call', async () => {
+          const result = await NextTransactionReferenceService.go(regime.id, 'R', 'presroc', 'I')
+          const secondResult = await NextTransactionReferenceService.go(regime.id, 'R', 'presroc', 'C')
+
+          // The call to slice(-1) grabs the last character from the returned string
+          expect(result.endsWith('1')).to.be.true()
+          expect(secondResult.endsWith('2')).to.be.true()
+        })
+
+        it('increments with each call independently for each regime & region', async () => {
+          const otherRegime = await RegimeHelper.addRegime('other', 'Other')
+          await SequenceCounterHelper.addSequenceCounter(otherRegime.id, 'S')
+
+          const result = await NextTransactionReferenceService.go(regime.id, 'R', 'presroc')
+          const otherResult = await NextTransactionReferenceService.go(otherRegime.id, 'S', 'presroc')
+
+          expect(result.endsWith('1')).to.be.true()
+          expect(otherResult.endsWith('1')).to.be.true()
+        })
       })
     })
 
-    describe("and the reference is needed for an 'invoice'", () => {
-      it('returns a correctly formatted transaction reference', async () => {
-        const result = await NextTransactionReferenceService.go(regime.id, 'R', 'I')
+    describe("and the ruleset provided is 'sroc'", () => {
+      describe("and the reference is needed for a 'credit note'", () => {
+        it('returns a correctly formatted transaction reference', async () => {
+          const result = await NextTransactionReferenceService.go(regime.id, 'R', 'sroc', 'C')
 
-        expect(result).to.equal('RAI1000001')
-      })
-    })
-
-    describe('the transaction reference generated', () => {
-      it('increments with each call', async () => {
-        const result = await NextTransactionReferenceService.go(regime.id, 'R', 'I')
-        const secondResult = await NextTransactionReferenceService.go(regime.id, 'R', 'C')
-
-        // The call to slice(-1) grabs the last character from the returned string
-        expect(result.slice(-1)).to.equal('1')
-        expect(secondResult.slice(-1)).to.equal('2')
+          expect(result).to.equal('RAC0000001T')
+        })
       })
 
-      it('increments with each call independently for each regime & region', async () => {
-        const otherRegime = await RegimeHelper.addRegime('other', 'Other')
-        await SequenceCounterHelper.addSequenceCounter(otherRegime.id, 'S')
+      describe("and the reference is needed for an 'invoice'", () => {
+        it('returns a correctly formatted transaction reference', async () => {
+          const result = await NextTransactionReferenceService.go(regime.id, 'R', 'sroc', 'I')
 
-        const result = await NextTransactionReferenceService.go(regime.id, 'R')
-        const otherResult = await NextTransactionReferenceService.go(otherRegime.id, 'S')
+          expect(result).to.equal('RAI0000001T')
+        })
+      })
 
-        // The call to slice(-1) grabs the last character from the returned string
-        expect(result.slice(-1)).to.equal('1')
-        expect(otherResult.slice(-1)).to.equal('1')
+      describe('the transaction reference generated', () => {
+        it('increments with each call', async () => {
+          const result = await NextTransactionReferenceService.go(regime.id, 'R', 'sroc', 'I')
+          const secondResult = await NextTransactionReferenceService.go(regime.id, 'R', 'sroc', 'C')
+
+          // The call to slice(-1) grabs the last character from the returned string
+          expect(result.endsWith('1T')).to.be.true()
+          expect(secondResult.endsWith('2T')).to.be.true()
+        })
+
+        it('increments with each call independently for each regime & region', async () => {
+          const otherRegime = await RegimeHelper.addRegime('other', 'Other')
+          await SequenceCounterHelper.addSequenceCounter(otherRegime.id, 'S')
+
+          const result = await NextTransactionReferenceService.go(regime.id, 'R', 'sroc')
+          const otherResult = await NextTransactionReferenceService.go(otherRegime.id, 'S', 'sroc')
+
+          expect(result.endsWith('1T')).to.be.true()
+          expect(otherResult.endsWith('1T')).to.be.true()
+        })
       })
     })
   })
@@ -68,7 +109,7 @@ describe('Next Transaction Reference service', () => {
   describe('When invalid data is specified', () => {
     it('throws an error for an invalid regime', async () => {
       const err = await expect(
-        NextTransactionReferenceService.go('11111111-1111-1111-1111-111111111111', 'R', 'I')
+        NextTransactionReferenceService.go('11111111-1111-1111-1111-111111111111', 'R', 'presroc', 'I')
       ).to.reject(NotFoundError)
 
       expect(err).to.be.an.error()
@@ -76,8 +117,16 @@ describe('Next Transaction Reference service', () => {
 
     it('throws an error for an invalid region', async () => {
       const err = await expect(
-        NextTransactionReferenceService.go(regime.id, 'X', 'C')
+        NextTransactionReferenceService.go(regime.id, 'X', 'presroc', 'C')
       ).to.reject(NotFoundError)
+
+      expect(err).to.be.an.error()
+    })
+
+    it('throws an error for an invalid ruleset', async () => {
+      const err = await expect(
+        NextTransactionReferenceService.go(regime.id, 'R', 'xxxx', 'C')
+      ).to.reject(TypeError)
 
       expect(err).to.be.an.error()
     })

--- a/test/services/next_references/next_transaction_reference.service.test.js
+++ b/test/services/next_references/next_transaction_reference.service.test.js
@@ -47,7 +47,6 @@ describe('Next Transaction Reference service', () => {
           const result = await NextTransactionReferenceService.go(regime.id, 'R', 'presroc', 'I')
           const secondResult = await NextTransactionReferenceService.go(regime.id, 'R', 'presroc', 'C')
 
-          // The call to slice(-1) grabs the last character from the returned string
           expect(result.endsWith('1')).to.be.true()
           expect(secondResult.endsWith('2')).to.be.true()
         })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/CMEA-220

A transaction reference is assigned to each invoice to be billed when a bill run is `sent`. There is a need for the SROC references to be distinguishable from PRE-SROC. In the [TCM](https://github.com/DEFRA/sroc-tcm-admin) this is done by adding a `T` to the end of the reference.

We've been asked to do the same in the CM. We also need to maintain separate sequences.

So, this change handles updating the sequence counters to allow for a new SROC transaction number sequence.