### PR TITLE
Create SRoC transaction file references

### DIFF
--- a/app/services/bill_runs/send_bill_run_reference.service.js
+++ b/app/services/bill_runs/send_bill_run_reference.service.js
@@ -57,7 +57,7 @@ class SendBillRunReferenceService {
 
       // We only generate a file reference for the bill run if there was 1 or more billable invoices. This avoids gaps
       // in the file references and concern about whether something got lost in transit
-      const fileReference = billableCount ? await NextTransactionFileReferenceService.go(regime, billRun.region, trx) : null
+      const fileReference = billableCount ? await NextTransactionFileReferenceService.go(regime, billRun.region, billRun.ruleset, trx) : null
 
       // We set the status to `sending` to show that we've finished updating the bill run info and it's now being sent
       return BillRunModel.query(trx)

--- a/app/services/files/customers/prepare_customer_file.service.js
+++ b/app/services/files/customers/prepare_customer_file.service.js
@@ -51,7 +51,7 @@ class PrepareCustomerFileService {
    * Obtains the next file reference for the given regime and region
    */
   static async _fileReference (regime, region, trx) {
-    return NextCustomerFileReferenceService.go(regime, region, trx)
+    return NextCustomerFileReferenceService.go(regime, region, null, trx)
   }
 
   /**

--- a/app/services/next_references/base_next_file_reference.service.js
+++ b/app/services/next_references/base_next_file_reference.service.js
@@ -75,7 +75,7 @@ class BaseNextFileReferenceService {
   static _getFilenameSuffix (regimeSlug, ruleset) {
     // We use nullish coalescing to return the value if it exists, or '' if it doesn't. Optional chaining on rulesets
     // means we don't error if an invalid ruleset is passed in (which would be the case if no ruleset was passed to the
-    // service so we defaulted to `null`
+    // service so we defaulted to `null`)
     return RulesServiceConfig.endpoints[regimeSlug].rulesets[ruleset]?.filenameSuffix ?? ''
   }
 

--- a/app/services/next_references/base_next_file_reference.service.js
+++ b/app/services/next_references/base_next_file_reference.service.js
@@ -55,8 +55,8 @@ class BaseNextFileReferenceService {
   }
 
   static _response (regimeSlug, region, ruleset, fileNumber) {
-    const filenamePrefix = BaseNextFileReferenceService._getFilenamePrefix(regimeSlug)
-    const filenameSuffix = BaseNextFileReferenceService._getFilenameSuffix(regimeSlug, ruleset)
+    const filenamePrefix = this._getFilenamePrefix(regimeSlug)
+    const filenameSuffix = this._getFilenameSuffix(regimeSlug, ruleset)
 
     return `${filenamePrefix}${region.toLowerCase()}${this._fileFixedChar()}${fileNumber}${filenameSuffix}`
   }

--- a/app/services/next_references/next_customer_file_reference.service.js
+++ b/app/services/next_references/next_customer_file_reference.service.js
@@ -7,16 +7,26 @@
 const BaseNextFileReferenceService = require('./base_next_file_reference.service')
 
 /**
- * Returns the next customer file reference for the given region and regime, in the format `nalrc50001`. See
- * `BaseNextFileReferenceService` for further details.
+ * Returns the next customer file reference for the given region and regime, in the format `nalrc50001` where:
+ *
+ * - `nal` is the filename prefix for the regime (set in `RulesServiceConfig`)
+ * - `r` is the region lowercased
+ * - `c` is a fixed character for customer files
+ * - `50001` is our sequential file number padded which starts at 50000
+ *
+ * For example, if the regime was WRLS, the region was 'R' and the next file number was 3 then the customer file
+ * reference would be `nalrc50003`.
  */
+
 class NextCustomerFileReferenceService extends BaseNextFileReferenceService {
   static _field () {
     return 'customerFileNumber'
   }
 
-  static _fileFixedChar () {
-    return 'c'
+  static _response (regimeSlug, region, _ruleset, fileNumber) {
+    const filenamePrefix = this._getFilenamePrefix(regimeSlug)
+
+    return `${filenamePrefix}${region.toLowerCase()}c${fileNumber}`
   }
 }
 

--- a/app/services/next_references/next_transaction_file_reference.service.js
+++ b/app/services/next_references/next_transaction_file_reference.service.js
@@ -5,18 +5,55 @@
  */
 
 const BaseNextFileReferenceService = require('./base_next_file_reference.service')
+const StaticLookupLib = require('../../lib/static_lookup.lib')
 
 /**
- * Returns the next transaction file reference for the given region and regime, in the format `nalri50001`. See
- * `BaseNextFileReferenceService` for further details.
+ * Returns the next customer file reference for the given region, regime and ruleset, in the format `nalri50001t` where:
+ *
+ * - `nal` is the filename prefix for the regime (set in `RulesServiceConfig`)
+ * - `r` is the region lowercased
+ * - `i` is a fixed character for transaction files
+ * - `50001` is our sequential file number padded which starts at 50000
+ * - `t` is an optional suffix, which is only present for sroc transaction files
+ *
+ * For example, if the regime was WRLS, the region was 'R', the ruleset was sroc and the next file number was 3 then the
+ * transaction file reference would be `nalri50003t`. If the ruleset was presroc then the reference would be
+ * `nalri50003` without the `t` suffix.
+ *
+ * If an invalid ruleset has been supplied, a `TypeError` will be thrown.
  */
+
 class NextTransactionFileReferenceService extends BaseNextFileReferenceService {
   static _field () {
     return 'transactionFileNumber'
   }
 
-  static _fileFixedChar () {
-    return 'i'
+  static _response (regimeSlug, region, ruleset, fileNumber) {
+    if (!StaticLookupLib.rulesets.includes(ruleset)) {
+      throw new TypeError(`Invalid ruleset ${ruleset}`)
+    }
+
+    const filenamePrefix = this._getFilenamePrefix(regimeSlug)
+
+    if (ruleset === 'sroc') {
+      return this._srocResponse(filenamePrefix, region, fileNumber)
+    }
+
+    return this._presrocResponse(filenamePrefix, region, fileNumber)
+  }
+
+  /**
+   * Returns an sroc response, eg. `nalri50003t`
+   */
+  static _srocResponse (filenamePrefix, region, fileNumber) {
+    return `${filenamePrefix}${region.toLowerCase()}i${fileNumber}t`
+  }
+
+  /**
+   * Returns a presroc response, eg. `nalri50003`
+   */
+  static _presrocResponse (filenamePrefix, region, fileNumber) {
+    return `${filenamePrefix}${region.toLowerCase()}i${fileNumber}`
   }
 }
 

--- a/config/rules_service.config.js
+++ b/config/rules_service.config.js
@@ -56,7 +56,8 @@ const config = {
         },
         sroc: {
           application: process.env.WRLS_SROC_APP,
-          ruleset: process.env.WRLS_SROC_RULESET
+          ruleset: process.env.WRLS_SROC_RULESET,
+          filenameSuffix: 't'
         }
       }
     }

--- a/config/rules_service.config.js
+++ b/config/rules_service.config.js
@@ -56,8 +56,7 @@ const config = {
         },
         sroc: {
           application: process.env.WRLS_SROC_APP,
-          ruleset: process.env.WRLS_SROC_RULESET,
-          filenameSuffix: 't'
+          ruleset: process.env.WRLS_SROC_RULESET
         }
       }
     }

--- a/test/services/bill_runs/send_bill_run_reference.service.test.js
+++ b/test/services/bill_runs/send_bill_run_reference.service.test.js
@@ -71,12 +71,25 @@ describe('Send Bill Run Reference service', () => {
       expect(sentBillRun.status).to.equal('sending')
     })
 
-    it('generates a file reference for the bill run', async () => {
-      // A bill run needs at least one billable invoice for a file reference to be generated
-      await InvoiceHelper.addInvoice(billRun.id, 'CMA0000001', 2020, 0, 0, 1, 501, 0) // standard debit
-      const sentBillRun = await SendBillRunReferenceService.go(regime, billRun)
+    describe('generates a file reference for the bill run', () => {
+      beforeEach(async () => {
+        // A bill run needs at least one billable invoice for a file reference to be generated
+        await InvoiceHelper.addInvoice(billRun.id, 'CMA0000001', 2020, 0, 0, 1, 501, 0) // standard debit
+      })
 
-      expect(sentBillRun.fileReference).to.equal('nalai50001')
+      it('for presroc', async () => {
+        const sentBillRun = await SendBillRunReferenceService.go(regime, billRun)
+
+        expect(sentBillRun.fileReference).to.equal('nalai50001')
+      })
+
+      it('for sroc', async () => {
+        billRun.ruleset = 'sroc'
+
+        const sentBillRun = await SendBillRunReferenceService.go(regime, billRun)
+
+        expect(sentBillRun.fileReference).to.equal('nalai50001t')
+      })
     })
 
     describe('for each invoice linked to the bill run', () => {

--- a/test/services/next_references/base_next_file_reference.service.test.js
+++ b/test/services/next_references/base_next_file_reference.service.test.js
@@ -22,12 +22,12 @@ describe('Base Next File Reference service', () => {
       expect(throws).to.throw("Extending service must implement '_field()'")
     })
 
-    it("must override the '_fileFixedChar()' method", () => {
+    it("must override the '_response()' method", () => {
       const throws = () => {
-        TestService._fileFixedChar()
+        TestService._response()
       }
 
-      expect(throws).to.throw("Extending service must implement '_fileFixedChar()'")
+      expect(throws).to.throw("Extending service must implement '_response()'")
     })
   })
 })

--- a/test/services/next_references/next_transaction_file_reference.service.test.js
+++ b/test/services/next_references/next_transaction_file_reference.service.test.js
@@ -26,42 +26,46 @@ describe('Next Transaction File Reference service', () => {
 
   describe('When a valid region and regime are specified', () => {
     it('returns a correctly formatted file reference', async () => {
-      const result = await NextTransactionFileReferenceService.go(regime, 'R')
+      const result = await NextTransactionFileReferenceService.go(regime, 'R', 'presroc')
 
       expect(result).to.equal('nalri50001')
     })
 
     describe('the file reference generated', () => {
       it('increments with each call', async () => {
-        const result = await NextTransactionFileReferenceService.go(regime, 'R')
-        const secondResult = await NextTransactionFileReferenceService.go(regime, 'R')
+        const result = await NextTransactionFileReferenceService.go(regime, 'R', 'presroc')
+        const secondResult = await NextTransactionFileReferenceService.go(regime, 'R', 'presroc')
 
-        // The call to slice(-1) grabs the last character from the returned string
-        expect(result.slice(-1)).to.equal('1')
-        expect(secondResult.slice(-1)).to.equal('2')
+        expect(result).endsWith('1')
+        expect(secondResult).endsWith('2')
       })
 
-      it('increments with each call independently for each regime & region', async () => {
+      it('increments with each call independently for each regime, region and ruleset', async () => {
         const otherRegime = await RegimeHelper.addRegime('cfd', 'CFD')
         await SequenceCounterHelper.addSequenceCounter(otherRegime.id, 'S')
 
-        const result = await NextTransactionFileReferenceService.go(regime, 'R')
+        const result = await NextTransactionFileReferenceService.go(regime, 'R', 'presroc')
         const otherResult = await NextTransactionFileReferenceService.go(otherRegime, 'S')
 
-        // The call to slice(-1) grabs the last character from the returned string
-        expect(result.slice(-1)).to.equal('1')
-        expect(otherResult.slice(-1)).to.equal('1')
+        expect(result).endsWith('1')
+        expect(otherResult).endsWith('1')
       })
 
       it('has a prefix specific to the regime', async () => {
         const otherRegime = await RegimeHelper.addRegime('cfd', 'CFD')
         await SequenceCounterHelper.addSequenceCounter(otherRegime.id, 'S')
 
-        const result = await NextTransactionFileReferenceService.go(regime, 'R')
+        const result = await NextTransactionFileReferenceService.go(regime, 'R', 'presroc')
         const otherResult = await NextTransactionFileReferenceService.go(otherRegime, 'S')
 
         expect(result).startsWith('nal')
         expect(otherResult).startsWith('cfd')
+      })
+
+      it('has the correct suffix for a ruleset', async () => {
+        const result = await NextTransactionFileReferenceService.go(regime, 'R', 'sroc')
+
+        expect(result).endsWith('t')
       })
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/projects/CMEA/boards/907?selectedIssue=CMEA-221

Currently, presroc transaction files have a filename in the format `nalri50001`. We want sroc transaction files to have a filename in the format `nalri50001t`, ie. with a `t` suffix. However, we want the sroc and presroc sequences to be continuous, ie. `nalri50001t` would be followed by either `nalri50002` or `nalri50002t`, which would be followed by either `nalri50003` or `nalri50003t`, etc.

We implement this as follows:

- We update `BaseNextFileReferenceService` to no longer have a generic filename template in `_response()`, but instead expect services that extend it to provide their own `_response()` method;
- We add a `_response()` method to `NextTransactionFileReferenceService` which checks whether the ruleset is sroc or presroc and returns the appropriate filename;
- We also add a `_response()` method to `NextCustomerFileReferenceService` to return the expected filename format for customer files.