### PR TITLE
Create v3 send bill run route

### DIFF
--- a/app/routes/bill_run.routes.js
+++ b/app/routes/bill_run.routes.js
@@ -55,6 +55,11 @@ const routes = [
     handler: BillRunsController.send
   },
   {
+    method: 'PATCH',
+    path: '/v3/{regimeSlug}/bill-runs/{billRunId}/send',
+    handler: BillRunsController.send
+  },
+  {
     method: 'GET',
     path: '/v2/{regimeSlug}/bill-runs/{billRunId}/status',
     handler: BillRunsController.status


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/CMEA-239

Since we are not changing the behaviour of the send bill run endpoint, we simply create a new route `PATCH /v3/{regimeSlug}/bill-runs/{billRunId}/send` and point it to the existing controller.