### PR TITLE
Create v3 Post customer changes route

### DIFF
--- a/app/routes/customer_details.routes.js
+++ b/app/routes/customer_details.routes.js
@@ -15,6 +15,11 @@ const routes = [
     method: 'POST',
     path: '/v2/{regimeSlug}/customer-changes',
     handler: CustomerDetailsController.create
+  },
+  {
+    method: 'POST',
+    path: '/v3/{regimeSlug}/customer-changes',
+    handler: CustomerDetailsController.create
   }
 ]
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/CMEA-262

Since we are not changing the behaviour of the v3 customer changes endpoint, we simply create a new route `POST /v3/{regimeSlug}/customer-changes` and point it to the existing controller.