### PR TITLE
Revert presroc `regionalChargingArea` validation change

### DIFF
--- a/app/translators/calculate_charge_base.translator.js
+++ b/app/translators/calculate_charge_base.translator.js
@@ -29,9 +29,6 @@ class CalculateChargeBaseTranslator extends BaseTranslator {
         .when('compensationCharge', { is: true, then: Joi.required() }),
       twoPartTariff: Joi.boolean().required()
         .when('compensationCharge', { is: true, then: Joi.equal(false) }),
-      // Case-insensitive validation matches and returns the correctly-capitalised string
-      regionalChargingArea: this._validateStringAgainstList(this._validRegionalChargingAreas())
-        .when('compensationCharge', { is: true, then: Joi.required() }),
 
       // Dependent on `twoPartTariff`
       section127Agreement: Joi.boolean().required()

--- a/app/translators/calculate_charge_presroc.translator.js
+++ b/app/translators/calculate_charge_presroc.translator.js
@@ -36,6 +36,7 @@ class CalculateChargePresrocTranslator extends CalculateChargeBaseTranslator {
         .when('compensationCharge', { is: true, then: Joi.required() }),
 
       // Case-insensitive validation matches and returns the correctly-capitalised string
+      regionalChargingArea: this._validateStringAgainstList(this._validRegionalChargingAreas()).required(),
       source: this._validateStringAgainstList(this._validSources()).required(),
       season: this._validateStringAgainstList(this._validSeasons()).required()
     }

--- a/app/translators/calculate_charge_sroc.translator.js
+++ b/app/translators/calculate_charge_sroc.translator.js
@@ -41,6 +41,10 @@ class CalculateChargeSrocTranslator extends CalculateChargeBaseTranslator {
         // If `false` then this should be undefined (ie. not present) and we set the value as `Not Applicable`
         .when('supportedSource', { is: false, then: Joi.forbidden().default('Not Applicable') }),
 
+      // Dependent on `compensationCharge` and case-insensitive to return the correctly-capitalised string
+      regionalChargingArea: this._validateStringAgainstList(this._validRegionalChargingAreas())
+        .when('compensationCharge', { is: true, then: Joi.required() }),
+
       // Validated by the rules service
       chargeCategoryCode: Joi.string().required()
     }

--- a/test/translators/calculate_charge_presroc.translator.test.js
+++ b/test/translators/calculate_charge_presroc.translator.test.js
@@ -417,14 +417,27 @@ describe('Calculate Charge Presroc translator', () => {
         })
       })
 
-      describe('because regionalChargingArea is not valid', () => {
-        it('throws an error', async () => {
-          const invalidPayload = {
-            ...payload,
-            regionalChargingArea: 'INVALID'
-          }
+      describe('because regionalChargingArea', () => {
+        describe('is not valid', () => {
+          it('throws an error', async () => {
+            const invalidPayload = {
+              ...payload,
+              regionalChargingArea: 'INVALID'
+            }
 
-          expect(() => new CalculateChargePresrocTranslator(data(invalidPayload))).to.throw(ValidationError)
+            expect(() => new CalculateChargePresrocTranslator(data(invalidPayload))).to.throw(ValidationError)
+          })
+        })
+
+        describe('is missing', () => {
+          it('throws an error', async () => {
+            const invalidPayload = {
+              ...payload
+            }
+            delete invalidPayload.regionalChargingArea
+
+            expect(() => new CalculateChargePresrocTranslator(data(invalidPayload))).to.throw(ValidationError)
+          })
         })
       })
 


### PR DESCRIPTION
We previously changed the charge validation for the field `regionalChargingArea` as part of our work to bring presroc validation in line with sroc, by making the field optional if `compensationCharge` is set to `false`. This was done on the basis that this isn't part of the charge calculation for either ruleset, and therefore doesn't need to be sent to the Rules Service.

However, it turns out that the Rules Service still requires `regionalChargingArea` in order to calculate the `sucFactor` of a presroc charge, and therefore presroc requests will fail if this field isn't present. Note that `sucFactor` is not part of sroc, so is still optional for that ruleset.

We therefore revert our previous change and make `regionalChargingArea` a required field for presroc, regardless of `compensationCharge`.