### PR TITLE
Validate new bill run status when rebilling

### DIFF
--- a/app/services/invoices/invoice_rebilling_validation.service.js
+++ b/app/services/invoices/invoice_rebilling_validation.service.js
@@ -14,6 +14,7 @@ class InvoiceRebillingValidationService {
   * - The invoice does not already belong to the bill run it is being rebilled to;
   * - The invoice is not already subject to a rebilling request;
   * - The status of its current bill run is 'billed';
+  * - The status of the new bill run is an editable status (ie. it is not 'pending', 'billed', etc.);
   * - The region of the bill run it is being rebilled to matches the region of its current bill run;
   * - It is not a rebill cancel invoice.
   *
@@ -31,6 +32,7 @@ class InvoiceRebillingValidationService {
     this._validateNotOnNewBillRun(currentBillRun, newBillRun, invoice.id)
     await this._validateNotCurrentlyRebilled(invoice.id)
     this._validateCurrentBillRunStatus(currentBillRun)
+    this._validateNewBillRunStatus(newBillRun)
     this._validateRegion(currentBillRun, newBillRun, invoice.id)
     this._validateNotCancelInvoice(invoice)
 
@@ -60,6 +62,12 @@ class InvoiceRebillingValidationService {
   static _validateCurrentBillRunStatus (billRun) {
     if (!billRun.$billed()) {
       throw Boom.conflict(`Bill run ${billRun.id} does not have a status of 'billed'.`)
+    }
+  }
+
+  static _validateNewBillRunStatus (billRun) {
+    if (!billRun.$editable()) {
+      throw Boom.conflict(`Bill run ${billRun.id} does not have an editable status.`)
     }
   }
 

--- a/test/services/invoices/invoice_rebilling_validation.service.test.js
+++ b/test/services/invoices/invoice_rebilling_validation.service.test.js
@@ -154,5 +154,21 @@ describe('Invoice Rebilling Validation service', () => {
         )
       })
     })
+
+    describe('because its status is not an editable status', () => {
+      it('throws an error', async () => {
+        const invalidNewBillRun = await BillRunHelper.addBillRun(authorisedSystem.id, regime.id, 'A', 'billed')
+        const invoice = await InvoiceHelper.addInvoice(currentBillRun.id, 'CUSTOMER REFERENCE', 2020)
+
+        const err = await expect(
+          InvoiceRebillingValidationService.go(invalidNewBillRun, invoice)
+        ).to.reject()
+
+        expect(err).to.be.an.error()
+        expect(err.output.payload.message).to.equal(
+          `Bill run ${invalidNewBillRun.id} does not have an editable status.`
+        )
+      })
+    })
   })
 })


### PR DESCRIPTION
When an invoice is rebilled onto a new bill run, we should have been validating that the new bill run's status is an "editable" status (ie. `initialised` or `generated`). We therefore update `InvoiceRebillingValidationService` to check this.