### PR TITLE
Rebilling SRoC support and v3 route

### DIFF
--- a/app/routes/bill_run_invoice.routes.js
+++ b/app/routes/bill_run_invoice.routes.js
@@ -27,6 +27,11 @@ const routes = [
     method: 'PATCH',
     path: '/v2/{regimeSlug}/bill-runs/{billRunId}/invoices/{invoiceId}/rebill',
     handler: BillRunsInvoicesController.rebill
+  },
+  {
+    method: 'PATCH',
+    path: '/v3/{regimeSlug}/bill-runs/{billRunId}/invoices/{invoiceId}/rebill',
+    handler: BillRunsInvoicesController.rebill
   }
 ]
 

--- a/app/services/invoices/invoice_rebilling_validation.service.js
+++ b/app/services/invoices/invoice_rebilling_validation.service.js
@@ -32,6 +32,7 @@ class InvoiceRebillingValidationService {
     await this._validateNotCurrentlyRebilled(invoice.id)
     this._validateCurrentBillRunStatus(currentBillRun)
     this._validateRegion(currentBillRun, newBillRun, invoice.id)
+    this._validateRuleset(currentBillRun, newBillRun, invoice.id)
     this._validateNotCancelInvoice(invoice)
 
     return true
@@ -67,6 +68,14 @@ class InvoiceRebillingValidationService {
     if (currentBillRun.region !== newBillRun.region) {
       throw Boom.conflict(
           `Invoice ${invoiceId} is for region ${currentBillRun.region} but bill run ${newBillRun.id} is for region ${newBillRun.region}.`
+      )
+    }
+  }
+
+  static _validateRuleset (currentBillRun, newBillRun, invoiceId) {
+    if (currentBillRun.ruleset !== newBillRun.ruleset) {
+      throw Boom.conflict(
+          `Invoice ${invoiceId} is for ruleset ${currentBillRun.ruleset} but bill run ${newBillRun.id} is for ruleset ${newBillRun.ruleset}.`
       )
     }
   }

--- a/test/services/invoices/invoice_rebilling_validation.service.test.js
+++ b/test/services/invoices/invoice_rebilling_validation.service.test.js
@@ -154,5 +154,21 @@ describe('Invoice Rebilling Validation service', () => {
         )
       })
     })
+
+    describe("because its ruleset does not match the invoice's current ruleset", () => {
+      it('throws an error', async () => {
+        const invalidNewBillRun = await BillRunHelper.addBillRun(authorisedSystem.id, regime.id, 'A', 'initialised', 'sroc')
+        const invoice = await InvoiceHelper.addInvoice(currentBillRun.id, 'CUSTOMER REFERENCE', 2020)
+
+        const err = await expect(
+          InvoiceRebillingValidationService.go(invalidNewBillRun, invoice)
+        ).to.reject()
+
+        expect(err).to.be.an.error()
+        expect(err.output.payload.message).to.equal(
+          `Invoice ${invoice.id} is for ruleset presroc but bill run ${invalidNewBillRun.id} is for ruleset sroc.`
+        )
+      })
+    })
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/projects/CMEA/boards/907?selectedIssue=CMEA-244

The only change we need to allow rebilling to support sroc is to add validation that ensures the invoice being rebilled has the same ruleset as the bill run it is being rebilled to. We therefore update `InvoiceRebillingValidationService` to do this.

After adding this validation, we then create a v3 route and point it to the existing controller.