### PR TITLE
Remove sroc deminimis limit

### DIFF
--- a/app/lib/static_lookup.lib.js
+++ b/app/lib/static_lookup.lib.js
@@ -19,7 +19,8 @@ class StaticLookupLib {
   static get deminimisLimits () {
     return {
       presroc: 500,
-      sroc: 1000
+      // Deminimis is no longer part of sroc so we disable it by setting a 0 deminimis limit
+      sroc: 0
     }
   }
 }

--- a/test/models/bill_run.model.test.js
+++ b/test/models/bill_run.model.test.js
@@ -171,27 +171,17 @@ describe('Bill Run Model', () => {
     })
 
     describe('for an sroc bill run', () => {
-      let firstDeminimisInvoice
-      let secondDeminimisInvoice
-
       beforeEach(async () => {
         deminimisBillRun = await NewBillRunHelper.create(null, null, { ruleset: 'sroc' })
 
-        // Add a deminimis invoice to the bill run (value of 400 is within the deminimis limit)
-        firstDeminimisInvoice = await NewInvoiceHelper.create(deminimisBillRun, { customerReference: 'DEM_1', debitLineValue: 500, creditLineValue: 100 })
-        // Add a deminimis invoice to the bill run (value of 900 is within the sroc deminimis limit)
-        secondDeminimisInvoice = await NewInvoiceHelper.create(deminimisBillRun, { customerReference: 'DEM_2', debitLineValue: 1000, creditLineValue: 100 })
-        // Add a non-deminimis invoice (value of 1500 is over both presroc and sroc deminimis limits)
-        await NewInvoiceHelper.create(deminimisBillRun, { customerReference: 'NOT_DEM_1', debitLineValue: 1500 })
-        // Add a non-deminimis invoice (value is within deminimis limit but rebill invoices are not subject to deminimis)
-        await NewInvoiceHelper.create(deminimisBillRun, { customerReference: 'NOT_DEM_2', debitLineValue: 500, creditLineValue: 100, rebilledType: 'R' })
+        // Add an invoice with the smallest possible value of a penny to show deminimis is not being applied
+        await NewInvoiceHelper.create(deminimisBillRun, { customerReference: 'NOT_DEM_1', debitLineValue: 1 })
       })
 
-      it('returns all invoices which are deminimis', async () => {
+      it('returns no invoices as sroc is not subject to deminimis', async () => {
         const result = await deminimisBillRun.$deminimisInvoices()
 
-        expect(result.length).to.equal(2)
-        expect(result).to.only.contain([firstDeminimisInvoice, secondDeminimisInvoice])
+        expect(result.length).to.equal(0)
       })
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/projects/CMEA/boards/907?selectedIssue=CMEA-256

We disable deminimis for sroc by setting the deminimis limit to `0`. We also update unit tests to demonstrate that even the smallest invoice is not identified as deminimis for sroc.