### PR TITLE
Develop sroc transaction file body presenter

### DIFF
--- a/app/presenters/index.js
+++ b/app/presenters/index.js
@@ -15,8 +15,8 @@ const ListCustomerFilesPresenter = require('./list_customer_files.presenter')
 const RulesServicePresrocPresenter = require('./rules_service_presroc.presenter')
 const RulesServiceSrocPresenter = require('./rules_service_sroc.presenter')
 const TableFilePresenter = require('./table_file.presenter')
-const TransactionFileBodyPresenter = require('./transaction_file_body.presenter')
 const TransactionFileHeadPresenter = require('./transaction_file_head.presenter')
+const TransactionFilePresrocBodyPresenter = require('./transaction_file_presroc_body.presenter')
 const TransactionFileTailPresenter = require('./transaction_file_tail.presenter')
 const ViewBillRunPresenter = require('./view_bill_run.presenter')
 const ViewBillRunInvoicePresenter = require('./view_bill_run_invoice.presenter')
@@ -40,8 +40,8 @@ module.exports = {
   RulesServicePresrocPresenter,
   RulesServiceSrocPresenter,
   TableFilePresenter,
-  TransactionFileBodyPresenter,
   TransactionFileHeadPresenter,
+  TransactionFilePresrocBodyPresenter,
   TransactionFileTailPresenter,
   ViewBillRunPresenter,
   ViewBillRunInvoicePresenter,

--- a/app/presenters/index.js
+++ b/app/presenters/index.js
@@ -17,6 +17,7 @@ const RulesServiceSrocPresenter = require('./rules_service_sroc.presenter')
 const TableFilePresenter = require('./table_file.presenter')
 const TransactionFileHeadPresenter = require('./transaction_file_head.presenter')
 const TransactionFilePresrocBodyPresenter = require('./transaction_file_presroc_body.presenter')
+const TransactionFileSrocBodyPresenter = require('./transaction_file_sroc_body.presenter')
 const TransactionFileTailPresenter = require('./transaction_file_tail.presenter')
 const ViewBillRunPresenter = require('./view_bill_run.presenter')
 const ViewBillRunInvoicePresenter = require('./view_bill_run_invoice.presenter')
@@ -42,6 +43,7 @@ module.exports = {
   TableFilePresenter,
   TransactionFileHeadPresenter,
   TransactionFilePresrocBodyPresenter,
+  TransactionFileSrocBodyPresenter,
   TransactionFileTailPresenter,
   ViewBillRunPresenter,
   ViewBillRunInvoicePresenter,

--- a/app/presenters/transaction_file_presroc_body.presenter.js
+++ b/app/presenters/transaction_file_presroc_body.presenter.js
@@ -1,13 +1,13 @@
 'use strict'
 
 /**
- * @module TransactionFileBodyPresenter
+ * @module TransactionFilePresrocBodyPresenter
  */
 
 const BasePresenter = require('./base.presenter')
 
 /**
- * Formats data for the body of a transaction file.
+ * Formats data for the body of a presroc transaction file.
  *
  * Note that data.index and data.transactionReference are added by StreamTransformUsingPresenter and are not part of the
  * data originally read from the source transaction record.
@@ -16,7 +16,7 @@ const BasePresenter = require('./base.presenter')
  * https://github.com/DEFRA/charging-module-api/blob/main/app/schema/pre_sroc/wrls/transaction_file_presenter.js
  */
 
-class TransactionFileBodyPresenter extends BasePresenter {
+class TransactionFilePresrocBodyPresenter extends BasePresenter {
   _presentation (data) {
     return {
       col01: 'D',
@@ -112,4 +112,4 @@ class TransactionFileBodyPresenter extends BasePresenter {
   }
 }
 
-module.exports = TransactionFileBodyPresenter
+module.exports = TransactionFilePresrocBodyPresenter

--- a/app/presenters/transaction_file_sroc_body.presenter.js
+++ b/app/presenters/transaction_file_sroc_body.presenter.js
@@ -1,0 +1,115 @@
+'use strict'
+
+/**
+ * @module TransactionFileSrocBodyPresenter
+ */
+
+const BasePresenter = require('./base.presenter')
+
+/**
+ * Formats data for the body of an sroc transaction file.
+ *
+ * Note that data.index and data.transactionReference are added by StreamTransformUsingPresenter and are not part of the
+ * data originally read from the source transaction record.
+ *
+ * With reference to the existing v1 charging module transaction file presenter:
+ * https://github.com/DEFRA/charging-module-api/blob/main/app/schema/pre_sroc/wrls/transaction_file_presenter.js
+ */
+
+class TransactionFileSrocBodyPresenter extends BasePresenter {
+  _presentation (data) {
+    return {
+      col01: 'D',
+      col02: this._leftPadZeroes(data.index, 7),
+      col03: data.customerReference,
+      col04: this._formatDate(Date.now()),
+      col05: this._invoiceType(data.debitLineValue, data.creditLineValue),
+      col06: data.transactionReference,
+      col07: '',
+      col08: 'GBP',
+      col09: '',
+      col10: this._formatDate(Date.now()),
+      col11: '',
+      col12: '',
+      col13: '',
+      col14: '',
+      col15: '',
+      col16: '',
+      col17: '',
+      col18: '',
+      col19: '',
+      col20: this._signedCreditValue(data.chargeValue, data.chargeCredit),
+      col21: '',
+      col22: data.lineAreaCode,
+      col23: data.lineDescription,
+      col24: 'A',
+      col25: '',
+      col26: this._blankIfCompensationCharge(data.lineAttr1, data),
+      col27: this._blankIfCompensationChargeOrMinimumCharge(data.lineAttr2, data),
+      col28: this._blankIfCompensationChargeOrMinimumCharge(data.lineAttr3, data),
+      col29: this._blankIfCompensationChargeOrMinimumCharge(data.lineAttr4, data),
+      col30: this._blankIfCompensationChargeOrMinimumCharge(this._volumeInMegaLitres(data.lineAttr5), data),
+      col31: this._blankIfCompensationChargeOrMinimumCharge(data.lineAttr6, data),
+      col32: this._blankIfCompensationChargeOrMinimumCharge(data.lineAttr7, data),
+      col33: this._blankIfCompensationChargeOrMinimumCharge(data.lineAttr8, data),
+      col34: this._blankIfCompensationChargeOrMinimumCharge(this._cleanseNull(data.lineAttr9), data),
+      col35: this._blankIfCompensationChargeOrMinimumCharge(this._cleanseNull(data.lineAttr10), data),
+      col36: '',
+      col37: '',
+      col38: this._blankIfNotCompensationCharge(data.lineAttr13, data),
+      col39: this._blankIfNotCompensationCharge(data.lineAttr14, data),
+      col40: '',
+      col41: '1',
+      col42: 'Each',
+      col43: this._signedCreditValue(data.chargeValue, data.chargeCredit)
+    }
+  }
+
+  /**
+   * Returns 'C' if the invoice is a credit and 'I' if the invoice is a debit
+   */
+  _invoiceType (debit, credit) {
+    return debit - credit < 0 ? 'C' : 'I'
+  }
+
+  /**
+   * Several fields rely on whether or not this transaction is a compensation charge. This is held in regimeValue17 as a
+   * string so we add a helper function to return it as a boolean.
+   */
+  _compensationCharge (data) {
+    // We don't expect to store anything other than lower case but we change case just to be safe. We use optional
+    // chaining as regimeValue17 is null for minimum charge transactions.
+    return data.regimeValue17?.toLowerCase() === 'true'
+  }
+
+  /**
+   * Returns an empty string if this is a compensation charge
+   */
+  _blankIfCompensationCharge (value, data) {
+    return this._compensationCharge(data) ? '' : value
+  }
+
+  /**
+   * Returns an empty string if this is a compensation charge
+   * Also returns an empty string if this is a minimum charge adjustment
+   */
+  _blankIfCompensationChargeOrMinimumCharge (value, data) {
+    return this._compensationCharge(data) || data.minimumChargeAdjustment ? '' : value
+  }
+
+  /**
+   * Returns an empty string if this is not a compensation charge
+   */
+  _blankIfNotCompensationCharge (value, data) {
+    return this._compensationCharge(data) ? value : ''
+  }
+
+  /**
+   * Returns the provided value with ' Ml' appended.
+   */
+  _volumeInMegaLitres (value) {
+    return `${value} Ml`
+  }
+}
+
+module.exports = TransactionFileSrocBodyPresenter

--- a/app/presenters/transaction_file_sroc_body.presenter.js
+++ b/app/presenters/transaction_file_sroc_body.presenter.js
@@ -11,9 +11,6 @@ const BasePresenter = require('./base.presenter')
  *
  * Note that data.index and data.transactionReference are added by StreamTransformUsingPresenter and are not part of the
  * data originally read from the source transaction record.
- *
- * With reference to the existing v1 charging module transaction file presenter:
- * https://github.com/DEFRA/charging-module-api/blob/main/app/schema/pre_sroc/wrls/transaction_file_presenter.js
  */
 
 class TransactionFileSrocBodyPresenter extends BasePresenter {
@@ -97,14 +94,7 @@ class TransactionFileSrocBodyPresenter extends BasePresenter {
   }
 
   /**
-   * Returns the provided value with ' Ml' appended.
-   */
-  _volumeInMegaLitres (value) {
-    return `${value} Ml`
-  }
-
-  /**
-   * Returns a list of reductions
+   * Returns a string containing a list of reductions, separated with commas
    */
   _reductionsList (data) {
     const reductions = []
@@ -133,55 +123,40 @@ class TransactionFileSrocBodyPresenter extends BasePresenter {
   }
 
   /**
-   * TODO: REFACTOR THE BELOW INTO A SINGLE "POPULATE IF TRUE" METHOD
+   * Returns `supportedSourceValue, supportedSourceName` if supportedSource is true or blank string if false
    */
-
   _supportedSource (data) {
-    // If supportedSource is false then return blank
-    if (this._isFalse(data.headerAttr5)) {
-      return ''
-    }
-
-    // Otherwise, return supportedSourceValue and supportedSourceName
-    return `${data.lineAttr11}, ${data.headerAttr6}`
+    return this._isTrue(data.headerAttr5) ? `${data.lineAttr11}, ${data.headerAttr6}` : ''
   }
 
+  /**
+   * Returns `actualVolume / authorisedVolume Ml` if twoPartTariff is true or blank string if false
+   */
   _volume (data) {
-    // If twoPartTariff is false then return blank
-    if (this._isFalse(data.regimeValue16)) {
-      return ''
-    }
-
-    // Otherwise, return actualVolume and authorisedVolume
-    return `${data.regimeValue20} / ${data.headerAttr3} Ml`
+    return this._isTrue(data.regimeValue16) ? `${data.regimeValue20} / ${data.headerAttr3} Ml` : ''
   }
 
-  // If waterCompanyCharge is `true` then this is waterCompanyChargeValue
+  /**
+   * Returns `waterCompanyChargeValue` if waterCompanyCharge is true or blank string if false
+   */
   _waterCompany (data) {
-    // If waterCompanyCharge is `false` then return blank
-    if (this._isFalse(data.headerAttr7)) {
-      return ''
-    }
-
-    // Otherwise, return waterCompanyChargeValue
-    return data.headerAttr10
+    return this._isTrue(data.headerAttr7) ? data.headerAttr10 : ''
   }
 
+  /**
+   * Returns `compensationChargePercent% (regionalChargingArea)`
+   */
   _compensationChargeAndRegion (data) {
     return `${data.regimeValue2}% (${data.regimeValue15})`
   }
 
   /**
-   * Convenience methods to determine if a boolean stored as a string is true or false
+   * Convenience method to determine if a boolean stored as a string is true
    */
   _isTrue (field) {
     // We don't expect to store anything other than lower case but we change case just to be safe. We use optional
     // chaining to avoid issues if field is `null`
     return field?.toLowerCase() === 'true'
-  }
-
-  _isFalse (field) {
-    return !this._isTrue(field)
   }
 }
 

--- a/app/services/files/transactions/generate_presroc_transaction_file.service.js
+++ b/app/services/files/transactions/generate_presroc_transaction_file.service.js
@@ -7,7 +7,7 @@
 const BaseGenerateTransactionFileService = require('./base_generate_transaction_file.service')
 
 const {
-  TransactionFileBodyPresenter,
+  TransactionFilePresrocBodyPresenter,
   TransactionFileHeadPresenter,
   TransactionFileTailPresenter
 } = require('../../../presenters')
@@ -18,7 +18,7 @@ class GeneratePresrocTransactionFileService extends BaseGenerateTransactionFileS
   }
 
   static _bodyPresenter () {
-    return TransactionFileBodyPresenter
+    return TransactionFilePresrocBodyPresenter
   }
 
   static _tailPresenter () {

--- a/test/presenters/transaction_file_presroc_body.presenter.test.js
+++ b/test/presenters/transaction_file_presroc_body.presenter.test.js
@@ -12,9 +12,9 @@ const { BasePresenter } = require('../../app/presenters')
 const { PresenterHelper } = require('../support/helpers')
 
 // Thing under test
-const { TransactionFileBodyPresenter } = require('../../app/presenters')
+const { TransactionFilePresrocBodyPresenter } = require('../../app/presenters')
 
-describe('Transaction File Body Presenter', () => {
+describe('Transaction File Presroc Body Presenter', () => {
   const data = {
     index: 1,
     customerReference: 'CUSTOMER_REF',
@@ -43,7 +43,7 @@ describe('Transaction File Body Presenter', () => {
   }
 
   it('returns the required columns', () => {
-    const presenter = new TransactionFileBodyPresenter(data)
+    const presenter = new TransactionFilePresrocBodyPresenter(data)
     const result = presenter.go()
 
     const expectedFields = PresenterHelper.generateNumberedColumns(43)
@@ -52,7 +52,7 @@ describe('Transaction File Body Presenter', () => {
   })
 
   it('returns the correct values for static fields', () => {
-    const presenter = new TransactionFileBodyPresenter(data)
+    const presenter = new TransactionFilePresrocBodyPresenter(data)
     const result = presenter.go()
 
     expect(result.col01).to.equal('D')
@@ -79,7 +79,7 @@ describe('Transaction File Body Presenter', () => {
   })
 
   it('returns the correct values for dynamic fields', () => {
-    const presenter = new TransactionFileBodyPresenter(data)
+    const presenter = new TransactionFilePresrocBodyPresenter(data)
     const result = presenter.go()
 
     expect(result.col02).to.equal('0000001')
@@ -92,21 +92,21 @@ describe('Transaction File Body Presenter', () => {
   })
 
   it('returns the correct values for col05 (transactionType) when given a credit', () => {
-    const presenter = new TransactionFileBodyPresenter({ ...data, creditLineValue: 500, debitLineValue: 100 })
+    const presenter = new TransactionFilePresrocBodyPresenter({ ...data, creditLineValue: 500, debitLineValue: 100 })
     const result = presenter.go()
 
     expect(result.col05).to.equal('C')
   })
 
   it('returns the correct values for col05 (transactionType) when given a debit', () => {
-    const presenter = new TransactionFileBodyPresenter({ ...data, debitLineValue: 500, creditLineValue: 100 })
+    const presenter = new TransactionFilePresrocBodyPresenter({ ...data, debitLineValue: 500, creditLineValue: 100 })
     const result = presenter.go()
 
     expect(result.col05).to.equal('I')
   })
 
   it('correctly formats dates', () => {
-    const presenter = new TransactionFileBodyPresenter(data)
+    const presenter = new TransactionFilePresrocBodyPresenter(data)
     const result = presenter.go()
 
     const basePresenter = new BasePresenter()
@@ -117,7 +117,7 @@ describe('Transaction File Body Presenter', () => {
   })
 
   it('returns correct values when compensation charge and minimum charge adjustment are false', () => {
-    const presenter = new TransactionFileBodyPresenter({
+    const presenter = new TransactionFilePresrocBodyPresenter({
       ...data,
       regimeValue17: 'false',
       minimumChargeAdjustment: false
@@ -141,7 +141,7 @@ describe('Transaction File Body Presenter', () => {
   })
 
   it('returns correct values when compensation charge is true', () => {
-    const presenter = new TransactionFileBodyPresenter({
+    const presenter = new TransactionFilePresrocBodyPresenter({
       ...data,
       regimeValue17: 'true',
       minimumChargeAdjustment: false
@@ -166,7 +166,7 @@ describe('Transaction File Body Presenter', () => {
 
   it('returns correct values when minimum charge adjustment is true', () => {
     // regimeValue17 is null for minimum charge transactions
-    const presenter = new TransactionFileBodyPresenter({
+    const presenter = new TransactionFilePresrocBodyPresenter({
       ...data,
       regimeValue17: null,
       minimumChargeAdjustment: true
@@ -190,7 +190,7 @@ describe('Transaction File Body Presenter', () => {
   })
 
   it('returns the correct value for col30', () => {
-    const presenter = new TransactionFileBodyPresenter({
+    const presenter = new TransactionFilePresrocBodyPresenter({
       ...data,
       regimeValue17: 'false',
       minimumChargeAdjustment: false

--- a/test/presenters/transaction_file_sroc_body.presenter.test.js
+++ b/test/presenters/transaction_file_sroc_body.presenter.test.js
@@ -15,31 +15,43 @@ const { PresenterHelper } = require('../support/helpers')
 const { TransactionFileSrocBodyPresenter } = require('../../app/presenters')
 
 describe('Transaction File Sroc Body Presenter', () => {
+  // Note that generic fields hold true/false values as text, not boolean
   const data = {
     index: 1,
     customerReference: 'CUSTOMER_REF',
-    transactionDate: Date.now(),
     chargeCredit: false,
     transactionReference: 'TRANSACTION_REF',
-    headerAttr1: Date.now(),
     chargeValue: 772,
     lineAreaCode: 'ARCA',
     lineDescription: 'Well at Chigley Town Hall',
     lineAttr1: 'LINE_ATTR_1',
-    lineAttr2: '01-APR-2020 - 31-MAR-2021',
-    lineAttr3: 'TEST',
-    lineAttr4: '1234',
-    lineAttr5: '1.23',
-    lineAttr6: '123',
-    lineAttr7: '2.34',
-    lineAttr8: '3.45',
-    lineAttr9: 'TEST',
-    lineAttr10: 'TEST',
-    lineAttr13: '0',
-    lineAttr14: '0',
-    // Note that the generic field regimeValue17 stores this as a string, not a boolean
+    lineAttr3: 'LINE_ATTR_3',
+    lineAttr4: 'LINE_ATTR_4',
+    headerAttr4: 'HEADER_ATTR_4',
+    regimeValue18: 'REGIME_VALUE_18',
+    headerAttr9: 'HEADER_ATTR_9',
+    // Reductions, col33
+    headerAttr2: 1,
+    lineAttr12: 'false',
+    regimeValue9: 'false',
+    regimeValue19: 1,
+    regimeValue12: 'false',
+    // Supported source, col34
+    headerAttr5: 'true',
+    lineAttr11: 15000,
+    headerAttr6: 'SUPPORTED_SOURCE_NAME',
+    // Volume, col35
+    regimeValue16: 'true',
+    regimeValue20: 123.4,
+    headerAttr3: 567.8,
+    // waterCompany, col36
+    headerAttr7: 'true',
+    headerAttr10: 12345,
+    // Compensation charge %, col37
+    // Note that we set compensation charge to 'false' as many fields are empty when this is 'true'
     regimeValue17: 'false',
-    minimumChargeAdjustment: false
+    regimeValue2: 50,
+    regimeValue15: 'REGIONAL_CHARGING_AREA'
   }
 
   it('returns the required columns', () => {
@@ -51,153 +63,242 @@ describe('Transaction File Sroc Body Presenter', () => {
     expect(result).to.only.include(expectedFields)
   })
 
-  it('returns the correct values for static fields', () => {
-    const presenter = new TransactionFileSrocBodyPresenter(data)
-    const result = presenter.go()
+  describe('for static fields', () => {
+    it('returns the correct values', () => {
+      const presenter = new TransactionFileSrocBodyPresenter(data)
+      const result = presenter.go()
 
-    expect(result.col01).to.equal('D')
-    expect(result.col07).to.equal('')
-    expect(result.col08).to.equal('GBP')
-    expect(result.col09).to.equal('')
-    expect(result.col11).to.equal('')
-    expect(result.col12).to.equal('')
-    expect(result.col13).to.equal('')
-    expect(result.col14).to.equal('')
-    expect(result.col15).to.equal('')
-    expect(result.col16).to.equal('')
-    expect(result.col17).to.equal('')
-    expect(result.col18).to.equal('')
-    expect(result.col19).to.equal('')
-    expect(result.col21).to.equal('')
-    expect(result.col24).to.equal('A')
-    expect(result.col25).to.equal('')
-    expect(result.col36).to.equal('')
-    expect(result.col37).to.equal('')
-    expect(result.col40).to.equal('')
-    expect(result.col41).to.equal('1')
-    expect(result.col42).to.equal('Each')
+      expect(result.col01).to.equal('D')
+      expect(result.col07).to.equal('')
+      expect(result.col08).to.equal('GBP')
+      expect(result.col09).to.equal('')
+      expect(result.col11).to.equal('')
+      expect(result.col12).to.equal('')
+      expect(result.col13).to.equal('')
+      expect(result.col14).to.equal('')
+      expect(result.col15).to.equal('')
+      expect(result.col16).to.equal('')
+      expect(result.col17).to.equal('')
+      expect(result.col18).to.equal('')
+      expect(result.col19).to.equal('')
+      expect(result.col21).to.equal('')
+      expect(result.col24).to.equal('AT')
+      expect(result.col25).to.equal('')
+      expect(result.col38).to.equal('')
+      expect(result.col39).to.equal('')
+      expect(result.col40).to.equal('')
+      expect(result.col41).to.equal('1')
+      expect(result.col42).to.equal('Each')
+    })
   })
 
-  it('returns the correct values for dynamic fields', () => {
-    const presenter = new TransactionFileSrocBodyPresenter(data)
-    const result = presenter.go()
+  describe('for dynamic fields', () => {
+    it('returns the correct values', () => {
+      const presenter = new TransactionFileSrocBodyPresenter(data)
+      const result = presenter.go()
 
-    expect(result.col02).to.equal('0000001')
-    expect(result.col03).to.equal(data.customerReference)
-    expect(result.col06).to.equal(data.transactionReference)
-    expect(result.col20).to.equal(data.chargeValue)
-    expect(result.col22).to.equal(data.lineAreaCode)
-    expect(result.col23).to.equal(data.lineDescription)
-    expect(result.col43).to.equal(data.chargeValue)
+      expect(result.col02).to.equal('0000001')
+      expect(result.col03).to.equal(data.customerReference)
+      expect(result.col06).to.equal(data.transactionReference)
+      expect(result.col20).to.equal(data.chargeValue)
+      expect(result.col22).to.equal(data.lineAreaCode)
+      expect(result.col23).to.equal(data.lineDescription)
+      expect(result.col43).to.equal(data.chargeValue)
+    })
   })
 
-  it('returns the correct values for col05 (transactionType) when given a credit', () => {
-    const presenter = new TransactionFileSrocBodyPresenter({ ...data, creditLineValue: 500, debitLineValue: 100 })
-    const result = presenter.go()
+  describe('for col05 (transactionType)', () => {
+    it('returns the correct values when given a credit', () => {
+      const presenter = new TransactionFileSrocBodyPresenter({ ...data, creditLineValue: 500, debitLineValue: 100 })
+      const result = presenter.go()
 
-    expect(result.col05).to.equal('C')
-  })
-
-  it('returns the correct values for col05 (transactionType) when given a debit', () => {
-    const presenter = new TransactionFileSrocBodyPresenter({ ...data, debitLineValue: 500, creditLineValue: 100 })
-    const result = presenter.go()
-
-    expect(result.col05).to.equal('I')
-  })
-
-  it('correctly formats dates', () => {
-    const presenter = new TransactionFileSrocBodyPresenter(data)
-    const result = presenter.go()
-
-    const basePresenter = new BasePresenter()
-    const date = basePresenter._formatDate(new Date())
-
-    expect(result.col04).to.equal(date)
-    expect(result.col10).to.equal(date)
-  })
-
-  it('returns correct values when compensation charge and minimum charge adjustment are false', () => {
-    const presenter = new TransactionFileSrocBodyPresenter({
-      ...data,
-      regimeValue17: 'false',
-      minimumChargeAdjustment: false
+      expect(result.col05).to.equal('C')
     })
 
-    const result = presenter.go()
+    it('returns the correct values when given a debit', () => {
+      const presenter = new TransactionFileSrocBodyPresenter({ ...data, debitLineValue: 500, creditLineValue: 100 })
+      const result = presenter.go()
 
-    expect(result.col26).to.equal(data.lineAttr1)
-    expect(result.col27).to.equal(data.lineAttr2)
-    expect(result.col28).to.equal(data.lineAttr3)
-    expect(result.col29).to.equal(data.lineAttr4)
-    expect(result.col30).to.not.equal('') // We test col30's content in a separate test
-    expect(result.col31).to.equal(data.lineAttr6)
-    expect(result.col32).to.equal(data.lineAttr7)
-    expect(result.col33).to.equal(data.lineAttr8)
-    expect(result.col34).to.equal(data.lineAttr9)
-    expect(result.col35).to.equal(data.lineAttr10)
-
-    expect(result.col38).to.equal('')
-    expect(result.col39).to.equal('')
+      expect(result.col05).to.equal('I')
+    })
   })
 
-  it('returns correct values when compensation charge is true', () => {
-    const presenter = new TransactionFileSrocBodyPresenter({
-      ...data,
-      regimeValue17: 'true',
-      minimumChargeAdjustment: false
+  describe('for col04 and col10 (date columns)', () => {
+    it('correctly formats dates', () => {
+      const presenter = new TransactionFileSrocBodyPresenter(data)
+      const result = presenter.go()
+
+      const basePresenter = new BasePresenter()
+      const date = basePresenter._formatDate(new Date())
+
+      expect(result.col04).to.equal(date)
+      expect(result.col10).to.equal(date)
     })
-
-    const result = presenter.go()
-
-    expect(result.col26).to.equal('')
-    expect(result.col27).to.equal('')
-    expect(result.col28).to.equal('')
-    expect(result.col29).to.equal('')
-    expect(result.col30).to.equal('')
-    expect(result.col31).to.equal('')
-    expect(result.col32).to.equal('')
-    expect(result.col33).to.equal('')
-    expect(result.col34).to.equal('')
-    expect(result.col35).to.equal('')
-
-    expect(result.col38).to.equal(data.lineAttr13)
-    expect(result.col39).to.equal(data.lineAttr14)
   })
 
-  it('returns correct values when minimum charge adjustment is true', () => {
-    // regimeValue17 is null for minimum charge transactions
-    const presenter = new TransactionFileSrocBodyPresenter({
-      ...data,
-      regimeValue17: null,
-      minimumChargeAdjustment: true
+  describe('for cols that are dependent on compensation charge', () => {
+    it('returns expected values when compensation charge is false', () => {
+      const presenter = new TransactionFileSrocBodyPresenter({
+        ...data,
+        regimeValue17: 'false',
+        // We set a reduction to ensure the reductions col is not empty
+        lineAttr12: 'true'
+      })
+
+      const result = presenter.go()
+
+      expect(result.col26).to.equal(data.lineAttr1)
+      expect(result.col28).to.equal(data.lineAttr3)
+      expect(result.col29).to.equal(data.lineAttr4)
+      expect(result.col30).to.equal(data.headerAttr4)
+      expect(result.col31).to.equal(data.regimeValue18)
+      expect(result.col32).to.equal(data.headerAttr9)
+      expect(result.col33).to.not.equal('') // This column is checked in a separate test
+      expect(result.col34).to.not.equal('') // This column is checked in a separate test
+      expect(result.col35).to.not.equal('') // This column is checked in a separate test
+      expect(result.col36).to.not.equal('') // This column is checked in a separate test
+
+      expect(result.col37).to.equal('')
     })
 
-    const result = presenter.go()
+    it('returns expected values when compensation charge is true', () => {
+      const presenter = new TransactionFileSrocBodyPresenter({
+        ...data,
+        regimeValue17: 'true'
+      })
 
-    expect(result.col26).to.equal(data.lineAttr1)
-    expect(result.col27).to.equal('')
-    expect(result.col28).to.equal('')
-    expect(result.col29).to.equal('')
-    expect(result.col30).to.equal('')
-    expect(result.col31).to.equal('')
-    expect(result.col32).to.equal('')
-    expect(result.col33).to.equal('')
-    expect(result.col34).to.equal('')
-    expect(result.col35).to.equal('')
+      const result = presenter.go()
 
-    expect(result.col38).to.equal('')
-    expect(result.col39).to.equal('')
+      expect(result.col26).to.equal('')
+      expect(result.col28).to.equal('')
+      expect(result.col29).to.equal('')
+      expect(result.col30).to.equal('')
+      expect(result.col31).to.equal('')
+      expect(result.col32).to.equal('')
+      expect(result.col33).to.equal('')
+      expect(result.col34).to.equal('')
+      expect(result.col35).to.equal('')
+      expect(result.col36).to.equal('')
+
+      expect(result.col37).to.not.equal('') // This column is checked in a separate test
+    })
   })
 
-  it('returns the correct value for col30', () => {
-    const presenter = new TransactionFileSrocBodyPresenter({
-      ...data,
-      regimeValue17: 'false',
-      minimumChargeAdjustment: false
+  describe('for col33 (reductions list)', () => {
+    it('returns a populated list if reductions apply', () => {
+      const presenter = new TransactionFileSrocBodyPresenter({
+        ...data,
+        regimeValue17: 'false',
+        headerAttr2: 0.5,
+        lineAttr12: 'true',
+        regimeValue9: 'true',
+        regimeValue19: 0.5,
+        regimeValue12: 'true'
+      })
+
+      const result = presenter.go()
+
+      expect(result.col33).to.equal('Aggregate, Winter Only Discount, CRT Discount, Abatement of Charges, Two-Part Tariff')
     })
 
-    const result = presenter.go()
+    it('returns an empty list if no reductions apply', () => {
+      const presenter = new TransactionFileSrocBodyPresenter({
+        ...data,
+        regimeValue17: 'false'
+      })
 
-    expect(result.col30).to.equal('1.23 Ml')
+      const result = presenter.go()
+
+      expect(result.col33).to.equal('')
+    })
+  })
+
+  describe('for col34 (supported source)', () => {
+    it('returns the correct data if supported source is true', () => {
+      const presenter = new TransactionFileSrocBodyPresenter({
+        ...data,
+        regimeValue17: 'false'
+      })
+
+      const result = presenter.go()
+
+      expect(result.col34).to.equal('15000, SUPPORTED_SOURCE_NAME')
+    })
+
+    it('returns blank if supported source is false', () => {
+      const presenter = new TransactionFileSrocBodyPresenter({
+        ...data,
+        regimeValue17: 'false',
+        headerAttr5: 'false'
+      })
+
+      const result = presenter.go()
+
+      expect(result.col34).to.equal('')
+    })
+  })
+
+  describe('for col35 (volume)', () => {
+    it('returns the correct data if two part tariff is true', () => {
+      const presenter = new TransactionFileSrocBodyPresenter({
+        ...data,
+        regimeValue17: 'false'
+      })
+
+      const result = presenter.go()
+
+      expect(result.col35).to.equal('123.4 / 567.8 Ml')
+    })
+
+    it('returns blank if two part tariff is false', () => {
+      const presenter = new TransactionFileSrocBodyPresenter({
+        ...data,
+        regimeValue17: 'false',
+        regimeValue16: 'false'
+      })
+
+      const result = presenter.go()
+
+      expect(result.col35).to.equal('')
+    })
+  })
+
+  describe('for col36 (water company)', () => {
+    it('returns the correct data if water company charge is true', () => {
+      const presenter = new TransactionFileSrocBodyPresenter({
+        ...data,
+        regimeValue17: 'false'
+      })
+
+      const result = presenter.go()
+
+      expect(result.col36).to.equal(data.headerAttr10)
+    })
+
+    it('returns blank if water company charge is false', () => {
+      const presenter = new TransactionFileSrocBodyPresenter({
+        ...data,
+        regimeValue17: 'false',
+        headerAttr7: 'false'
+      })
+
+      const result = presenter.go()
+
+      expect(result.col36).to.equal('')
+    })
+  })
+
+  describe('for col37 (compensation charge)', () => {
+    it('returns the correct data if water company charge is true', () => {
+      const presenter = new TransactionFileSrocBodyPresenter({
+        ...data,
+        // Note that compensation charge is true here unlike the other col tests
+        regimeValue17: 'true'
+      })
+
+      const result = presenter.go()
+
+      expect(result.col37).to.equal('50% (REGIONAL_CHARGING_AREA)')
+    })
   })
 })

--- a/test/presenters/transaction_file_sroc_body.presenter.test.js
+++ b/test/presenters/transaction_file_sroc_body.presenter.test.js
@@ -1,0 +1,203 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it } = exports.lab = Lab.script()
+const { expect } = Code
+
+const { BasePresenter } = require('../../app/presenters')
+
+const { PresenterHelper } = require('../support/helpers')
+
+// Thing under test
+const { TransactionFileSrocBodyPresenter } = require('../../app/presenters')
+
+describe('Transaction File Sroc Body Presenter', () => {
+  const data = {
+    index: 1,
+    customerReference: 'CUSTOMER_REF',
+    transactionDate: Date.now(),
+    chargeCredit: false,
+    transactionReference: 'TRANSACTION_REF',
+    headerAttr1: Date.now(),
+    chargeValue: 772,
+    lineAreaCode: 'ARCA',
+    lineDescription: 'Well at Chigley Town Hall',
+    lineAttr1: 'LINE_ATTR_1',
+    lineAttr2: '01-APR-2020 - 31-MAR-2021',
+    lineAttr3: 'TEST',
+    lineAttr4: '1234',
+    lineAttr5: '1.23',
+    lineAttr6: '123',
+    lineAttr7: '2.34',
+    lineAttr8: '3.45',
+    lineAttr9: 'TEST',
+    lineAttr10: 'TEST',
+    lineAttr13: '0',
+    lineAttr14: '0',
+    // Note that the generic field regimeValue17 stores this as a string, not a boolean
+    regimeValue17: 'false',
+    minimumChargeAdjustment: false
+  }
+
+  it('returns the required columns', () => {
+    const presenter = new TransactionFileSrocBodyPresenter(data)
+    const result = presenter.go()
+
+    const expectedFields = PresenterHelper.generateNumberedColumns(43)
+
+    expect(result).to.only.include(expectedFields)
+  })
+
+  it('returns the correct values for static fields', () => {
+    const presenter = new TransactionFileSrocBodyPresenter(data)
+    const result = presenter.go()
+
+    expect(result.col01).to.equal('D')
+    expect(result.col07).to.equal('')
+    expect(result.col08).to.equal('GBP')
+    expect(result.col09).to.equal('')
+    expect(result.col11).to.equal('')
+    expect(result.col12).to.equal('')
+    expect(result.col13).to.equal('')
+    expect(result.col14).to.equal('')
+    expect(result.col15).to.equal('')
+    expect(result.col16).to.equal('')
+    expect(result.col17).to.equal('')
+    expect(result.col18).to.equal('')
+    expect(result.col19).to.equal('')
+    expect(result.col21).to.equal('')
+    expect(result.col24).to.equal('A')
+    expect(result.col25).to.equal('')
+    expect(result.col36).to.equal('')
+    expect(result.col37).to.equal('')
+    expect(result.col40).to.equal('')
+    expect(result.col41).to.equal('1')
+    expect(result.col42).to.equal('Each')
+  })
+
+  it('returns the correct values for dynamic fields', () => {
+    const presenter = new TransactionFileSrocBodyPresenter(data)
+    const result = presenter.go()
+
+    expect(result.col02).to.equal('0000001')
+    expect(result.col03).to.equal(data.customerReference)
+    expect(result.col06).to.equal(data.transactionReference)
+    expect(result.col20).to.equal(data.chargeValue)
+    expect(result.col22).to.equal(data.lineAreaCode)
+    expect(result.col23).to.equal(data.lineDescription)
+    expect(result.col43).to.equal(data.chargeValue)
+  })
+
+  it('returns the correct values for col05 (transactionType) when given a credit', () => {
+    const presenter = new TransactionFileSrocBodyPresenter({ ...data, creditLineValue: 500, debitLineValue: 100 })
+    const result = presenter.go()
+
+    expect(result.col05).to.equal('C')
+  })
+
+  it('returns the correct values for col05 (transactionType) when given a debit', () => {
+    const presenter = new TransactionFileSrocBodyPresenter({ ...data, debitLineValue: 500, creditLineValue: 100 })
+    const result = presenter.go()
+
+    expect(result.col05).to.equal('I')
+  })
+
+  it('correctly formats dates', () => {
+    const presenter = new TransactionFileSrocBodyPresenter(data)
+    const result = presenter.go()
+
+    const basePresenter = new BasePresenter()
+    const date = basePresenter._formatDate(new Date())
+
+    expect(result.col04).to.equal(date)
+    expect(result.col10).to.equal(date)
+  })
+
+  it('returns correct values when compensation charge and minimum charge adjustment are false', () => {
+    const presenter = new TransactionFileSrocBodyPresenter({
+      ...data,
+      regimeValue17: 'false',
+      minimumChargeAdjustment: false
+    })
+
+    const result = presenter.go()
+
+    expect(result.col26).to.equal(data.lineAttr1)
+    expect(result.col27).to.equal(data.lineAttr2)
+    expect(result.col28).to.equal(data.lineAttr3)
+    expect(result.col29).to.equal(data.lineAttr4)
+    expect(result.col30).to.not.equal('') // We test col30's content in a separate test
+    expect(result.col31).to.equal(data.lineAttr6)
+    expect(result.col32).to.equal(data.lineAttr7)
+    expect(result.col33).to.equal(data.lineAttr8)
+    expect(result.col34).to.equal(data.lineAttr9)
+    expect(result.col35).to.equal(data.lineAttr10)
+
+    expect(result.col38).to.equal('')
+    expect(result.col39).to.equal('')
+  })
+
+  it('returns correct values when compensation charge is true', () => {
+    const presenter = new TransactionFileSrocBodyPresenter({
+      ...data,
+      regimeValue17: 'true',
+      minimumChargeAdjustment: false
+    })
+
+    const result = presenter.go()
+
+    expect(result.col26).to.equal('')
+    expect(result.col27).to.equal('')
+    expect(result.col28).to.equal('')
+    expect(result.col29).to.equal('')
+    expect(result.col30).to.equal('')
+    expect(result.col31).to.equal('')
+    expect(result.col32).to.equal('')
+    expect(result.col33).to.equal('')
+    expect(result.col34).to.equal('')
+    expect(result.col35).to.equal('')
+
+    expect(result.col38).to.equal(data.lineAttr13)
+    expect(result.col39).to.equal(data.lineAttr14)
+  })
+
+  it('returns correct values when minimum charge adjustment is true', () => {
+    // regimeValue17 is null for minimum charge transactions
+    const presenter = new TransactionFileSrocBodyPresenter({
+      ...data,
+      regimeValue17: null,
+      minimumChargeAdjustment: true
+    })
+
+    const result = presenter.go()
+
+    expect(result.col26).to.equal(data.lineAttr1)
+    expect(result.col27).to.equal('')
+    expect(result.col28).to.equal('')
+    expect(result.col29).to.equal('')
+    expect(result.col30).to.equal('')
+    expect(result.col31).to.equal('')
+    expect(result.col32).to.equal('')
+    expect(result.col33).to.equal('')
+    expect(result.col34).to.equal('')
+    expect(result.col35).to.equal('')
+
+    expect(result.col38).to.equal('')
+    expect(result.col39).to.equal('')
+  })
+
+  it('returns the correct value for col30', () => {
+    const presenter = new TransactionFileSrocBodyPresenter({
+      ...data,
+      regimeValue17: 'false',
+      minimumChargeAdjustment: false
+    })
+
+    const result = presenter.go()
+
+    expect(result.col30).to.equal('1.23 Ml')
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/CMEA-257

We rename the existing `TransactionFileBodyPresenter` to `TransactionFileSrocBodyPresenter`, and proceed to create `TransactionFileSrocBodyPresenter` which formats the data for an sroc transaction file. Some additional refactoring could be done to consolidate common functions between the sroc and presroc body presenters but we will do this later once we've completed the sroc transaction file work.

Note that we don't actually use this presenter yet when generating an sroc transaction file; we'll be adding this functionality in a future PR.