### PR TITLE
Amend transaction file head presenter for sroc

### DIFF
--- a/app/presenters/transaction_file_head.presenter.js
+++ b/app/presenters/transaction_file_head.presenter.js
@@ -31,11 +31,13 @@ class TransactionFileHeadPresenter extends BasePresenter {
   }
 
   /**
-   * When given a file reference eg. 'nalwi50003', returns the file number part '50003'. The format we return it in
-   * doesn't matter so we simply return a string without converting to an integer first.
+   * When given a presroc file reference eg. 'nalwi50003', returns the file number part '50003'.
+   * When given an sroc file reference, eg. 'nalwi50003t', returns the file number part '50003T'.
    */
   _fileNumber (fileReference) {
-    return fileReference.slice(-5)
+    return fileReference
+      .slice(5)
+      .toUpperCase()
   }
 }
 

--- a/test/presenters/transaction_file_head.presenter.test.js
+++ b/test/presenters/transaction_file_head.presenter.test.js
@@ -48,4 +48,14 @@ describe('Transaction File Head presenter', () => {
     expect(result.col07).to.equal(data.billRunNumber)
     expect(result.col08).to.equal(date)
   })
+
+  it('correctly presents an sroc file reference', () => {
+    const testPresenter = new TransactionFileHeadPresenter({
+      ...data,
+      fileReference: 'nalri50003t'
+    })
+    const result = testPresenter.go()
+
+    expect(result.col06).to.equal('50003T')
+  })
 })

--- a/test/services/files/transactions/generate_presroc_transaction_file.service.test.js
+++ b/test/services/files/transactions/generate_presroc_transaction_file.service.test.js
@@ -29,7 +29,7 @@ const { temporaryFilePath } = require('../../../../config/server.config')
 const { GeneratePresrocTransactionFileService } = require('../../../../app/services')
 
 describe('Generate Presroc Transaction File service', () => {
-  const filename = 'test.txt'
+  const filename = 'abcde67890'
   const filenameWithPath = path.join(temporaryFilePath, filename)
 
   let billRun
@@ -95,7 +95,7 @@ describe('Generate Presroc Transaction File service', () => {
     const presenter = new BasePresenter()
     const date = presenter._formatDate(new Date())
 
-    const head = _contentLine(['H', '0000000', 'NAL', 'A', 'I', 't.txt', '12345', date])
+    const head = _contentLine(['H', '0000000', 'NAL', 'A', 'I', '67890', '12345', date])
     const body = _contentLine(['D', '0000001', 'TH230000222', date, 'I', 'TRANSACTION_REF', '', 'GBP', '', date, '', '', '', '', '', '', '', '', '', '772', '', 'ARCA', 'Well at Chigley Town Hall', 'A', '', 'TONY/TF9222/37', '01-APR-2018 - 31-MAR-2019', 'null', '1495', '6.22 Ml', '3', '1.6', '0.03', '', '', '', '', '', '', '', '1', 'Each', '772'])
     const tail = _contentLine(['T', '0000002', '3', '0', '0'])
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/CMEA-257

As per AC1 in the card, the format of the transaction file head is pretty much the same for both presroc and sroc. However the way it turns a file reference into a file number needs to be changed.

The existing code takes a reference in the format `nalwi50003` and extracts the last 5 characters, ie. `50003`. However for sroc references like `nalwi50003t` we want to extract the last 6 characters and make it upper case, ie. `50003T`.

Since file references always have 5 letters at the start, we simply change this to extract the 6th character onwards and upper-case it.