### PR TITLE
Generate sroc transaction file service

### DIFF
--- a/app/presenters/transaction_file_sroc_body.presenter.js
+++ b/app/presenters/transaction_file_sroc_body.presenter.js
@@ -44,7 +44,7 @@ class TransactionFileSrocBodyPresenter extends BasePresenter {
       col26: this._blankIfCompensationCharge(data.lineAttr1, data),
       col27: '',
       col28: this._blankIfCompensationCharge(data.lineAttr2, data),
-      col29: this._blankIfCompensationCharge(data.lineAttr3, data), // TODO: prorata days need to be stored in the db or generated dynamically here
+      col29: this._blankIfCompensationCharge(data.lineAttr3, data),
       col30: this._blankIfCompensationCharge(data.headerAttr4, data), // chargeCategoryCode
       col31: this._blankIfCompensationCharge(data.regimeValue18, data), // chargeCategoryDescription
       col32: this._blankIfCompensationCharge(data.headerAttr9, data), // baseCharge [in pence]

--- a/app/presenters/transaction_file_sroc_body.presenter.js
+++ b/app/presenters/transaction_file_sroc_body.presenter.js
@@ -43,8 +43,8 @@ class TransactionFileSrocBodyPresenter extends BasePresenter {
       col25: '',
       col26: this._blankIfCompensationCharge(data.lineAttr1, data),
       col27: '',
-      col28: this._blankIfCompensationCharge(data.lineAttr2, data),
-      col29: this._blankIfCompensationCharge(data.lineAttr3, data),
+      col28: this._blankIfCompensationCharge(data.lineAttr2, data), // chargePeriod
+      col29: this._blankIfCompensationCharge(data.lineAttr3, data), // prorata days
       col30: this._blankIfCompensationCharge(data.headerAttr4, data), // chargeCategoryCode
       col31: this._blankIfCompensationCharge(data.regimeValue18, data), // chargeCategoryDescription
       col32: this._blankIfCompensationCharge(data.headerAttr9, data), // baseCharge [in pence]

--- a/app/presenters/transaction_file_sroc_body.presenter.js
+++ b/app/presenters/transaction_file_sroc_body.presenter.js
@@ -43,8 +43,8 @@ class TransactionFileSrocBodyPresenter extends BasePresenter {
       col25: '',
       col26: this._blankIfCompensationCharge(data.lineAttr1, data),
       col27: '',
-      col28: this._blankIfCompensationCharge(data.lineAttr3, data),
-      col29: this._blankIfCompensationCharge(data.lineAttr4, data),
+      col28: this._blankIfCompensationCharge(data.lineAttr2, data),
+      col29: this._blankIfCompensationCharge(data.lineAttr3, data), // TODO: prorata days need to be stored in the db or generated dynamically here
       col30: this._blankIfCompensationCharge(data.headerAttr4, data), // chargeCategoryCode
       col31: this._blankIfCompensationCharge(data.regimeValue18, data), // chargeCategoryDescription
       col32: this._blankIfCompensationCharge(data.headerAttr9, data), // baseCharge [in pence]
@@ -99,7 +99,7 @@ class TransactionFileSrocBodyPresenter extends BasePresenter {
   _reductionsList (data) {
     const reductions = []
 
-    if (data.headerAttr2 !== 1) { // aggregateProportion
+    if (data.headerAttr2 !== '1') { // aggregateProportion
       reductions.push('Aggregate')
     }
 
@@ -111,7 +111,7 @@ class TransactionFileSrocBodyPresenter extends BasePresenter {
       reductions.push('CRT Discount')
     }
 
-    if (data.regimeValue19 !== 1) { // abatementFactor
+    if (data.regimeValue19 !== '1') { // abatementFactor
       reductions.push('Abatement of Charges')
     }
 

--- a/app/services/files/transactions/generate_presroc_transaction_file.service.js
+++ b/app/services/files/transactions/generate_presroc_transaction_file.service.js
@@ -6,27 +6,11 @@
 
 const BaseGenerateTransactionFileService = require('./base_generate_transaction_file.service')
 
-const {
-  TransactionFilePresrocBodyPresenter,
-  TransactionFileHeadPresenter,
-  TransactionFileTailPresenter
-} = require('../../../presenters')
+const TransactionFilePresrocBodyPresenter = require('../../../presenters/transaction_file_presroc_body.presenter')
 
 class GeneratePresrocTransactionFileService extends BaseGenerateTransactionFileService {
-  static _headPresenter () {
-    return TransactionFileHeadPresenter
-  }
-
   static _bodyPresenter () {
     return TransactionFilePresrocBodyPresenter
-  }
-
-  static _tailPresenter () {
-    return TransactionFileTailPresenter
-  }
-
-  static _join () {
-    return ['invoices', 'transactions.invoiceId', 'invoices.id']
   }
 
   static _select () {
@@ -56,32 +40,6 @@ class GeneratePresrocTransactionFileService extends BaseGenerateTransactionFileS
       'invoices.creditLineValue',
       'invoices.debitLineValue'
     ]
-  }
-
-  static _sort () {
-    return [
-      'invoices.transactionReference', // sort by transaction reference
-      'lineAttr1', // then sort by licence number
-      'regimeValue17' // then sort by compensation charge, where non-compensation charge (ie. false) is first
-    ]
-  }
-
-  static _where (builder, billRun) {
-    return builder
-      .where('transactions.billRunId', billRun.id)
-      .whereNotNull('invoices.transactionReference')
-      .whereNot('chargeValue', 0)
-  }
-
-  static _additionalData (billRun) {
-    return {
-      region: billRun.region,
-      billRunNumber: billRun.billRunNumber,
-      billRunUpdatedAt: billRun.updatedAt,
-      invoiceValue: billRun.invoiceValue,
-      creditNoteValue: billRun.creditNoteValue,
-      fileReference: billRun.fileReference
-    }
   }
 }
 

--- a/app/services/files/transactions/generate_sroc_transaction_file.service.js
+++ b/app/services/files/transactions/generate_sroc_transaction_file.service.js
@@ -1,0 +1,88 @@
+'use strict'
+
+/**
+ * @module GenerateSrocTransactionFileService
+ */
+
+const BaseGenerateTransactionFileService = require('./base_generate_transaction_file.service')
+
+const {
+  TransactionFilePresrocBodyPresenter,
+  TransactionFileHeadPresenter,
+  TransactionFileTailPresenter
+} = require('../../../presenters')
+
+class GenerateSrocTransactionFileService extends BaseGenerateTransactionFileService {
+  static _headPresenter () {
+    return TransactionFileHeadPresenter
+  }
+
+  static _bodyPresenter () {
+    return TransactionFilePresrocBodyPresenter
+  }
+
+  static _tailPresenter () {
+    return TransactionFileTailPresenter
+  }
+
+  static _join () {
+    return ['invoices', 'transactions.invoiceId', 'invoices.id']
+  }
+
+  static _select () {
+    return [
+      'transactions.customerReference',
+      'transactionDate',
+      'chargeCredit',
+      'headerAttr1',
+      'chargeValue',
+      'lineAreaCode',
+      'lineDescription',
+      'lineAttr1',
+      'lineAttr2',
+      'lineAttr3',
+      'lineAttr4',
+      'lineAttr5',
+      'lineAttr6',
+      'lineAttr7',
+      'lineAttr8',
+      'lineAttr9',
+      'lineAttr10',
+      'lineAttr13',
+      'lineAttr14',
+      'regimeValue17',
+      'minimumChargeAdjustment',
+      'invoices.transactionReference',
+      'invoices.creditLineValue',
+      'invoices.debitLineValue'
+    ]
+  }
+
+  static _sort () {
+    return [
+      'invoices.transactionReference', // sort by transaction reference
+      'lineAttr1', // then sort by licence number
+      'regimeValue17' // then sort by compensation charge, where non-compensation charge (ie. false) is first
+    ]
+  }
+
+  static _where (builder, billRun) {
+    return builder
+      .where('transactions.billRunId', billRun.id)
+      .whereNotNull('invoices.transactionReference')
+      .whereNot('chargeValue', 0)
+  }
+
+  static _additionalData (billRun) {
+    return {
+      region: billRun.region,
+      billRunNumber: billRun.billRunNumber,
+      billRunUpdatedAt: billRun.updatedAt,
+      invoiceValue: billRun.invoiceValue,
+      creditNoteValue: billRun.creditNoteValue,
+      fileReference: billRun.fileReference
+    }
+  }
+}
+
+module.exports = GenerateSrocTransactionFileService

--- a/app/services/files/transactions/generate_sroc_transaction_file.service.js
+++ b/app/services/files/transactions/generate_sroc_transaction_file.service.js
@@ -6,27 +6,11 @@
 
 const BaseGenerateTransactionFileService = require('./base_generate_transaction_file.service')
 
-const {
-  TransactionFileHeadPresenter,
-  TransactionFileSrocBodyPresenter,
-  TransactionFileTailPresenter
-} = require('../../../presenters')
+const TransactionFileSrocBodyPresenter = require('../../../presenters/transaction_file_sroc_body.presenter')
 
 class GenerateSrocTransactionFileService extends BaseGenerateTransactionFileService {
-  static _headPresenter () {
-    return TransactionFileHeadPresenter
-  }
-
   static _bodyPresenter () {
     return TransactionFileSrocBodyPresenter
-  }
-
-  static _tailPresenter () {
-    return TransactionFileTailPresenter
-  }
-
-  static _join () {
-    return ['invoices', 'transactions.invoiceId', 'invoices.id']
   }
 
   static _select () {
@@ -65,32 +49,6 @@ class GenerateSrocTransactionFileService extends BaseGenerateTransactionFileServ
       'invoices.creditLineValue',
       'invoices.debitLineValue'
     ]
-  }
-
-  static _sort () {
-    return [
-      'invoices.transactionReference', // sort by transaction reference
-      'lineAttr1', // then sort by licence number
-      'regimeValue17' // then sort by compensation charge, where non-compensation charge (ie. false) is first
-    ]
-  }
-
-  static _where (builder, billRun) {
-    return builder
-      .where('transactions.billRunId', billRun.id)
-      .whereNotNull('invoices.transactionReference')
-      .whereNot('chargeValue', 0)
-  }
-
-  static _additionalData (billRun) {
-    return {
-      region: billRun.region,
-      billRunNumber: billRun.billRunNumber,
-      billRunUpdatedAt: billRun.updatedAt,
-      invoiceValue: billRun.invoiceValue,
-      creditNoteValue: billRun.creditNoteValue,
-      fileReference: billRun.fileReference
-    }
   }
 }
 

--- a/app/services/files/transactions/generate_sroc_transaction_file.service.js
+++ b/app/services/files/transactions/generate_sroc_transaction_file.service.js
@@ -60,7 +60,6 @@ class GenerateSrocTransactionFileService extends BaseGenerateTransactionFileServ
       'headerAttr10', // waterCompanyChargeValue
       'regimeValue2', // compensationChargePercent
       'regimeValue15', // regionalChargingArea
-
       'minimumChargeAdjustment',
       'invoices.transactionReference',
       'invoices.creditLineValue',

--- a/app/services/files/transactions/generate_sroc_transaction_file.service.js
+++ b/app/services/files/transactions/generate_sroc_transaction_file.service.js
@@ -7,8 +7,8 @@
 const BaseGenerateTransactionFileService = require('./base_generate_transaction_file.service')
 
 const {
-  TransactionFilePresrocBodyPresenter,
   TransactionFileHeadPresenter,
+  TransactionFileSrocBodyPresenter,
   TransactionFileTailPresenter
 } = require('../../../presenters')
 
@@ -18,7 +18,7 @@ class GenerateSrocTransactionFileService extends BaseGenerateTransactionFileServ
   }
 
   static _bodyPresenter () {
-    return TransactionFilePresrocBodyPresenter
+    return TransactionFileSrocBodyPresenter
   }
 
   static _tailPresenter () {
@@ -41,16 +41,26 @@ class GenerateSrocTransactionFileService extends BaseGenerateTransactionFileServ
       'lineAttr1',
       'lineAttr2',
       'lineAttr3',
-      'lineAttr4',
-      'lineAttr5',
-      'lineAttr6',
-      'lineAttr7',
-      'lineAttr8',
-      'lineAttr9',
-      'lineAttr10',
-      'lineAttr13',
-      'lineAttr14',
-      'regimeValue17',
+      'headerAttr4', // chargeCategoryCode
+      'regimeValue18', // chargeCategoryDescription
+      'headerAttr9', // baseCharge
+      'regimeValue17', // compensationCharge
+      'headerAttr2', // aggregateProportion
+      'lineAttr12', // winterOnly
+      'regimeValue9', // section130Agreement
+      'regimeValue19', // abatementFactor
+      'regimeValue12', // section127Agreement
+      'headerAttr5', // supportedSource
+      'lineAttr11', // supportedSourceValue
+      'headerAttr6', // supportedSourceName
+      'regimeValue16', // twoPartTariff
+      'regimeValue20', // actualVolume
+      'headerAttr3', // authorisedVolume
+      'headerAttr7', // waterCompanyCharge
+      'headerAttr10', // waterCompanyChargeValue
+      'regimeValue2', // compensationChargePercent
+      'regimeValue15', // regionalChargingArea
+
       'minimumChargeAdjustment',
       'invoices.transactionReference',
       'invoices.creditLineValue',

--- a/app/services/index.js
+++ b/app/services/index.js
@@ -33,6 +33,7 @@ const GenerateBillRunService = require('./bill_runs/generate_bill_run.service')
 const GenerateBillRunValidationService = require('./bill_runs/generate_bill_run_validation.service')
 const GenerateCustomerFileService = require('./files/customers/generate_customer_file.service')
 const GeneratePresrocTransactionFileService = require('./files/transactions/generate_presroc_transaction_file.service')
+const GenerateSrocTransactionFileService = require('./files/transactions/generate_sroc_transaction_file.service')
 const InvoiceRebillingCopyService = require('./invoices/invoice_rebilling_copy.service')
 const InvoiceRebillingCreateLicenceService = require('./invoices/invoice_rebilling_create_licence.service')
 const InvoiceRebillingCreateTransactionService = require('./invoices/invoice_rebilling_create_transaction.service')
@@ -110,6 +111,7 @@ module.exports = {
   GenerateBillRunValidationService,
   GenerateCustomerFileService,
   GeneratePresrocTransactionFileService,
+  GenerateSrocTransactionFileService,
   InvoiceRebillingCopyService,
   InvoiceRebillingCreateLicenceService,
   InvoiceRebillingCreateTransactionService,

--- a/test/presenters/transaction_file_sroc_body.presenter.test.js
+++ b/test/presenters/transaction_file_sroc_body.presenter.test.js
@@ -31,10 +31,10 @@ describe('Transaction File Sroc Body Presenter', () => {
     regimeValue18: 'REGIME_VALUE_18',
     headerAttr9: 'HEADER_ATTR_9',
     // Reductions, col33
-    headerAttr2: 1,
+    headerAttr2: '1',
     lineAttr12: 'false',
     regimeValue9: 'false',
-    regimeValue19: 1,
+    regimeValue19: '1',
     regimeValue12: 'false',
     // Supported source, col34
     headerAttr5: 'true',

--- a/test/presenters/transaction_file_sroc_body.presenter.test.js
+++ b/test/presenters/transaction_file_sroc_body.presenter.test.js
@@ -148,8 +148,8 @@ describe('Transaction File Sroc Body Presenter', () => {
       const result = presenter.go()
 
       expect(result.col26).to.equal(data.lineAttr1)
-      expect(result.col28).to.equal(data.lineAttr3)
-      expect(result.col29).to.equal(data.lineAttr4)
+      expect(result.col28).to.equal(data.lineAttr2)
+      expect(result.col29).to.equal(data.lineAttr3)
       expect(result.col30).to.equal(data.headerAttr4)
       expect(result.col31).to.equal(data.regimeValue18)
       expect(result.col32).to.equal(data.headerAttr9)

--- a/test/services/files/transactions/base_generate_transaction_file.service.test.js
+++ b/test/services/files/transactions/base_generate_transaction_file.service.test.js
@@ -13,14 +13,8 @@ const { BaseGenerateTransactionFileService } = require('../../../../app/services
 describe('Base Generate Transaction File service', () => {
   describe('When a class extends it', () => {
     const methodsToOverride = [
-      '_headPresenter',
       '_bodyPresenter',
-      '_tailPresenter',
-      '_additionalData',
-      '_join',
-      '_select',
-      '_sort',
-      '_where'
+      '_select'
     ]
 
     for (const method of methodsToOverride) {

--- a/test/services/files/transactions/generate_sroc_transaction_file.service.test.js
+++ b/test/services/files/transactions/generate_sroc_transaction_file.service.test.js
@@ -13,13 +13,11 @@ const path = require('path')
 
 // Test helpers
 const {
-  BillRunHelper,
   DatabaseHelper,
-  GeneralHelper,
-  TransactionHelper
+  NewTransactionHelper
 } = require('../../../support/helpers')
 
-const { InvoiceModel, TransactionModel } = require('../../../../app/models')
+const { InvoiceModel, TransactionModel, BillRunModel } = require('../../../../app/models')
 
 const { BasePresenter } = require('../../../../app/presenters')
 
@@ -37,14 +35,20 @@ describe.only('Generate Sroc Transaction File service', () => {
   beforeEach(async () => {
     await DatabaseHelper.clean()
 
-    billRun = await BillRunHelper.addBillRun(GeneralHelper.uuid4(), GeneralHelper.uuid4())
-    billRun.fileReference = filename
-    billRun.billRunNumber = 12345
+    const transaction = await NewTransactionHelper.create()
+    billRun = await BillRunModel.query().findOne({ id: transaction.billRunId })
 
-    await TransactionHelper.addTransaction(billRun.id)
+    // Set the file reference and bill run number on the bill run
+    await billRun.$query()
+      .patch({
+        fileReference: filename,
+        billRunNumber: 12345
+      })
 
     // Set the transaction reference on the invoice
-    await InvoiceModel.query().findOne({ billRunId: billRun.id }).patch({ transactionReference: 'TRANSACTION_REF' })
+    await InvoiceModel.query()
+      .findOne({ billRunId: transaction.billRunId })
+      .patch({ transactionReference: 'TRANSACTION_REF' })
   })
 
   afterEach(async () => {

--- a/test/services/files/transactions/generate_sroc_transaction_file.service.test.js
+++ b/test/services/files/transactions/generate_sroc_transaction_file.service.test.js
@@ -26,7 +26,7 @@ const { temporaryFilePath } = require('../../../../config/server.config')
 // Thing under test
 const { GenerateSrocTransactionFileService } = require('../../../../app/services')
 
-describe.only('Generate Sroc Transaction File service', () => {
+describe('Generate Sroc Transaction File service', () => {
   const filename = 'abcde67890t'
   const filenameWithPath = path.join(temporaryFilePath, filename)
 

--- a/test/services/files/transactions/generate_sroc_transaction_file.service.test.js
+++ b/test/services/files/transactions/generate_sroc_transaction_file.service.test.js
@@ -35,7 +35,7 @@ describe.only('Generate Sroc Transaction File service', () => {
   beforeEach(async () => {
     await DatabaseHelper.clean()
 
-    const transaction = await NewTransactionHelper.create(null, { ruleset: 'sroc' })
+    const transaction = await NewTransactionHelper.create(null, _srocOverrides())
     billRun = await BillRunModel.query().findOne({ id: transaction.billRunId })
 
     // Set the file reference and bill run number on the bill run
@@ -100,7 +100,7 @@ describe.only('Generate Sroc Transaction File service', () => {
     const date = presenter._formatDate(new Date())
 
     const head = _contentLine(['H', '0000000', 'NAL', 'A', 'I', '67890T', '12345', date])
-    const body = _contentLine(['D', '0000001', 'TH230000222', date, 'I', 'TRANSACTION_REF', '', 'GBP', '', date, '', '', '', '', '', '', '', '', '', '772', '', 'ARCA', 'Well at Chigley Town Hall', 'AT', '', 'TONY/TF9222/37', '', '01-APR-2018 - 31-MAR-2019', '100/200', '2.1.145', 'CHARGE_CATEGORY_DESC', '178300', '', '628200,Nene - Water Newton', '125.1 / 322.23 Ml', '78500', '30% (Northumbria)', '', '', '', '1', 'Each', '772'])
+    const body = _contentLine(['D', '0000001', 'TH230000222', date, 'I', 'TRANSACTION_REF', '', 'GBP', '', date, '', '', '', '', '', '', '', '', '', '772', '', 'ARCA', 'Well at Chigley Town Hall', 'AT', '', 'TONY/TF9222/37', '', '01-APR-2018 - 31-MAR-2019', '100/200', '2.1.145', 'CHARGE_CATEGORY_DESC', '178300', '', '628200, Nene - Water Newton', '125.1 / 322.23 Ml', '78500', '', '', '', '', '1', 'Each', '772'])
     const tail = _contentLine(['T', '0000002', '3', '0', '0'])
 
     return head.concat(body).concat(tail)
@@ -124,5 +124,26 @@ describe.only('Generate Sroc Transaction File service', () => {
     }
 
     return splitLines.length
+  }
+
+  function _srocOverrides () {
+    return {
+      ruleset: 'sroc',
+      lineAttr3: '100/200',
+      headerAttr4: '2.1.145',
+      regimeValue18: 'CHARGE_CATEGORY_DESC',
+      headerAttr9: '178300',
+      headerAttr2: '1',
+      regimeValue19: '1',
+      lineAttr2: '01-APR-2018 - 31-MAR-2019',
+      headerAttr5: 'true',
+      lineAttr11: '628200',
+      headerAttr6: 'Nene - Water Newton',
+      regimeValue16: 'true',
+      regimeValue20: '125.1',
+      headerAttr3: '322.23',
+      headerAttr7: 'true',
+      headerAttr10: '78500'
+    }
   }
 })

--- a/test/services/files/transactions/generate_sroc_transaction_file.service.test.js
+++ b/test/services/files/transactions/generate_sroc_transaction_file.service.test.js
@@ -27,7 +27,7 @@ const { temporaryFilePath } = require('../../../../config/server.config')
 const { GenerateSrocTransactionFileService } = require('../../../../app/services')
 
 describe.only('Generate Sroc Transaction File service', () => {
-  const filename = 'abcde67890'
+  const filename = 'abcde67890t'
   const filenameWithPath = path.join(temporaryFilePath, filename)
 
   let billRun
@@ -35,7 +35,7 @@ describe.only('Generate Sroc Transaction File service', () => {
   beforeEach(async () => {
     await DatabaseHelper.clean()
 
-    const transaction = await NewTransactionHelper.create()
+    const transaction = await NewTransactionHelper.create(null, { ruleset: 'sroc' })
     billRun = await BillRunModel.query().findOne({ id: transaction.billRunId })
 
     // Set the file reference and bill run number on the bill run
@@ -99,8 +99,8 @@ describe.only('Generate Sroc Transaction File service', () => {
     const presenter = new BasePresenter()
     const date = presenter._formatDate(new Date())
 
-    const head = _contentLine(['H', '0000000', 'NAL', 'A', 'I', '67890', '12345', date])
-    const body = _contentLine(['D', '0000001', 'TH230000222', date, 'I', 'TRANSACTION_REF', '', 'GBP', '', date, '', '', '', '', '', '', '', '', '', '772', '', 'ARCA', 'Well at Chigley Town Hall', 'A', '', 'TONY/TF9222/37', '01-APR-2018 - 31-MAR-2019', 'null', '1495', '6.22 Ml', '3', '1.6', '0.03', '', '', '', '', '', '', '', '1', 'Each', '772'])
+    const head = _contentLine(['H', '0000000', 'NAL', 'A', 'I', '67890T', '12345', date])
+    const body = _contentLine(['D', '0000001', 'TH230000222', date, 'I', 'TRANSACTION_REF', '', 'GBP', '', date, '', '', '', '', '', '', '', '', '', '772', '', 'ARCA', 'Well at Chigley Town Hall', 'AT', '', 'TONY/TF9222/37', '', '01-APR-2018 - 31-MAR-2019', '100/200', '2.1.145', 'CHARGE_CATEGORY_DESC', '178300', '', '628200,Nene - Water Newton', '125.1 / 322.23 Ml', '78500', '30% (Northumbria)', '', '', '', '1', 'Each', '772'])
     const tail = _contentLine(['T', '0000002', '3', '0', '0'])
 
     return head.concat(body).concat(tail)

--- a/test/services/files/transactions/generate_sroc_transaction_file.service.test.js
+++ b/test/services/files/transactions/generate_sroc_transaction_file.service.test.js
@@ -1,0 +1,124 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { afterEach, beforeEach, describe, it } = exports.lab = Lab.script()
+const { expect } = Code
+
+const fs = require('fs')
+const path = require('path')
+
+// Test helpers
+const {
+  BillRunHelper,
+  DatabaseHelper,
+  GeneralHelper,
+  TransactionHelper
+} = require('../../../support/helpers')
+
+const { InvoiceModel, TransactionModel } = require('../../../../app/models')
+
+const { BasePresenter } = require('../../../../app/presenters')
+
+const { temporaryFilePath } = require('../../../../config/server.config')
+
+// Thing under test
+const { GenerateSrocTransactionFileService } = require('../../../../app/services')
+
+describe.only('Generate Sroc Transaction File service', () => {
+  const filename = 'abcde67890'
+  const filenameWithPath = path.join(temporaryFilePath, filename)
+
+  let billRun
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+
+    billRun = await BillRunHelper.addBillRun(GeneralHelper.uuid4(), GeneralHelper.uuid4())
+    billRun.fileReference = filename
+    billRun.billRunNumber = 12345
+
+    await TransactionHelper.addTransaction(billRun.id)
+
+    // Set the transaction reference on the invoice
+    await InvoiceModel.query().findOne({ billRunId: billRun.id }).patch({ transactionReference: 'TRANSACTION_REF' })
+  })
+
+  afterEach(async () => {
+    Sinon.restore()
+  })
+
+  it('creates a file with the correct content', async () => {
+    const returnedFilenameWithPath = await GenerateSrocTransactionFileService.go(billRun, filename)
+
+    const file = fs.readFileSync(returnedFilenameWithPath, 'utf-8')
+    const expectedContent = _expectedContent()
+
+    expect(file).to.equal(expectedContent)
+  })
+
+  it('returns the filename and path', async () => {
+    const returnedFilenameWithPath = await GenerateSrocTransactionFileService.go(billRun, filename)
+
+    expect(returnedFilenameWithPath).to.equal(filenameWithPath)
+  })
+
+  it('excludes invoices without a transaction reference', async () => {
+    // Remove the transaction reference
+    await InvoiceModel.query().findOne({ billRunId: billRun.id }).patch({ transactionReference: null })
+    const returnedFilenameWithPath = await GenerateSrocTransactionFileService.go(billRun, filename)
+
+    const file = fs.readFileSync(returnedFilenameWithPath, 'utf-8')
+    const numberOfLines = _numberOfLines(file)
+
+    // The transaction should be excluded so only the head and tail should be written to the file
+    expect(numberOfLines).to.equal(2)
+  })
+
+  it('excludes zero-value transactions', async () => {
+    // Set the charge value to 0
+    await TransactionModel.query().findOne({ billRunId: billRun.id }).patch({ chargeValue: 0 })
+    const returnedFilenameWithPath = await GenerateSrocTransactionFileService.go(billRun, filename)
+
+    const file = fs.readFileSync(returnedFilenameWithPath, 'utf-8')
+    const numberOfLines = _numberOfLines(file)
+
+    // The transaction should be excluded so only the head and tail should be written to the file
+    expect(numberOfLines).to.equal(2)
+  })
+
+  function _expectedContent () {
+    // Get today's date using new Date() and convert it to the format we expect using BaseBresenter._formatDate()
+    const presenter = new BasePresenter()
+    const date = presenter._formatDate(new Date())
+
+    const head = _contentLine(['H', '0000000', 'NAL', 'A', 'I', '67890', '12345', date])
+    const body = _contentLine(['D', '0000001', 'TH230000222', date, 'I', 'TRANSACTION_REF', '', 'GBP', '', date, '', '', '', '', '', '', '', '', '', '772', '', 'ARCA', 'Well at Chigley Town Hall', 'A', '', 'TONY/TF9222/37', '01-APR-2018 - 31-MAR-2019', 'null', '1495', '6.22 Ml', '3', '1.6', '0.03', '', '', '', '', '', '', '', '1', 'Each', '772'])
+    const tail = _contentLine(['T', '0000002', '3', '0', '0'])
+
+    return head.concat(body).concat(tail)
+  }
+
+  function _contentLine (contentArray) {
+    return contentArray.map(item => `"${item}"`)
+      .join(',')
+      .concat('\n')
+  }
+
+  function _numberOfLines (file) {
+    // Split the file into an array by \n
+    const splitLines = file.split('\n')
+
+    // Pop the last element from the array then push it back if it contains text
+    // This gets rid of the last line if it's empty to ensure the value we return is the number of populated lines
+    const lastElement = splitLines.pop()
+    if (lastElement) {
+      splitLines.push(lastElement)
+    }
+
+    return splitLines.length
+  }
+})

--- a/test/services/files/transactions/send_transaction_file.service.test.js
+++ b/test/services/files/transactions/send_transaction_file.service.test.js
@@ -17,7 +17,12 @@ const {
 } = require('../../../support/helpers')
 
 // Things we need to stub
-const { DeleteFileService, GeneratePresrocTransactionFileService, SendFileToS3Service } = require('../../../../app/services')
+const {
+  DeleteFileService,
+  GeneratePresrocTransactionFileService,
+  GenerateSrocTransactionFileService,
+  SendFileToS3Service
+} = require('../../../../app/services')
 
 // Thing under test
 const { SendTransactionFileService } = require('../../../../app/services')
@@ -26,7 +31,7 @@ describe('Send Transaction File service', () => {
   let regime
   let billRun
   let deleteStub
-  let generateStub
+  let generatePresrocStub
   let sendStub
   let notifierFake
 
@@ -37,7 +42,7 @@ describe('Send Transaction File service', () => {
     billRun = await BillRunHelper.addBillRun(regime.id, GeneralHelper.uuid4())
 
     deleteStub = Sinon.stub(DeleteFileService, 'go')
-    generateStub = Sinon.stub(GeneratePresrocTransactionFileService, 'go').returns('stubFilename')
+    generatePresrocStub = Sinon.stub(GeneratePresrocTransactionFileService, 'go').returns('stubPresrocFilename')
     sendStub = Sinon.stub(SendFileToS3Service, 'go')
 
     // Create a fake function to stand in place of Notifier.omfg()
@@ -61,15 +66,15 @@ describe('Send Transaction File service', () => {
       it('generates a transaction file', async () => {
         await SendTransactionFileService.go(regime, billRun)
 
-        expect(generateStub.calledOnce).to.be.true()
-        expect(generateStub.getCall(0).args[1]).to.equal(`${billRun.fileReference}.dat`)
+        expect(generatePresrocStub.calledOnce).to.be.true()
+        expect(generatePresrocStub.getCall(0).args[1]).to.equal(`${billRun.fileReference}.dat`)
       })
 
       it('sends the transaction file', async () => {
         await SendTransactionFileService.go(regime, billRun)
 
         expect(sendStub.calledOnce).to.be.true()
-        expect(sendStub.getCall(0).firstArg).to.equal('stubFilename')
+        expect(sendStub.getCall(0).firstArg).to.equal('stubPresrocFilename')
         expect(sendStub.getCall(0).args[1]).to.equal(`export/${regime.slug}/transaction/${billRun.fileReference}.dat`)
       })
 
@@ -92,7 +97,7 @@ describe('Send Transaction File service', () => {
       it("doesn't try to generate a transaction file", async () => {
         await SendTransactionFileService.go(regime, billRun)
 
-        expect(generateStub.notCalled).to.be.true()
+        expect(generatePresrocStub.notCalled).to.be.true()
       })
 
       it("doesn't try to send the transaction file", async () => {

--- a/test/services/files/transactions/send_transaction_file.service.test.js
+++ b/test/services/files/transactions/send_transaction_file.service.test.js
@@ -86,6 +86,20 @@ describe('Send Transaction File service', () => {
           expect(generateSrocStub.calledOnce).to.be.true()
         })
       })
+
+      describe('but, if the bill run has an invalid ruleset', () => {
+        beforeEach(async () => {
+          billRun.ruleset = 'INVALID'
+        })
+
+        it('throws an error', async () => {
+          const err = await expect(
+            SendTransactionFileService.go(regime, billRun)
+          ).to.reject()
+
+          expect(err).to.be.an.error()
+        })
+      })
     })
 
     describe('and a transaction file is required', () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/CMEA-257

We create `GenerateSrocTransactionFileService` which uses `TransactionFileSrocBodyPresenter` (along with the regular head and tail presenters) to format a transaction file for sroc.

Testing this uncovered a small defect with `TransactionFileSrocBodyPresenter` -- we check whether `headerAttr2` and `regimeValue19` equal `1`, but these are stored as strings in the db so we fix this to check against `'1'` instead.