### PR TITLE
Add `prorataDays`/`lineAttr3` to sroc charge

### DIFF
--- a/app/translators/calculate_charge_base.translator.js
+++ b/app/translators/calculate_charge_base.translator.js
@@ -110,6 +110,32 @@ class CalculateChargeBaseTranslator extends BaseTranslator {
 
     return (month <= 2 ? year - 1 : year)
   }
+
+  /**
+   * Returns billable and authorised day values as a specially formatted string.
+   *
+   * For example, if billable days is 12 and authorised days is 6 it will return `012/006`.
+   *
+   * The exception is if this is a two-part tariff (ie. regimeValue16 is true); in this case, it returns `000/000`.
+   *
+   * @returns {String} Billable days and authorised days as a formatted string
+   */
+  _prorataDays () {
+    return this.regimeValue16
+      ? '000/000'
+      : `${this._padNumber(this.regimeValue4)}/${this._padNumber(this.regimeValue5)}`
+  }
+
+  /**
+   * Return a number as a string, padded to 3 digits with leading zeroes
+   *
+   * For example, `_padNumber(3)` will return `003`.
+   *
+   * @returns {Number} the number padded with leading zeroes
+   */
+  _padNumber (number) {
+    return number.toString().padStart(3, '0')
+  }
 }
 
 module.exports = CalculateChargeBaseTranslator

--- a/app/translators/calculate_charge_presroc.translator.js
+++ b/app/translators/calculate_charge_presroc.translator.js
@@ -114,32 +114,6 @@ class CalculateChargePresrocTranslator extends CalculateChargeBaseTranslator {
       throw Boom.badData(error)
     }
   }
-
-  /**
-   * Returns billable and authorised day values as a specially formatted string.
-   *
-   * For example, if billable days is 12 and authorised days is 6 it will return `012/006`.
-   *
-   * The exception is if this is a two-part tariff (ie. regimeValue16 is true); in this case, it returns `000/000`.
-   *
-   * @returns {String} Billable days and authorised days as a formatted string
-   */
-  _prorataDays () {
-    return this.regimeValue16
-      ? '000/000'
-      : `${this._padNumber(this.regimeValue4)}/${this._padNumber(this.regimeValue5)}`
-  }
-
-  /**
-   * Return a number as a string, padded to 3 digits with leading zeroes
-   *
-   * For example, `_padNumber(3)` will return `003`.
-   *
-   * @returns {Number} the number padded with leading zeroes
-   */
-  _padNumber (number) {
-    return number.toString().padStart(3, '0')
-  }
 }
 
 module.exports = CalculateChargePresrocTranslator

--- a/app/translators/calculate_charge_sroc.translator.js
+++ b/app/translators/calculate_charge_sroc.translator.js
@@ -11,6 +11,7 @@ class CalculateChargeSrocTranslator extends CalculateChargeBaseTranslator {
   constructor (data) {
     super(data)
 
+    this.lineAttr3 = this._prorataDays()
     this.chargeFinancialYear = this._financialYear(this.chargePeriodStart)
 
     // Additional post-getter validation to ensure periodStart and periodEnd are in the same financial year

--- a/app/translators/transaction_sroc.translator.js
+++ b/app/translators/transaction_sroc.translator.js
@@ -19,6 +19,7 @@ class TransactionSrocTranslator extends TransactionBaseTranslator {
   _translations () {
     return {
       ruleset: 'ruleset',
+      prorataDays: 'lineAttr3',
 
       // Transaction-related, validated here
       billRunId: 'billRunId',

--- a/test/translators/calculate_charge_sroc.translator.test.js
+++ b/test/translators/calculate_charge_sroc.translator.test.js
@@ -77,6 +77,44 @@ describe('Calculate Charge Sroc translator', () => {
     })
   })
 
+  describe('calculating prorataDays', () => {
+    it('correctly calculates the format', async () => {
+      const proraratPayload = {
+        ...payload,
+        billableDays: 128,
+        authorisedDays: 256
+      }
+      const testTranslator = new CalculateChargeSrocTranslator(data(proraratPayload))
+
+      expect(testTranslator.lineAttr3).to.equal('128/256')
+    })
+
+    it('correctly pads values to 3 digits', async () => {
+      const proraratPayload = {
+        ...payload,
+        billableDays: 8,
+        authorisedDays: 16
+      }
+      const testTranslator = new CalculateChargeSrocTranslator(data(proraratPayload))
+
+      expect(testTranslator.lineAttr3).to.equal('008/016')
+    })
+
+    it("correctly uses '000/000' for a 2-part tariff", async () => {
+      const proraratPayload = {
+        ...payload,
+        billableDays: 8,
+        authorisedDays: 16,
+        section127Agreement: true,
+        twoPartTariff: true
+      }
+
+      const testTranslator = new CalculateChargeSrocTranslator(data(proraratPayload))
+
+      expect(testTranslator.lineAttr3).to.equal('000/000')
+    })
+  })
+
   describe('calculating the financial year', () => {
     it("correctly determines the previous year for 'period' dates in March or earlier", async () => {
       const financialYearPayload = {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/CMEA-257

We need to put the prorata days string in the sroc transaction file (as we do with presroc transaction files), however we overlooked this when setting up our sroc charge. Therefore we need to update `CalculateChargeSrocTranslator` so that it adds this in. We do this by refactoring the prorata days methods into the `CalculateChargeBaseTranslator`.