### PR TITLE
Store `abatementFactor` in `regimeValue11`

### DIFF
--- a/app/presenters/rules_service_sroc.presenter.js
+++ b/app/presenters/rules_service_sroc.presenter.js
@@ -19,7 +19,7 @@ class RulesServiceSrocPresenter extends BasePresenter {
         WRLSChargingRequest: {
           // Some field names differ from their use elsewhere, eg. CalculateChargeSrocTranslator. Their alternate names
           // are commented below.
-          abatementAdjustment: data.regimeValue19,
+          abatementAdjustment: data.regimeValue11,
           abstractableDays: data.regimeValue5, // authorisedDays
           actualVolume: data.regimeValue20,
           aggregateProportion: data.headerAttr2,

--- a/app/presenters/rules_service_sroc.presenter.js
+++ b/app/presenters/rules_service_sroc.presenter.js
@@ -19,7 +19,7 @@ class RulesServiceSrocPresenter extends BasePresenter {
         WRLSChargingRequest: {
           // Some field names differ from their use elsewhere, eg. CalculateChargeSrocTranslator. Their alternate names
           // are commented below.
-          abatementAdjustment: data.regimeValue11,
+          abatementAdjustment: data.regimeValue11, // abatementFactor
           abstractableDays: data.regimeValue5, // authorisedDays
           actualVolume: data.regimeValue20,
           aggregateProportion: data.headerAttr2,

--- a/app/presenters/transaction_file_sroc_body.presenter.js
+++ b/app/presenters/transaction_file_sroc_body.presenter.js
@@ -111,7 +111,7 @@ class TransactionFileSrocBodyPresenter extends BasePresenter {
       reductions.push('CRT Discount')
     }
 
-    if (data.regimeValue19 !== '1') { // abatementFactor
+    if (data.regimeValue11 !== '1') { // abatementFactor
       reductions.push('Abatement of Charges')
     }
 

--- a/app/services/files/transactions/generate_sroc_transaction_file.service.js
+++ b/app/services/files/transactions/generate_sroc_transaction_file.service.js
@@ -32,7 +32,7 @@ class GenerateSrocTransactionFileService extends BaseGenerateTransactionFileServ
       'headerAttr2', // aggregateProportion
       'lineAttr12', // winterOnly
       'regimeValue9', // section130Agreement
-      'regimeValue19', // abatementFactor
+      'regimeValue11', // abatementFactor
       'regimeValue12', // section127Agreement
       'headerAttr5', // supportedSource
       'lineAttr11', // supportedSourceValue

--- a/app/translators/calculate_charge_sroc.translator.js
+++ b/app/translators/calculate_charge_sroc.translator.js
@@ -53,7 +53,7 @@ class CalculateChargeSrocTranslator extends CalculateChargeBaseTranslator {
 
   _translations () {
     return {
-      abatementFactor: 'regimeValue19',
+      abatementFactor: 'regimeValue11',
       actualVolume: 'regimeValue20',
       aggregateProportion: 'headerAttr2',
       authorisedDays: 'regimeValue5',

--- a/app/translators/transaction_sroc.translator.js
+++ b/app/translators/transaction_sroc.translator.js
@@ -37,7 +37,7 @@ class TransactionSrocTranslator extends TransactionBaseTranslator {
       chargeCategoryDescription: 'regimeValue18',
 
       // Charge-related, validated in CalculateChargeSrocTranslator
-      abatementFactor: 'regimeValue19',
+      abatementFactor: 'regimeValue11',
       actualVolume: 'regimeValue20',
       aggregateProportion: 'headerAttr2',
       authorisedDays: 'regimeValue5',

--- a/test/presenters/transaction_file_sroc_body.presenter.test.js
+++ b/test/presenters/transaction_file_sroc_body.presenter.test.js
@@ -34,7 +34,7 @@ describe('Transaction File Sroc Body Presenter', () => {
     headerAttr2: '1',
     lineAttr12: 'false',
     regimeValue9: 'false',
-    regimeValue19: '1',
+    regimeValue11: '1',
     regimeValue12: 'false',
     // Supported source, col34
     headerAttr5: 'true',
@@ -192,7 +192,7 @@ describe('Transaction File Sroc Body Presenter', () => {
         headerAttr2: 0.5,
         lineAttr12: 'true',
         regimeValue9: 'true',
-        regimeValue19: 0.5,
+        regimeValue11: 0.5,
         regimeValue12: 'true'
       })
 

--- a/test/services/files/transactions/generate_sroc_transaction_file.service.test.js
+++ b/test/services/files/transactions/generate_sroc_transaction_file.service.test.js
@@ -134,7 +134,7 @@ describe('Generate Sroc Transaction File service', () => {
       regimeValue18: 'CHARGE_CATEGORY_DESC',
       headerAttr9: '178300',
       headerAttr2: '1',
-      regimeValue19: '1',
+      regimeValue11: '1',
       lineAttr2: '01-APR-2018 - 31-MAR-2019',
       headerAttr5: 'true',
       lineAttr11: '628200',

--- a/test/translators/calculate_charge_sroc.translator.test.js
+++ b/test/translators/calculate_charge_sroc.translator.test.js
@@ -52,7 +52,7 @@ describe('Calculate Charge Sroc translator', () => {
       }
       const testTranslator = new CalculateChargeSrocTranslator(data(abatementFactorPayload))
 
-      expect(testTranslator.regimeValue19).to.be.a.number().and.equal(1.0)
+      expect(testTranslator.regimeValue11).to.be.a.number().and.equal(1.0)
     })
 
     it('defaults aggregateProportion to `1.0`', async () => {
@@ -245,7 +245,7 @@ describe('Calculate Charge Sroc translator', () => {
         it('accepts a decimal value', async () => {
           const testTranslator = new CalculateChargeSrocTranslator(data(validPayload))
 
-          expect(testTranslator.regimeValue19).to.be.a.number().and.equal(0.75)
+          expect(testTranslator.regimeValue11).to.be.a.number().and.equal(0.75)
         })
       })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/CMEA-258

We need to find somewhere in the database to store `adjustmentFactor` as part of the above card. As part of our previous work of storing sroc-only data in unused fields, we ended up using all the existing generic fields to do so. This means that we potentially need to create a new db field for `adjustmentFactor` -- which we would like to avoid if possible so we don't need to run migrations on all our environments (including prod). Thankfully, a solution presents itself!

While looking over the existing data, we realised that the presroc `section126Factor` value which we currently store in the db as `regimeValue11` and the sroc `abatementFactor` value which we currently store as `regimeValue19` are simply two names for pretty much the same thing. (To be precise: the section 126 factor is an example of an abatement factor; we are simply giving it a more general name under sroc). This was in part identified by the fact that we pass both of these to the rules service under the same name `abatementAdjustment` (and we acknowledge that this name is a little confusing for an **abatement** factor, given that an **adjustment** factor is an entirely separate thing!).

Since `section126Factor` and `abatementFactor` are effectively the presroc and sroc names for the same thing, we therefore change our existing code so we now store `abatementFactor` as `regimeValue11` to match how we store `section126Factor`. This therefore frees us `regimeValue19` for us to store `adjustmentFactor`.