### PR TITLE
Add `adjustmentFactor` to sroc validation

### DIFF
--- a/app/translators/calculate_charge_sroc.translator.js
+++ b/app/translators/calculate_charge_sroc.translator.js
@@ -24,6 +24,7 @@ class CalculateChargeSrocTranslator extends CalculateChargeBaseTranslator {
       ruleset: Joi.string().valid('sroc').required(),
 
       abatementFactor: Joi.number().allow(null).empty(null).default(1.0),
+      adjustmentFactor: Joi.number().greater(0).required(),
       aggregateProportion: Joi.number().allow(null).empty(null).default(1.0),
       periodStart: Joi.date().format(this._validDateFormats()).min('01-APR-2021').max(Joi.ref('periodEnd')).required(),
       authorisedVolume: Joi.number().greater(0).required(),
@@ -55,6 +56,7 @@ class CalculateChargeSrocTranslator extends CalculateChargeBaseTranslator {
     return {
       abatementFactor: 'regimeValue11',
       actualVolume: 'regimeValue20',
+      adjustmentFactor: 'regimeValue19',
       aggregateProportion: 'headerAttr2',
       authorisedDays: 'regimeValue5',
       authorisedVolume: 'headerAttr3',

--- a/app/translators/transaction_sroc.translator.js
+++ b/app/translators/transaction_sroc.translator.js
@@ -39,6 +39,7 @@ class TransactionSrocTranslator extends TransactionBaseTranslator {
       // Charge-related, validated in CalculateChargeSrocTranslator
       abatementFactor: 'regimeValue11',
       actualVolume: 'regimeValue20',
+      adjustmentFactor: 'regimeValue19',
       aggregateProportion: 'headerAttr2',
       authorisedDays: 'regimeValue5',
       authorisedVolume: 'headerAttr3',

--- a/test/support/fixtures/calculate_charge/sroc/simple_request.json
+++ b/test/support/fixtures/calculate_charge/sroc/simple_request.json
@@ -1,6 +1,7 @@
 {
   "abatementFactor": 1.0,
   "actualVolume": 2.0,
+  "adjustmentFactor": 1.0,
   "aggregateProportion": 1.0,
   "authorisedDays": 214,
   "billableDays": 214,

--- a/test/support/fixtures/create_transaction/sroc/simple.json
+++ b/test/support/fixtures/create_transaction/sroc/simple.json
@@ -1,6 +1,7 @@
 {
   "abatementFactor": 1.0,
   "actualVolume": 2.0,
+  "adjustmentFactor": 1.0,
   "aggregateProportion": 1.0,
   "areaCode": "ARCA",
   "authorisedDays": 214,

--- a/test/translators/calculate_charge_sroc.translator.test.js
+++ b/test/translators/calculate_charge_sroc.translator.test.js
@@ -34,7 +34,8 @@ describe('Calculate Charge Sroc translator', () => {
     loss: 'Low',
     authorisedVolume: 1,
     actualVolume: 1,
-    credit: false
+    credit: false,
+    adjustmentFactor: 1
   }
 
   const data = (payload, regime = 'wrls') => {
@@ -967,6 +968,50 @@ describe('Calculate Charge Sroc translator', () => {
             const invalidPayload = {
               ...payload,
               credit: 'INVALID'
+            }
+
+            expect(() => new CalculateChargeSrocTranslator(data(invalidPayload))).to.throw(ValidationError)
+          })
+        })
+      })
+
+      describe('because adjustmentFactor', () => {
+        describe('is missing', () => {
+          it('throws an error', async () => {
+            const invalidPayload = { ...payload }
+            delete invalidPayload.adjustmentFactor
+
+            expect(() => new CalculateChargeSrocTranslator(data(invalidPayload))).to.throw(ValidationError)
+          })
+        })
+
+        describe('is not a number', () => {
+          it('throws an error', async () => {
+            const invalidPayload = {
+              ...payload,
+              adjustmentFactor: 'INVALID'
+            }
+
+            expect(() => new CalculateChargeSrocTranslator(data(invalidPayload))).to.throw(ValidationError)
+          })
+        })
+
+        describe('is 0', () => {
+          it('throws an error', async () => {
+            const invalidPayload = {
+              ...payload,
+              adjustmentFactor: 0
+            }
+
+            expect(() => new CalculateChargeSrocTranslator(data(invalidPayload))).to.throw(ValidationError)
+          })
+        })
+
+        describe('is less than 0', () => {
+          it('throws an error', async () => {
+            const invalidPayload = {
+              ...payload,
+              adjustmentFactor: -1
             }
 
             expect(() => new CalculateChargeSrocTranslator(data(invalidPayload))).to.throw(ValidationError)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/CMEA-258

We update `CalculateChargeSrocTranslator` to validate `adjustmentFactor` and translate it to `regimeValue19`. We also update `TransactionSrocTranslator` to accept it and pass it on to the charge translator.