### PR TITLE
Add `adjustmentFactor` to `RulesServiceSrocPresenter`

### DIFF
--- a/app/presenters/rules_service_sroc.presenter.js
+++ b/app/presenters/rules_service_sroc.presenter.js
@@ -22,6 +22,7 @@ class RulesServiceSrocPresenter extends BasePresenter {
           abatementAdjustment: data.regimeValue11, // abatementFactor
           abstractableDays: data.regimeValue5, // authorisedDays
           actualVolume: data.regimeValue20,
+          adjustmentFactor: data.regimeValue19,
           aggregateProportion: data.headerAttr2,
           authorisedVolume: data.headerAttr3,
           billableDays: data.regimeValue4,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/CMEA-258

Now that we expect and validate `adjustmentFactor` for sroc charge and transaction requests, the next thing we need to do is include this in Rules Service requests for sroc, which is simply a case of adding it to `RulesServiceSrocPresenter`.