### PR TITLE
Use `adjustmentFactor` in sroc transaction file

### DIFF
--- a/app/presenters/transaction_file_sroc_body.presenter.js
+++ b/app/presenters/transaction_file_sroc_body.presenter.js
@@ -119,6 +119,10 @@ class TransactionFileSrocBodyPresenter extends BasePresenter {
       reductions.push('Two-Part Tariff')
     }
 
+    if (data.regimeValue19 !== '1') { // adjustmentFactor
+      reductions.push('Other')
+    }
+
     return reductions.join(', ')
   }
 

--- a/app/services/files/transactions/generate_sroc_transaction_file.service.js
+++ b/app/services/files/transactions/generate_sroc_transaction_file.service.js
@@ -33,6 +33,7 @@ class GenerateSrocTransactionFileService extends BaseGenerateTransactionFileServ
       'lineAttr12', // winterOnly
       'regimeValue9', // section130Agreement
       'regimeValue11', // abatementFactor
+      'regimeValue19', // adjustmentFactor
       'regimeValue12', // section127Agreement
       'headerAttr5', // supportedSource
       'lineAttr11', // supportedSourceValue

--- a/test/presenters/transaction_file_sroc_body.presenter.test.js
+++ b/test/presenters/transaction_file_sroc_body.presenter.test.js
@@ -36,6 +36,7 @@ describe('Transaction File Sroc Body Presenter', () => {
     regimeValue9: 'false',
     regimeValue11: '1',
     regimeValue12: 'false',
+    regimeValue19: '1',
     // Supported source, col34
     headerAttr5: 'true',
     lineAttr11: 15000,
@@ -193,12 +194,13 @@ describe('Transaction File Sroc Body Presenter', () => {
         lineAttr12: 'true',
         regimeValue9: 'true',
         regimeValue11: 0.5,
-        regimeValue12: 'true'
+        regimeValue12: 'true',
+        regimeValue19: 0.5
       })
 
       const result = presenter.go()
 
-      expect(result.col33).to.equal('Aggregate, Winter Only Discount, CRT Discount, Abatement of Charges, Two-Part Tariff')
+      expect(result.col33).to.equal('Aggregate, Winter Only Discount, CRT Discount, Abatement of Charges, Two-Part Tariff, Other')
     })
 
     it('returns an empty list if no reductions apply', () => {

--- a/test/services/files/transactions/generate_sroc_transaction_file.service.test.js
+++ b/test/services/files/transactions/generate_sroc_transaction_file.service.test.js
@@ -135,6 +135,7 @@ describe('Generate Sroc Transaction File service', () => {
       headerAttr9: '178300',
       headerAttr2: '1',
       regimeValue11: '1',
+      regimeValue19: '1',
       lineAttr2: '01-APR-2018 - 31-MAR-2019',
       headerAttr5: 'true',
       lineAttr11: '628200',


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/CMEA-258

If `adjustmentFactor` is anything other than `1` then we want to add `Other` to the list of reductions in the sroc transaction file. We do this by amending `GenerateSrocTransactionFileService` to retrieve `regimeValue19` as part of the select query to get all the required data for the transaction file, then updating `TransactionFileSrocBodyPresenter` to add `Other` to the list of reductions based on its value.