### PR TITLE
Fix `Winter Only Discount` defect in transaction file

### DIFF
--- a/app/presenters/transaction_file_sroc_body.presenter.js
+++ b/app/presenters/transaction_file_sroc_body.presenter.js
@@ -103,7 +103,7 @@ class TransactionFileSrocBodyPresenter extends BasePresenter {
       reductions.push('Aggregate')
     }
 
-    if (this._isTrue(data.lineAttr12)) { // winterOnly
+    if (this._isTrue(data.headerAttr8)) { // winterOnly
       reductions.push('Winter Only Discount')
     }
 

--- a/app/services/files/transactions/generate_sroc_transaction_file.service.js
+++ b/app/services/files/transactions/generate_sroc_transaction_file.service.js
@@ -30,7 +30,7 @@ class GenerateSrocTransactionFileService extends BaseGenerateTransactionFileServ
       'headerAttr9', // baseCharge
       'regimeValue17', // compensationCharge
       'headerAttr2', // aggregateProportion
-      'lineAttr12', // winterOnly
+      'headerAttr8', // winterOnly
       'regimeValue9', // section130Agreement
       'regimeValue11', // abatementFactor
       'regimeValue19', // adjustmentFactor

--- a/test/presenters/transaction_file_sroc_body.presenter.test.js
+++ b/test/presenters/transaction_file_sroc_body.presenter.test.js
@@ -32,7 +32,7 @@ describe('Transaction File Sroc Body Presenter', () => {
     headerAttr9: 'HEADER_ATTR_9',
     // Reductions, col33
     headerAttr2: '1',
-    lineAttr12: 'false',
+    headerAttr8: 'false',
     regimeValue9: 'false',
     regimeValue11: '1',
     regimeValue12: 'false',
@@ -143,7 +143,7 @@ describe('Transaction File Sroc Body Presenter', () => {
         ...data,
         regimeValue17: 'false',
         // We set a reduction to ensure the reductions col is not empty
-        lineAttr12: 'true'
+        headerAttr8: 'true'
       })
 
       const result = presenter.go()
@@ -191,7 +191,7 @@ describe('Transaction File Sroc Body Presenter', () => {
         ...data,
         regimeValue17: 'false',
         headerAttr2: 0.5,
-        lineAttr12: 'true',
+        headerAttr8: 'true',
         regimeValue9: 'true',
         regimeValue11: 0.5,
         regimeValue12: 'true',


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/CMEA-257

It was found during testing that the reductions list in the transaction file was not correctly being populated with `Winter Only Discount` when the `winterOnly` flag was set in a transaction.

On investigation, we realised that we were checking the wrong value in the db. We were reading the value of `lineAttr12` to determine whether this string should be added to the transactions list; this is in fact `winterOnlyFactor`. We therefore change this to read `headerAttr8`, which is the `winterOnly` boolean we had intended to use.