### PR TITLE
Fix transaction file sort order

### DIFF
--- a/app/services/files/transactions/base_generate_transaction_file.service.js
+++ b/app/services/files/transactions/base_generate_transaction_file.service.js
@@ -36,7 +36,9 @@ class BaseGenerateTransactionFileService {
       .knexQuery()
       .join(...this._join())
       .select(...this._select())
-      .orderBy(...this._sort())
+      // Note that we don't use the spread operator for orderBy as it expects an array, whereas we use it for join and
+      // select as they expect multiple arguments ie. .select('first', 'second', 'third')
+      .orderBy(this._sort())
       .where(builder => this._where(builder, billRun))
   }
 

--- a/test/services/files/transactions/generate_presroc_transaction_file.service.test.js
+++ b/test/services/files/transactions/generate_presroc_transaction_file.service.test.js
@@ -14,6 +14,9 @@ const path = require('path')
 // Test helpers
 const {
   DatabaseHelper,
+  NewBillRunHelper,
+  NewInvoiceHelper,
+  NewLicenceHelper,
   NewTransactionHelper
 } = require('../../../support/helpers')
 
@@ -31,22 +34,24 @@ describe('Generate Presroc Transaction File service', () => {
   const filenameWithPath = path.join(temporaryFilePath, filename)
 
   let billRun
+  let transaction
 
   beforeEach(async () => {
     await DatabaseHelper.clean()
 
-    const transaction = await NewTransactionHelper.create()
+    // Create a transaction with line description 'second' for later comparison. We set compensation charge to 'true'
+    // to ensure this transaction comes second when checking the compensation charge sort order
+    transaction = await NewTransactionHelper.create()
+
+    // Get the bill run
+    billRun = await BillRunModel.query().findById(transaction.billRunId)
 
     // Patch the bill run with file reference and bill run number
-    await BillRunModel.query()
-      .findById(transaction.billRunId)
+    await billRun.$query()
       .patch({
         fileReference: filename,
         billRunNumber: 12345
       })
-
-    // Get the bill run
-    billRun = await BillRunModel.query().findById(transaction.billRunId)
 
     // Set the transaction reference on the invoice
     await InvoiceModel.query()
@@ -96,6 +101,129 @@ describe('Generate Presroc Transaction File service', () => {
     // The transaction should be excluded so only the head and tail should be written to the file
     expect(numberOfLines).to.equal(2)
   })
+
+  describe('the order of the file content', () => {
+    beforeEach(async () => {
+      // We clean the db and start again as we want our initial transaction to be different for these tests
+      await DatabaseHelper.clean()
+
+      // Create a transaction with line description 'second' for later comparison. We set compensation charge to 'true'
+      // to ensure this transaction comes second when checking the compensation charge sort order
+      transaction = await NewTransactionHelper.create(null, {
+        lineDescription: 'second',
+        regimeValue17: 'true'
+      })
+
+      // Get the bill run
+      billRun = await BillRunModel.query().findById(transaction.billRunId)
+
+      // Patch the bill run with file reference and bill run number
+      await billRun.$query()
+        .patch({
+          fileReference: filename,
+          billRunNumber: 12345
+        })
+
+      // Set the transaction reference on the invoice
+      await InvoiceModel.query()
+        .findOne({ billRunId: transaction.billRunId })
+        .patch({ transactionReference: 'TRANSACTION_REF' })
+    })
+
+    it('is correctly sorted by compensation charge', async () => {
+      const newInvoice = await NewInvoiceHelper.create(billRun, { transactionReference: 'TRANSACTION_REF' })
+      const newLicence = await NewLicenceHelper.create(newInvoice)
+      await NewTransactionHelper.create(newLicence, { regimeValue17: 'false', lineDescription: 'first' })
+
+      const returnedFilenameWithPath = await GeneratePresrocTransactionFileService.go(billRun, filename)
+      const file = fs.readFileSync(returnedFilenameWithPath, 'utf-8')
+
+      const result = _getLineDescriptions(file)
+      expect(result).to.equal(['first', 'second'])
+    })
+
+    it('is correctly sorted by licence number', async () => {
+      // Create a new invoice and add a licence with a different licence number, then add a transaction to it
+      const newInvoice = await NewInvoiceHelper.create(billRun, { transactionReference: 'TRANSACTION_REF' })
+      const newLicence = await NewLicenceHelper.create(newInvoice)
+      // We set compensation charge to 'true' to match the first transaction we created
+      await NewTransactionHelper.create(newLicence, { regimeValue17: 'true', lineAttr1: 'A', lineDescription: 'first' })
+
+      const returnedFilenameWithPath = await GeneratePresrocTransactionFileService.go(billRun, filename)
+      const file = fs.readFileSync(returnedFilenameWithPath, 'utf-8')
+
+      const result = _getLineDescriptions(file)
+      expect(result).to.equal(['first', 'second'])
+    })
+
+    it('is correctly sorted by invoice transaction reference', async () => {
+      // Create a new invoice with a different transaction reference and add a licence & transaction to it
+      const newInvoice = await NewInvoiceHelper.create(billRun, { transactionReference: 'A' })
+      const newLicence = await NewLicenceHelper.create(newInvoice)
+      // We set compensation charge to 'true' to match the first transaction we created
+      await NewTransactionHelper.create(newLicence, { regimeValue17: 'true', lineDescription: 'first' })
+
+      const returnedFilenameWithPath = await GeneratePresrocTransactionFileService.go(billRun, filename)
+      const file = fs.readFileSync(returnedFilenameWithPath, 'utf-8')
+
+      const result = _getLineDescriptions(file)
+      expect(result).to.equal(['first', 'second'])
+    })
+
+    it('sorts the fields in the correct order', async () => {
+      // For simplicity's sake we clean the db first then create a fresh bill run
+      await DatabaseHelper.clean()
+      billRun = await NewBillRunHelper.create()
+
+      // Patch the bill run with file reference and bill run number
+      await billRun.$query().patch({
+        fileReference: filename,
+        billRunNumber: 12345
+      })
+
+      // Create 2 invoices and licences
+      const invoiceA = await NewInvoiceHelper.create(billRun, { transactionReference: 'TRANSACTION_REF_A' })
+      const licenceOnInvoiceA = await NewLicenceHelper.create(invoiceA)
+      const invoiceB = await NewInvoiceHelper.create(billRun, { transactionReference: 'TRANSACTION_REF_B' })
+      const licenceOnInvoiceB = await NewLicenceHelper.create(invoiceB)
+
+      // Create our transactions. We do this in a mixed-up order to ensure that sorting takes place
+      await NewTransactionHelper.create(licenceOnInvoiceB, { lineAttr1: 'LICENCE_2', regimeValue17: 'true', lineDescription: 'eighth' })
+      await NewTransactionHelper.create(licenceOnInvoiceA, { lineAttr1: 'LICENCE_1', regimeValue17: 'false', lineDescription: 'first' })
+      await NewTransactionHelper.create(licenceOnInvoiceB, { lineAttr1: 'LICENCE_2', regimeValue17: 'false', lineDescription: 'seventh' })
+      await NewTransactionHelper.create(licenceOnInvoiceA, { lineAttr1: 'LICENCE_1', regimeValue17: 'true', lineDescription: 'second' })
+      await NewTransactionHelper.create(licenceOnInvoiceB, { lineAttr1: 'LICENCE_1', regimeValue17: 'true', lineDescription: 'sixth' })
+      await NewTransactionHelper.create(licenceOnInvoiceA, { lineAttr1: 'LICENCE_2', regimeValue17: 'false', lineDescription: 'third' })
+      await NewTransactionHelper.create(licenceOnInvoiceB, { lineAttr1: 'LICENCE_1', regimeValue17: 'false', lineDescription: 'fifth' })
+      await NewTransactionHelper.create(licenceOnInvoiceA, { lineAttr1: 'LICENCE_2', regimeValue17: 'true', lineDescription: 'fourth' })
+
+      const returnedFilenameWithPath = await GeneratePresrocTransactionFileService.go(billRun, filename)
+      const file = fs.readFileSync(returnedFilenameWithPath, 'utf-8')
+
+      const result = _getLineDescriptions(file)
+      expect(result).to.equal(['first', 'second', 'third', 'fourth', 'fifth', 'sixth', 'seventh', 'eighth'])
+    })
+  })
+
+  /**
+   * Returns an array of line descriptions from a file in order from the first to the last line.
+   *
+   * We expect to receive files which are comma-delimited with quotes around each item. For simplicity, we strip all
+   * double quotes from the file then split each line by comma. This is therefore unsuitable for test data which
+   * contains double quotes or commas.
+   */
+  function _getLineDescriptions (file) {
+    return file
+      // Split the file into an array of lines
+      .split('\n')
+      // Slice the array to remove the head and tail lines. We also exclude the blank line at the end of the file,
+      // hence `slice(1, -2)`
+      .slice(1, -2)
+      // Strip quotes from each line and split by comma
+      .map(line => line.replaceAll('"', '').split(','))
+      // Finally, extract the line description from each line
+      .map(line => line[22])
+  }
 
   function _expectedContent () {
     // Get today's date using new Date() and convert it to the format we expect using BaseBresenter._formatDate()


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/CMEA-257

We found during testing that transaction files were not being sorted in the correct order (first by transaction reference, then by licence number, and then by compensation charge). On investigation we traced this back to the work we did to refactor transaction generation into `BaseGenerateTransactionFileService`.

The issue turned out to be a simple one! Methods like `.select()` expect multiple parameters, eg:
```js
.select('first_field', 'second_field', 'third_field')
```
When we moved the fields into a function, we had that function return an array and then use the spread operator to turn that array into the required series of parameters:
```js
.select(...this._select())
```
This is fine! But what isn't fine is that we did the same for `.orderBy()`. We overlooked the fact that this expects an _array_ of items, not a series of parameters, eg:
```js
.orderBy(['first_field', 'second_field', 'third_field'])
```
As with `.select()`, we moved the fields into a function returning an array, and used the spread operator to turn that array into a series of parameters:
```js
.orderBy(...this_sort())
```
What we should actually have done was simply use the returned value of the function as-is, since it gives us the array that `.orderBy()` expects:
```js
.orderBy(this._sort())
```
Simply removing the spread operator was all we needed to get the sort order working correctly!