### PR TITLE
Change `FetchAndValidateInvoiceService` to `ValidateInvoiceService`

### DIFF
--- a/app/controllers/bill_runs_invoices.controller.js
+++ b/app/controllers/bill_runs_invoices.controller.js
@@ -1,15 +1,16 @@
 'use strict'
 
 const DeleteInvoiceService = require('../services/invoices/delete_invoice.service.js')
-const FetchAndValidateInvoiceService = require('../services/invoices/fetch_and_validate_invoice.service.js')
 const InvoiceRebillingService = require('../services/invoices/invoice_rebilling.service.js')
 const InvoiceRebillingValidationService = require('../services/invoices/invoice_rebilling_validation.service.js')
+const ValidateInvoiceService = require('../services/invoices/validate_invoice.service.js')
 const ViewInvoiceService = require('../services/invoices/view_invoice.service.js')
 
 class BillRunsInvoicesController {
   static async delete (req, h) {
-    // We fetch and validate the invoice within the controller so a not found/conflict error is returned immediately
-    const invoice = await FetchAndValidateInvoiceService.go(req.params.billRunId, req.params.invoiceId)
+    // We validate that the invoice is linked to the bill run within the controller so a not found/conflict error is
+    // returned immediately
+    const invoice = await ValidateInvoiceService.go(req.app.billRun, req.app.invoice)
 
     // We start DeleteInvoiceService without await so that it runs in the background
     DeleteInvoiceService.go(invoice, req.app.billRun, req.app.notifier)

--- a/app/controllers/bill_runs_invoices.controller.js
+++ b/app/controllers/bill_runs_invoices.controller.js
@@ -19,7 +19,7 @@ class BillRunsInvoicesController {
   }
 
   static async view (req, h) {
-    const result = await ViewInvoiceService.go(req.app.billRun.id, req.params.invoiceId)
+    const result = await ViewInvoiceService.go(req.app.billRun, req.app.invoice)
 
     return h.response(result).code(200)
   }

--- a/app/services/invoices/validate_invoice.service.js
+++ b/app/services/invoices/validate_invoice.service.js
@@ -1,0 +1,33 @@
+'use strict'
+
+/**
+ * @module ValidateInvoiceService
+ */
+
+const Boom = require('@hapi/boom')
+
+class ValidateInvoiceService {
+  /**
+  * Validates that an invoice is linked to the specified bill run and throws an error if the invoice is not linked.
+  *
+  * Note that this cannot be done as part of the "request invoice" plugin as the specified invoice is not linked to the
+  * specified bill run when rebilling.
+  *
+  * Intended for use in the `view` and `delete` invoice endpoints.
+  *
+  * @param {string} billRun The bill run the invoice should link to
+  * @param {string} invoice The invoice to validate
+  */
+  static async go (billRun, invoice) {
+    // Simply call the validation method. It will throw an error if any issue is found
+    this._validate(billRun, invoice)
+  }
+
+  static _validate (billRun, invoice) {
+    if (invoice.billRunId !== billRun.id) {
+      throw Boom.conflict(`Invoice ${invoice.id} is not linked to bill run ${billRun.id}.`)
+    }
+  }
+}
+
+module.exports = ValidateInvoiceService

--- a/app/services/invoices/view_invoice.service.js
+++ b/app/services/invoices/view_invoice.service.js
@@ -6,20 +6,20 @@
 
 const ViewInvoicePresenter = require('../../presenters/view_invoice.presenter.js')
 
-const FetchAndValidateInvoiceService = require('./fetch_and_validate_invoice.service.js')
+const ValidateInvoiceService = require('./validate_invoice.service.js')
 
 class ViewInvoiceService {
   /**
    * Locates and validates an invoice for the specificed bill run and returns the data needed by the View Invoice
    * endpoint
    *
-   * @param {string} billRunId The id of the bill run the invoice is linked to
-   * @param {string} invoiceId The id of the invoice we are trying to view
+   * @param {string} billRunId The bill run the invoice is linked to
+   * @param {string} invoiceId The invoice we are trying to view
    *
    * @returns {Object} The requested invoice data
    */
-  static async go (billRunId, invoiceId) {
-    let invoice = await FetchAndValidateInvoiceService.go(billRunId, invoiceId)
+  static async go (billRun, invoice) {
+    await ValidateInvoiceService.go(billRun, invoice)
 
     invoice = await this._invoiceResponseData(invoice)
 

--- a/test/controllers/bill_runs_invoices.controller.test.js
+++ b/test/controllers/bill_runs_invoices.controller.test.js
@@ -23,9 +23,9 @@ const RegimeHelper = require('../support/helpers/regime.helper.js')
 const Boom = require('@hapi/boom')
 
 const DeleteInvoiceService = require('../../app/services/invoices/delete_invoice.service.js')
-const FetchAndValidateInvoiceService = require('../../app/services/invoices/fetch_and_validate_invoice.service.js')
 const InvoiceRebillingService = require('../../app/services/invoices/invoice_rebilling.service.js')
 const InvoiceRebillingValidationService = require('../../app/services/invoices/invoice_rebilling_validation.service.js')
+const ValidateInvoiceService = require('../../app/services/invoices/validate_invoice.service.js')
 
 const BillRunModel = require('../../app/models/bill_run.model.js')
 const InvoiceModel = require('../../app/models/invoice.model.js')
@@ -72,16 +72,16 @@ describe('Invoices controller', () => {
       })
 
       describe('When the request is valid', () => {
-        let fetchStub
+        let validateStub
         let deleteStub
 
         before(async () => {
-          fetchStub = Sinon.stub(FetchAndValidateInvoiceService, 'go').returns()
+          validateStub = Sinon.stub(ValidateInvoiceService, 'go').returns()
           deleteStub = Sinon.stub(DeleteInvoiceService, 'go').returns()
         })
 
         after(async () => {
-          fetchStub.restore()
+          validateStub.restore()
           deleteStub.restore()
         })
 
@@ -93,29 +93,11 @@ describe('Invoices controller', () => {
       })
 
       describe('When the request is invalid', () => {
-        describe('because the invoice does not exist', () => {
-          let fetchStub
-
-          before(async () => {
-            fetchStub = Sinon.stub(FetchAndValidateInvoiceService, 'go').throws(Boom.notFound())
-          })
-
-          after(async () => {
-            fetchStub.restore()
-          })
-
-          it('returns error status 404', async () => {
-            const response = await server.inject(options(authToken, invoice.billRunId, invoice.id))
-
-            expect(response.statusCode).to.equal(404)
-          })
-        })
-
         describe('because the invoice is not linked to the bill run', () => {
           let fetchStub
 
           before(async () => {
-            fetchStub = Sinon.stub(FetchAndValidateInvoiceService, 'go').throws(Boom.conflict())
+            fetchStub = Sinon.stub(ValidateInvoiceService, 'go').throws(Boom.conflict())
           })
 
           after(async () => {

--- a/test/services/invoices/validate_invoice.service.test.js
+++ b/test/services/invoices/validate_invoice.service.test.js
@@ -1,0 +1,49 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const DatabaseHelper = require('../../support/helpers/database.helper.js')
+const NewBillRunHelper = require('../../support/helpers/new_bill_run.helper')
+const NewInvoiceHelper = require('../../support/helpers/new_invoice.helper')
+
+// Thing under test
+const ValidateInvoiceService = require('../../../app/services/invoices/validate_invoice.service.js')
+
+describe('Validate Invoice service', () => {
+  let billRun
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+    billRun = await NewBillRunHelper.create()
+  })
+
+  describe('When a valid bill run is supplied', () => {
+    describe('and a valid invoice', () => {
+      it('does not throw an error', async () => {
+        const validInvoice = await NewInvoiceHelper.create(billRun)
+
+        await expect(ValidateInvoiceService.go(billRun, validInvoice)).to.not.reject()
+      })
+    })
+
+    describe('and an invalid invoice', () => {
+      describe('because it is not linked to the bill run', () => {
+        it('throws an error', async () => {
+          const invalidInvoice = await NewInvoiceHelper.create()
+          const err = await expect(ValidateInvoiceService.go(billRun, invalidInvoice)).to.reject()
+
+          expect(err).to.be.an.error()
+          expect(err.output.payload.message).to.equal(
+            `Invoice ${invalidInvoice.id} is not linked to bill run ${billRun.id}.`
+          )
+        })
+      })
+    })
+  })
+})

--- a/test/services/invoices/view_invoice.service.test.js
+++ b/test/services/invoices/view_invoice.service.test.js
@@ -3,15 +3,20 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const BillRunHelper = require('../../support/helpers/bill_run.helper.js')
 const DatabaseHelper = require('../../support/helpers/database.helper.js')
-const GeneralHelper = require('../../support/helpers/general.helper.js')
-const TransactionHelper = require('../../support/helpers/transaction.helper.js')
+const NewTransactionHelper = require('../../support/helpers/new_transaction.helper')
+
+const BillRunModel = require('../../../app/models/bill_run.model.js')
+const InvoiceModel = require('../../../app/models/invoice.model.js')
+
+// Things we need to stub
+const ValidateInvoiceService = require('../../../app/services/invoices/validate_invoice.service')
 
 // Thing under test
 const ViewInvoiceService = require('../../../app/services/invoices/view_invoice.service.js')
@@ -19,56 +24,33 @@ const ViewInvoiceService = require('../../../app/services/invoices/view_invoice.
 describe('View Invoice service', () => {
   beforeEach(async () => {
     await DatabaseHelper.clean()
+    Sinon.stub(ValidateInvoiceService, 'go')
   })
 
-  describe('When a valid bill run ID is supplied', () => {
+  afterEach(async () => {
+    Sinon.restore()
+  })
+
+  describe('When a valid bill run and invoice are supplied', () => {
     let billRun
-    let invoiceId
+    let invoice
 
     beforeEach(async () => {
-      billRun = await BillRunHelper.addBillRun(GeneralHelper.uuid4(), GeneralHelper.uuid4())
-
-      await TransactionHelper.addTransaction(billRun.id)
-      const transactions = await billRun.$relatedQuery('transactions')
-      invoiceId = transactions[0].invoiceId
+      const transaction = await NewTransactionHelper.create()
+      invoice = await InvoiceModel.query().findById(transaction.invoiceId)
+      billRun = await BillRunModel.query().findById(transaction.billRunId)
     })
 
-    describe('and a valid invoice ID', () => {
-      it('returns the expected response', async () => {
-        const result = await ViewInvoiceService.go(billRun.id, invoiceId)
+    it('returns the expected response', async () => {
+      const result = await ViewInvoiceService.go(billRun, invoice)
 
-        expect(result.invoice.id).to.equal(invoiceId)
-        expect(result.invoice.netTotal).to.equal(0)
-        expect(result.invoice.ruleset).to.equal('presroc')
+      expect(result.invoice.id).to.equal(invoice.id)
+      expect(result.invoice.netTotal).to.equal(772)
+      expect(result.invoice.ruleset).to.equal('presroc')
 
-        expect(result.invoice.licences).to.be.an.array()
-        expect(result.invoice.licences[0].transactions).to.be.an.array()
-        expect(result.invoice.licences[0].netTotal).to.equal(0)
-      })
-    })
-
-    describe('and an invalid invoice ID', () => {
-      describe('because it is unknown', () => {
-        it('throws an error', async () => {
-          const unknownInvoiceId = GeneralHelper.uuid4()
-          const err = await expect(ViewInvoiceService.go(billRun.id, unknownInvoiceId)).to.reject()
-
-          expect(err).to.be.an.error()
-          expect(err.output.payload.message).to.equal(`Invoice ${unknownInvoiceId} is unknown.`)
-        })
-      })
-
-      describe('because it is not linked to the bill run', () => {
-        it('throws an error', async () => {
-          const otherBillRun = await BillRunHelper.addBillRun(GeneralHelper.uuid4(), GeneralHelper.uuid4())
-          const err = await expect(ViewInvoiceService.go(otherBillRun.id, invoiceId)).to.reject()
-
-          expect(err).to.be.an.error()
-          expect(err.output.payload.message).to.equal(
-            `Invoice ${invoiceId} is not linked to bill run ${otherBillRun.id}.`
-          )
-        })
-      })
+      expect(result.invoice.licences).to.be.an.array()
+      expect(result.invoice.licences[0].transactions).to.be.an.array()
+      expect(result.invoice.licences[0].netTotal).to.equal(772)
     })
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/CMEA-154

When we initially developed `FetchAndValidateInvoiceService`, we used it to fetch an invoice and perform a couple of checks on it:
1. that the invoice exists;
2. that the invoice is linked to the specified bill run.

We later created a plugin that automatically fetches an invoice when an invoice-related endpoint is used, and performs the first check. We now revisit our initial service to change it to be simply `ValidateInvoiceService`, which performs just the second check.