### PR TITLE
Give consistent "not linked" error responses

### DIFF
--- a/app/services/bill_runs/validate_bill_run_region.service.js
+++ b/app/services/bill_runs/validate_bill_run_region.service.js
@@ -23,7 +23,7 @@ class ValidateBillRunRegionService {
   static async _validateBillRun (billRun, region) {
     if (billRun.region !== region) {
       throw Boom.badData(
-        `Bill run ${billRun.id} is for region ${billRun.region} but transaction is for region ${region}.`
+        `Bill run ${billRun.id} is linked to region ${billRun.region} but transaction is linked to region ${region}.`
       )
     }
   }

--- a/app/services/invoices/invoice_rebilling_validation.service.js
+++ b/app/services/invoices/invoice_rebilling_validation.service.js
@@ -47,7 +47,7 @@ class InvoiceRebillingValidationService {
 
   static _validateNotOnNewBillRun (currentBillRun, newBillRun, invoiceId) {
     if (currentBillRun.id === newBillRun.id) {
-      throw Boom.conflict(`Invoice ${invoiceId} is already on bill run ${newBillRun.id}.`)
+      throw Boom.conflict(`Invoice ${invoiceId} is already linked to bill run ${newBillRun.id}.`)
     }
   }
 
@@ -76,7 +76,7 @@ class InvoiceRebillingValidationService {
   static _validateRegion (currentBillRun, newBillRun, invoiceId) {
     if (currentBillRun.region !== newBillRun.region) {
       throw Boom.conflict(
-          `Invoice ${invoiceId} is for region ${currentBillRun.region} but bill run ${newBillRun.id} is for region ${newBillRun.region}.`
+          `Invoice ${invoiceId} is linked to region ${currentBillRun.region} but bill run ${newBillRun.id} is linked to region ${newBillRun.region}.`
       )
     }
   }
@@ -84,7 +84,7 @@ class InvoiceRebillingValidationService {
   static _validateRuleset (currentBillRun, newBillRun, invoiceId) {
     if (currentBillRun.ruleset !== newBillRun.ruleset) {
       throw Boom.conflict(
-          `Invoice ${invoiceId} is for ruleset ${currentBillRun.ruleset} but bill run ${newBillRun.id} is for ruleset ${newBillRun.ruleset}.`
+          `Invoice ${invoiceId} is linked to ruleset ${currentBillRun.ruleset} but bill run ${newBillRun.id} is linked to ruleset ${newBillRun.ruleset}.`
       )
     }
   }

--- a/test/services/bill_runs/validate_bill_run_region.service.test.js
+++ b/test/services/bill_runs/validate_bill_run_region.service.test.js
@@ -37,7 +37,7 @@ describe('Validate Bill Run Region service', () => {
 
         expect(err).to.be.an.error()
         expect(err.output.payload.message).to.equal(
-          `Bill run ${billRun.id} is for region ${billRun.region} but transaction is for region ${region}.`
+          `Bill run ${billRun.id} is linked to region ${billRun.region} but transaction is linked to region ${region}.`
         )
       })
     })
@@ -50,7 +50,7 @@ describe('Validate Bill Run Region service', () => {
 
         expect(err).to.be.an.error()
         expect(err.output.payload.message).to.equal(
-          `Bill run ${billRun.id} is for region ${billRun.region} but transaction is for region undefined.`
+          `Bill run ${billRun.id} is linked to region ${billRun.region} but transaction is linked to region undefined.`
         )
       })
     })

--- a/test/services/invoices/invoice_rebilling_validation.service.test.js
+++ b/test/services/invoices/invoice_rebilling_validation.service.test.js
@@ -67,7 +67,7 @@ describe('Invoice Rebilling Validation service', () => {
 
           expect(err).to.be.an.error()
           expect(err.output.payload.message).to.equal(
-            `Invoice ${invoice.id} is already on bill run ${currentBillRun.id}.`
+            `Invoice ${invoice.id} is already linked to bill run ${currentBillRun.id}.`
           )
         })
       })
@@ -138,7 +138,7 @@ describe('Invoice Rebilling Validation service', () => {
 
         expect(err).to.be.an.error()
         expect(err.output.payload.message).to.equal(
-          `Invoice ${invoice.id} is for region A but bill run ${invalidNewBillRun.id} is for region B.`
+          `Invoice ${invoice.id} is linked to region A but bill run ${invalidNewBillRun.id} is linked to region B.`
         )
       })
     })
@@ -154,7 +154,7 @@ describe('Invoice Rebilling Validation service', () => {
 
         expect(err).to.be.an.error()
         expect(err.output.payload.message).to.equal(
-          `Invoice ${invoice.id} is for ruleset presroc but bill run ${invalidNewBillRun.id} is for ruleset sroc.`
+          `Invoice ${invoice.id} is linked to ruleset presroc but bill run ${invalidNewBillRun.id} is linked to ruleset sroc.`
         )
       })
     })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/CMEA-155

We update the wording of some of our error messages so we are more consistent about referring to entities being "linked to" other entities (ie. a bill run is now "linked to" a region, rather than being "for" that region).