### PR TITLE
Fix creditLineCount undefined in delete invoice

### DIFF
--- a/app/controllers/bill_runs_invoices.controller.js
+++ b/app/controllers/bill_runs_invoices.controller.js
@@ -10,10 +10,10 @@ class BillRunsInvoicesController {
   static async delete (req, h) {
     // We validate that the invoice is linked to the bill run within the controller so a not found/conflict error is
     // returned immediately
-    const invoice = await ValidateInvoiceService.go(req.app.billRun, req.app.invoice)
+    await ValidateInvoiceService.go(req.app.billRun, req.app.invoice)
 
     // We start DeleteInvoiceService without await so that it runs in the background
-    DeleteInvoiceService.go(invoice, req.app.billRun, req.app.notifier)
+    DeleteInvoiceService.go(req.app.invoice, req.app.billRun, req.app.notifier)
 
     return h.response().code(204)
   }


### PR DESCRIPTION
Whilst regression testing v0.18.0 we came across this error

```
TypeError: Cannot read properties of undefined (reading 'creditLineCount')
at Function._billRunPatch (/home/node/app/app/services/invoices/delete_invoice.service.js:82:61)
at Function._deleteInvoice (/home/node/app/app/services/invoices/delete_invoice.service.js:46:31)
at /home/node/app/app/services/invoices/delete_invoice.service.js:36:22
at /home/node/node_modules/knex/lib/transaction.js:183:22
at runMicrotasks (<anonymous>)
at processTicksAndRejections (node:internal/process/task_queues:96:5)
TypeError: Cannot read properties of undefined (reading 'id')
at Function.go (/home/node/app/app/services/invoices/delete_invoice.service.js:41:61)
at runMicrotasks (<anonymous>)
at processTicksAndRejections (node:internal/process/task_queues:96:5)
```

This change fixes the issue.