### PR TITLE
Change SRoC transaction file after user feedback

### DIFF
--- a/app/presenters/transaction_file_sroc_body.presenter.js
+++ b/app/presenters/transaction_file_sroc_body.presenter.js
@@ -41,7 +41,7 @@ class TransactionFileSrocBodyPresenter extends BasePresenter {
       col23: data.lineDescription,
       col24: 'AT',
       col25: '',
-      col26: this._blankIfCompensationCharge(data.lineAttr1, data),
+      col26: data.lineAttr1,
       col27: '',
       col28: this._blankIfCompensationCharge(data.lineAttr2, data), // chargePeriod
       col29: this._blankIfCompensationCharge(data.lineAttr3, data), // prorata days

--- a/app/presenters/transaction_file_sroc_body.presenter.js
+++ b/app/presenters/transaction_file_sroc_body.presenter.js
@@ -135,10 +135,10 @@ class TransactionFileSrocBodyPresenter extends BasePresenter {
   }
 
   /**
-   * Returns `actualVolume / authorisedVolume Ml` if twoPartTariff is true or blank string if false
+   * Returns a descriptive string including `actualVolume` if twoPartTariff is true or blank string if false
    */
   _volume (data) {
-    return this._isTrue(data.regimeValue16) ? `${data.regimeValue20} / ${data.headerAttr3} Ml` : ''
+    return this._isTrue(data.regimeValue16) ? `Calculated using reported abstracted quantity (${data.regimeValue20}ML) and the charge reference, which is based on the authorised quantity` : ''
   }
 
   /**

--- a/app/presenters/transaction_file_sroc_body.presenter.js
+++ b/app/presenters/transaction_file_sroc_body.presenter.js
@@ -47,7 +47,7 @@ class TransactionFileSrocBodyPresenter extends BasePresenter {
       col29: this._blankIfCompensationCharge(data.lineAttr3, data), // prorata days
       col30: this._blankIfCompensationCharge(data.headerAttr4, data), // chargeCategoryCode
       col31: this._blankIfCompensationCharge(data.regimeValue18, data), // chargeCategoryDescription
-      col32: this._blankIfCompensationCharge(data.headerAttr9, data), // baseCharge [in pence]
+      col32: this._blankIfCompensationCharge(this._pence(data.headerAttr9), data), // baseCharge [in pence]
       col33: this._blankIfCompensationCharge(this._reductionsList(data), data),
       col34: this._blankIfCompensationCharge(this._supportedSource(data), data),
       col35: this._blankIfCompensationCharge(this._volume(data), data),
@@ -141,10 +141,10 @@ class TransactionFileSrocBodyPresenter extends BasePresenter {
   }
 
   /**
-   * Returns `waterCompanyChargeValue` if waterCompanyCharge is true or blank string if false
+   * Returns `waterCompanyChargeValue` (with `pence` appended) if waterCompanyCharge is true or blank string if false
    */
   _waterCompany (data) {
-    return this._isTrue(data.headerAttr7) ? data.headerAttr10 : ''
+    return this._isTrue(data.headerAttr7) ? this._pence(data.headerAttr10) : ''
   }
 
   /**
@@ -161,6 +161,13 @@ class TransactionFileSrocBodyPresenter extends BasePresenter {
     // We don't expect to store anything other than lower case but we change case just to be safe. We use optional
     // chaining to avoid issues if field is `null`
     return field?.toLowerCase() === 'true'
+  }
+
+  /**
+   * Returns the value with `pence` added eg. `90210pence`
+   */
+  _pence (value) {
+    return `${value}pence`
   }
 }
 

--- a/app/presenters/transaction_file_sroc_body.presenter.js
+++ b/app/presenters/transaction_file_sroc_body.presenter.js
@@ -127,10 +127,11 @@ class TransactionFileSrocBodyPresenter extends BasePresenter {
   }
 
   /**
-   * Returns `supportedSourceValue, supportedSourceName` if supportedSource is true or blank string if false
+   * Returns `supportedSourceValue (supportedSourceName)` (with `pence` appended to the value) if supportedSource is
+   * true or blank string if false
    */
   _supportedSource (data) {
-    return this._isTrue(data.headerAttr5) ? `${data.lineAttr11}, ${data.headerAttr6}` : ''
+    return this._isTrue(data.headerAttr5) ? `${this._pence(data.lineAttr11)} (${data.headerAttr6})` : ''
   }
 
   /**

--- a/app/presenters/transaction_file_sroc_body.presenter.js
+++ b/app/presenters/transaction_file_sroc_body.presenter.js
@@ -138,7 +138,9 @@ class TransactionFileSrocBodyPresenter extends BasePresenter {
    * Returns a descriptive string including `actualVolume` if twoPartTariff is true or blank string if false
    */
   _volume (data) {
-    return this._isTrue(data.regimeValue16) ? `Calculated using reported abstracted quantity (${data.regimeValue20}ML) and the charge reference, which is based on the authorised quantity` : ''
+    return this._isTrue(data.regimeValue16)
+      ? `Calculated using reported abstracted quantity (${data.regimeValue20}ML) and the charge reference, which is based on the authorised quantity`
+      : ''
   }
 
   /**

--- a/test/presenters/transaction_file_sroc_body.presenter.test.js
+++ b/test/presenters/transaction_file_sroc_body.presenter.test.js
@@ -256,7 +256,7 @@ describe('Transaction File Sroc Body Presenter', () => {
 
       const result = presenter.go()
 
-      expect(result.col35).to.equal('123.4 / 567.8 Ml')
+      expect(result.col35).to.equal('Calculated using reported abstracted quantity (123.4ML) and the charge reference, which is based on the authorised quantity')
     })
 
     it('returns blank if two part tariff is false', () => {

--- a/test/presenters/transaction_file_sroc_body.presenter.test.js
+++ b/test/presenters/transaction_file_sroc_body.presenter.test.js
@@ -231,7 +231,7 @@ describe('Transaction File Sroc Body Presenter', () => {
 
       const result = presenter.go()
 
-      expect(result.col34).to.equal('15000, SUPPORTED_SOURCE_NAME')
+      expect(result.col34).to.equal('15000pence (SUPPORTED_SOURCE_NAME)')
     })
 
     it('returns blank if supported source is false', () => {

--- a/test/presenters/transaction_file_sroc_body.presenter.test.js
+++ b/test/presenters/transaction_file_sroc_body.presenter.test.js
@@ -170,7 +170,6 @@ describe('Transaction File Sroc Body Presenter', () => {
 
       const result = presenter.go()
 
-      expect(result.col26).to.equal('')
       expect(result.col28).to.equal('')
       expect(result.col29).to.equal('')
       expect(result.col30).to.equal('')

--- a/test/presenters/transaction_file_sroc_body.presenter.test.js
+++ b/test/presenters/transaction_file_sroc_body.presenter.test.js
@@ -29,7 +29,7 @@ describe('Transaction File Sroc Body Presenter', () => {
     lineAttr4: 'LINE_ATTR_4',
     headerAttr4: 'HEADER_ATTR_4',
     regimeValue18: 'REGIME_VALUE_18',
-    headerAttr9: 'HEADER_ATTR_9',
+    headerAttr9: 90210,
     // Reductions, col33
     headerAttr2: '1',
     headerAttr8: 'false',
@@ -137,6 +137,15 @@ describe('Transaction File Sroc Body Presenter', () => {
     })
   })
 
+  describe('for col 32 (value in pence)', () => {
+    it('correctly formats the value', () => {
+      const presenter = new TransactionFileSrocBodyPresenter(data)
+      const result = presenter.go()
+
+      expect(result.col32).to.equal('90210pence')
+    })
+  })
+
   describe('for cols that are dependent on compensation charge', () => {
     it('returns expected values when compensation charge is false', () => {
       const presenter = new TransactionFileSrocBodyPresenter({
@@ -153,7 +162,6 @@ describe('Transaction File Sroc Body Presenter', () => {
       expect(result.col29).to.equal(data.lineAttr3)
       expect(result.col30).to.equal(data.headerAttr4)
       expect(result.col31).to.equal(data.regimeValue18)
-      expect(result.col32).to.equal(data.headerAttr9)
       expect(result.col33).to.not.equal('') // This column is checked in a separate test
       expect(result.col34).to.not.equal('') // This column is checked in a separate test
       expect(result.col35).to.not.equal('') // This column is checked in a separate test
@@ -273,7 +281,7 @@ describe('Transaction File Sroc Body Presenter', () => {
 
       const result = presenter.go()
 
-      expect(result.col36).to.equal(data.headerAttr10)
+      expect(result.col36).to.equal('12345pence')
     })
 
     it('returns blank if water company charge is false', () => {

--- a/test/services/files/transactions/generate_sroc_transaction_file.service.test.js
+++ b/test/services/files/transactions/generate_sroc_transaction_file.service.test.js
@@ -100,7 +100,7 @@ describe('Generate Sroc Transaction File service', () => {
     const date = presenter._formatDate(new Date())
 
     const head = _contentLine(['H', '0000000', 'NAL', 'A', 'I', '67890T', '12345', date])
-    const body = _contentLine(['D', '0000001', 'TH230000222', date, 'I', 'TRANSACTION_REF', '', 'GBP', '', date, '', '', '', '', '', '', '', '', '', '772', '', 'ARCA', 'Well at Chigley Town Hall', 'AT', '', 'TONY/TF9222/37', '', '01-APR-2018 - 31-MAR-2019', '100/200', '2.1.145', 'CHARGE_CATEGORY_DESC', '178300', '', '628200, Nene - Water Newton', '125.1 / 322.23 Ml', '78500', '', '', '', '', '1', 'Each', '772'])
+    const body = _contentLine(['D', '0000001', 'TH230000222', date, 'I', 'TRANSACTION_REF', '', 'GBP', '', date, '', '', '', '', '', '', '', '', '', '772', '', 'ARCA', 'Well at Chigley Town Hall', 'AT', '', 'TONY/TF9222/37', '', '01-APR-2018 - 31-MAR-2019', '100/200', '2.1.145', 'CHARGE_CATEGORY_DESC', '178300pence', '', '628200, Nene - Water Newton', '125.1 / 322.23 Ml', '78500pence', '', '', '', '', '1', 'Each', '772'])
     const tail = _contentLine(['T', '0000002', '3', '0', '0'])
 
     return head.concat(body).concat(tail)

--- a/test/services/files/transactions/generate_sroc_transaction_file.service.test.js
+++ b/test/services/files/transactions/generate_sroc_transaction_file.service.test.js
@@ -100,7 +100,7 @@ describe('Generate Sroc Transaction File service', () => {
     const date = presenter._formatDate(new Date())
 
     const head = _contentLine(['H', '0000000', 'NAL', 'A', 'I', '67890T', '12345', date])
-    const body = _contentLine(['D', '0000001', 'TH230000222', date, 'I', 'TRANSACTION_REF', '', 'GBP', '', date, '', '', '', '', '', '', '', '', '', '772', '', 'ARCA', 'Well at Chigley Town Hall', 'AT', '', 'TONY/TF9222/37', '', '01-APR-2018 - 31-MAR-2019', '100/200', '2.1.145', 'CHARGE_CATEGORY_DESC', '178300pence', '', '628200, Nene - Water Newton', '125.1 / 322.23 Ml', '78500pence', '', '', '', '', '1', 'Each', '772'])
+    const body = _contentLine(['D', '0000001', 'TH230000222', date, 'I', 'TRANSACTION_REF', '', 'GBP', '', date, '', '', '', '', '', '', '', '', '', '772', '', 'ARCA', 'Well at Chigley Town Hall', 'AT', '', 'TONY/TF9222/37', '', '01-APR-2018 - 31-MAR-2019', '100/200', '2.1.145', 'CHARGE_CATEGORY_DESC', '178300pence', '', '628200pence (Nene - Water Newton)', '125.1 / 322.23 Ml', '78500pence', '', '', '', '', '1', 'Each', '772'])
     const tail = _contentLine(['T', '0000002', '3', '0', '0'])
 
     return head.concat(body).concat(tail)

--- a/test/services/files/transactions/generate_sroc_transaction_file.service.test.js
+++ b/test/services/files/transactions/generate_sroc_transaction_file.service.test.js
@@ -100,7 +100,7 @@ describe('Generate Sroc Transaction File service', () => {
     const date = presenter._formatDate(new Date())
 
     const head = _contentLine(['H', '0000000', 'NAL', 'A', 'I', '67890T', '12345', date])
-    const body = _contentLine(['D', '0000001', 'TH230000222', date, 'I', 'TRANSACTION_REF', '', 'GBP', '', date, '', '', '', '', '', '', '', '', '', '772', '', 'ARCA', 'Well at Chigley Town Hall', 'AT', '', 'TONY/TF9222/37', '', '01-APR-2018 - 31-MAR-2019', '100/200', '2.1.145', 'CHARGE_CATEGORY_DESC', '178300pence', '', '628200pence (Nene - Water Newton)', '125.1 / 322.23 Ml', '78500pence', '', '', '', '', '1', 'Each', '772'])
+    const body = _contentLine(['D', '0000001', 'TH230000222', date, 'I', 'TRANSACTION_REF', '', 'GBP', '', date, '', '', '', '', '', '', '', '', '', '772', '', 'ARCA', 'Well at Chigley Town Hall', 'AT', '', 'TONY/TF9222/37', '', '01-APR-2018 - 31-MAR-2019', '100/200', '2.1.145', 'CHARGE_CATEGORY_DESC', '178300pence', '', '628200pence (Nene - Water Newton)', 'Calculated using reported abstracted quantity (125.1ML) and the charge reference, which is based on the authorised quantity', '78500pence', '', '', '', '', '1', 'Each', '772'])
     const tail = _contentLine(['T', '0000002', '3', '0', '0'])
 
     return head.concat(body).concat(tail)


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/projects/CMEA/boards/907?selectedIssue=CMEA-309

The following changes have been requested for the sroc transaction file:

* Line attribute 1 (col 26) should be populated for all transactions -- a change from the current behaviour of populated for all except compensation charge transactions
* Line attribute 7 (col 32) and line attribute 11 (col 36) should all have `pence` appended without a space between eg. `969000pence`
* Line attribute 9 (col 34) should be in the format `${supportedSourceValue}pence (${supportedSourceName})` eg. `1881600pence (Kielder)`.
* Line attribute 10 (col 35) should be in the format `Calculated using reported abstracted quantity (${actualVolume}ML) and the charge reference, which is based on the authorised quantity`
