### PR TITLE
Correctly return `section127Factor` for sroc invoices

### DIFF
--- a/app/presenters/base.presenter.js
+++ b/app/presenters/base.presenter.js
@@ -65,6 +65,13 @@ class BasePresenter {
     return false
   }
 
+  _asNumber (value) {
+    const parsed = parseFloat(value)
+
+    // If the parsed value isn't a number then return `null`, otherwise return the number
+    return Number.isNaN(parsed) ? null : parsed
+  }
+
   /**
    * Extracts the factor value from a string in the format `... x n.n`. For example, when given the string `S130U x
    * 0.5`, the number `0.5` is returned. Returns `null` if the string isn't in the expected format.

--- a/app/presenters/view_transaction.presenter.js
+++ b/app/presenters/view_transaction.presenter.js
@@ -27,12 +27,13 @@ class ViewTransactionPresenter extends BasePresenter {
       compensationCharge: this._asBoolean(data.regimeValue17),
       rebilledTransactionId: data.rebilledTransactionId,
       // For historical reasons, presroc factors are persisted in the db as a string which needs to have the factor
-      // value extracted, whereas sroc factors are simply persisted as the value.
-      section130Factor: data.ruleset === 'presroc' ? this._extractFactorFromString(data.lineAttr9) : data.lineAttr9,
-      section127Factor: data.ruleset === 'presroc' ? this._extractS127FactorFromString(data.lineAttr10) : data.lineAttr10,
-      // We only include winterOnlyFactor if the ruleset is `sroc`. Therefore we don't need to use _presentFactor() as
-      // we do for the previous factors.
-      ...(data.ruleset === 'sroc') && { winterOnlyFactor: data.lineAttr12 },
+      // value extracted, whereas sroc factors are simply persisted as the value (but stored as a string so we must
+      // parse it back to a number)
+      section130Factor: data.ruleset === 'presroc' ? this._extractFactorFromString(data.lineAttr9) : this._asNumber(data.lineAttr9),
+      // Note presroc stores the string to be parsed in `lineAttr10` whereas sroc stores the factor in `lineAttr15`
+      section127Factor: data.ruleset === 'presroc' ? this._extractS127FactorFromString(data.lineAttr10) : this._asNumber(data.lineAttr15),
+      // We only include winterOnlyFactor if the ruleset is `sroc`
+      ...(data.ruleset === 'sroc') && { winterOnlyFactor: this._asNumber(data.lineAttr12) },
       calculation: data.chargeCalculation
     }
   }

--- a/app/services/invoices/view_invoice.service.js
+++ b/app/services/invoices/view_invoice.service.js
@@ -66,7 +66,8 @@ class ViewInvoiceService {
           'chargeCalculation',
           'lineAttr9',
           'lineAttr10',
-          'lineAttr12'
+          'lineAttr12',
+          'lineAttr15'
         )
       })
       .withGraphFetched('billRun')

--- a/test/presenters/base.presenter.test.js
+++ b/test/presenters/base.presenter.test.js
@@ -174,6 +174,32 @@ describe('Base presenter', () => {
     })
   })
 
+  describe('_asNumber method', () => {
+    it('returns a number if given a string that is a number', async () => {
+      const presenter = new BasePresenter()
+
+      const result = presenter._asNumber('123')
+
+      expect(result).to.equal(123)
+    })
+
+    it('returns a number if given a number', async () => {
+      const presenter = new BasePresenter()
+
+      const result = presenter._asNumber(123)
+
+      expect(result).to.equal(123)
+    })
+
+    it("returns `null` if given a string that isn't a number", async () => {
+      const presenter = new BasePresenter()
+
+      const result = presenter._asNumber('one two three')
+
+      expect(result).to.equal(null)
+    })
+  })
+
   describe('_extractFactorFromString method', () => {
     it('returns the factor if given a string in the format `... x n.n`', async () => {
       const presenter = new BasePresenter()

--- a/test/presenters/view_transaction.presenter.test.js
+++ b/test/presenters/view_transaction.presenter.test.js
@@ -85,9 +85,9 @@ describe('View Transaction Presenter', () => {
       ...baseData,
       // Ruleset is not normally part of the transaction record but we expect it to be passed in to the presenter
       ruleset: 'sroc',
-      lineAttr9: 0.833,
-      lineAttr10: 0.5,
-      lineAttr12: 0.5
+      lineAttr9: '0.833',
+      lineAttr12: '0.5',
+      lineAttr15: '0.5'
     }
 
     it('does not return `subjectToMinimumCharge`', () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/CMEA-310

We found in testing that `section127Factor` was not being correctly returned when an invoice was viewed. On investigation, we realised that we'd got our fields confused!

For presroc transactions, the field `lineAttr10` holds the factor string eg. `S127 x 0.5`. We mistakenly used this field when adding the factor to sroc transactions, when in fact we store the factor in `lineAttr15`. We therefore fix the transaction presenter to use the correct field.

While doing this, we realised that the two rulesets weren't consistent in how they return factors:
* For presroc we extract the factor from the string, parse it as a number and return it
* For sroc we return the value as-is, and since it's stored as a string (due to our use of generic fields in the db) this means we return it as a string.

We therefore make a further change to the transaction presenter to convert factors back from strings to floats.