### PR TITLE
Fix incompatible npm version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ RUN apk update \
   && apk add postgresql-client \
   && rm -rf /var/cache/apk/*
 
-# Get the latest version of npm at time of build, regardless of node version, for speed and fixes.
-RUN npm i npm@latest -g
+# Get the latest version of npm compatible with Node v16.
+RUN npm i npm@8.19.4 -g
 
 # We have chosen /home/node as our working directory to be consistent with https://github.com/DEFRA/defra-docker-node
 WORKDIR /home/node


### PR DESCRIPTION
We've just got the GitHub action `.github/workflows/docker.yml` working again but it has highlighted a new issue. The version of Node the CHA is using is now a few versions behind. This means the latest versions of NPM are no longer compatible with it.

This change fixes the issue specifying the version of NPM to install.

> See https://nodejs.org/en/about/previous-releases for Node and NPM compatibility