### PR TITLE
Fix and update Docker GitHub workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -58,7 +58,6 @@ jobs:
         run: |
           echo 'ALL_TAGS<<EOF' >> $GITHUB_ENV
           echo "${{ steps.meta.outputs.tags }}" >> $GITHUB_ENV
-          echo "${{ steps.meta.outputs.tags }}" | sed -e 's|${{ env.GHC_REGISTRY }}/defra|docker.io/environmentagency|g' >> $GITHUB_ENV
           if [ ${{ startsWith(github.ref, 'refs/tags/v') }} = false ]; then echo "ghcr.io/defra/sroc-charging-module-api:$(git describe --always --tags)"; fi >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
 


### PR DESCRIPTION
In [Remove pushing to Docker Hub](https://github.com/DEFRA/sroc-charging-module-api/pull/1059) we wanted to remove the step that logged us into Docker Hub as we no longer have access to that as an image repo. We thought removing the login step was all that was needed but we overlooked that we were still generating a label that [docker/build-push-action@v5](https://github.com/docker/build-push-action/tree/v5/) uses to try and attempt to push the image to.

Removing that should fix the issue.

But then we reflected on what other changes we've done in the [sroc-tcm-admin](https://github.com/DEFRA/sroc-tcm-admin) repo recently in its Docker workflow.

To get it ready for using AWS ECS and ECR we had to take a deeper dive into [metadata-action](https://github.com/docker/metadata-action) and how it works.

Now we've reduced the number of repos we're working with to one we realised we could bring over some of those changes rather than just remove the problem command.

So, this fixes our immediate issue, makes better use of the actions we've incorporated and moves us much closer to this repo using AWS ECR rather than GHCR for storing its images.