### PR TITLE
Remove version property from Docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   db:
     image: postgres:12-alpine


### PR DESCRIPTION
When rebuilding the project on a new machine, we saw the following warning in the Docker build output.

```text
WARN[0000] /Users/acruikshanks/projects/defra/sroc-charging-module-api/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
```

Since we built this project, the [version property has been made obsolete](https://docs.docker.com/reference/compose-file/version-and-name/#version-top-level-element-obsolete). Docker now always attempts to interpret your compose file against the latest schema, so you can automatically benefit from the latest features and improvements.

So, we can safely delete the property and remove the warning from our output.

> See also [Do you still use version in Docker compose?](https://dev.to/ajeetraina/do-we-still-use-version-in-compose-3inp)
