### PR TITLE
Stop populating col35 in SROC 2PT transaction file

### DIFF
--- a/app/presenters/transaction_file_sroc_body.presenter.js
+++ b/app/presenters/transaction_file_sroc_body.presenter.js
@@ -50,7 +50,7 @@ class TransactionFileSrocBodyPresenter extends BasePresenter {
       col32: this._blankIfCompensationCharge(this._pence(data.headerAttr9), data), // baseCharge [in pence]
       col33: this._blankIfCompensationCharge(this._reductionsList(data), data),
       col34: this._blankIfCompensationCharge(this._supportedSource(data), data),
-      col35: this._blankIfCompensationCharge(this._volume(data), data),
+      col35: '',
       col36: this._blankIfCompensationCharge(this._waterCompany(data), data),
       col37: this._blankIfNotCompensationCharge(this._compensationChargeAndRegion(data), data),
       col38: '',
@@ -132,15 +132,6 @@ class TransactionFileSrocBodyPresenter extends BasePresenter {
    */
   _supportedSource (data) {
     return this._isTrue(data.headerAttr5) ? `${this._pence(data.lineAttr11)} (${data.headerAttr6})` : ''
-  }
-
-  /**
-   * Returns a descriptive string including `actualVolume` if twoPartTariff is true or blank string if false
-   */
-  _volume (data) {
-    return this._isTrue(data.regimeValue16)
-      ? `Calculated using reported abstracted quantity (${data.regimeValue20}ML) and the charge reference, which is based on the authorised quantity`
-      : ''
   }
 
   /**

--- a/test/presenters/transaction_file_sroc_body.presenter.test.js
+++ b/test/presenters/transaction_file_sroc_body.presenter.test.js
@@ -85,6 +85,7 @@ describe('Transaction File Sroc Body Presenter', () => {
       expect(result.col21).to.equal('')
       expect(result.col24).to.equal('AT')
       expect(result.col25).to.equal('')
+      expect(result.col35).to.equal('')
       expect(result.col38).to.equal('')
       expect(result.col39).to.equal('')
       expect(result.col40).to.equal('')
@@ -164,7 +165,6 @@ describe('Transaction File Sroc Body Presenter', () => {
       expect(result.col31).to.equal(data.regimeValue18)
       expect(result.col33).to.not.equal('') // This column is checked in a separate test
       expect(result.col34).to.not.equal('') // This column is checked in a separate test
-      expect(result.col35).to.not.equal('') // This column is checked in a separate test
       expect(result.col36).to.not.equal('') // This column is checked in a separate test
 
       expect(result.col37).to.equal('')
@@ -185,7 +185,6 @@ describe('Transaction File Sroc Body Presenter', () => {
       expect(result.col32).to.equal('')
       expect(result.col33).to.equal('')
       expect(result.col34).to.equal('')
-      expect(result.col35).to.equal('')
       expect(result.col36).to.equal('')
 
       expect(result.col37).to.not.equal('') // This column is checked in a separate test
@@ -244,31 +243,6 @@ describe('Transaction File Sroc Body Presenter', () => {
       const result = presenter.go()
 
       expect(result.col34).to.equal('')
-    })
-  })
-
-  describe('for col35 (volume)', () => {
-    it('returns the correct data if two part tariff is true', () => {
-      const presenter = new TransactionFileSrocBodyPresenter({
-        ...data,
-        regimeValue17: 'false'
-      })
-
-      const result = presenter.go()
-
-      expect(result.col35).to.equal('Calculated using reported abstracted quantity (123.4ML) and the charge reference, which is based on the authorised quantity')
-    })
-
-    it('returns blank if two part tariff is false', () => {
-      const presenter = new TransactionFileSrocBodyPresenter({
-        ...data,
-        regimeValue17: 'false',
-        regimeValue16: 'false'
-      })
-
-      const result = presenter.go()
-
-      expect(result.col35).to.equal('')
     })
   })
 

--- a/test/services/files/transactions/generate_sroc_transaction_file.service.test.js
+++ b/test/services/files/transactions/generate_sroc_transaction_file.service.test.js
@@ -100,7 +100,7 @@ describe('Generate Sroc Transaction File service', () => {
     const date = presenter._formatDate(new Date())
 
     const head = _contentLine(['H', '0000000', 'NAL', 'A', 'I', '67890T', '12345', date])
-    const body = _contentLine(['D', '0000001', 'TH230000222', date, 'I', 'TRANSACTION_REF', '', 'GBP', '', date, '', '', '', '', '', '', '', '', '', '772', '', 'ARCA', 'Well at Chigley Town Hall', 'AT', '', 'TONY/TF9222/37', '', '01-APR-2018 - 31-MAR-2019', '100/200', '2.1.145', 'CHARGE_CATEGORY_DESC', '178300pence', '', '628200pence (Nene - Water Newton)', 'Calculated using reported abstracted quantity (125.1ML) and the charge reference, which is based on the authorised quantity', '78500pence', '', '', '', '', '1', 'Each', '772'])
+    const body = _contentLine(['D', '0000001', 'TH230000222', date, 'I', 'TRANSACTION_REF', '', 'GBP', '', date, '', '', '', '', '', '', '', '', '', '772', '', 'ARCA', 'Well at Chigley Town Hall', 'AT', '', 'TONY/TF9222/37', '', '01-APR-2018 - 31-MAR-2019', '100/200', '2.1.145', 'CHARGE_CATEGORY_DESC', '178300pence', '', '628200pence (Nene - Water Newton)', '', '78500pence', '', '', '', '', '1', 'Each', '772'])
     const tail = _contentLine(['T', '0000002', '3', '0', '0'])
 
     return head.concat(body).concat(tail)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4740

This request has come from the [http://github.com/DEFRA/water-abstraction-team](Water Abstraction Team) to amend the transaction file generated for SROC bill runs.

When the transaction is flagged as being two-part tariff, we currently have logic that outputs an attempt to explain how the charge was calculated. However, if the charge involves aggregates, the explanation is wrong. Explaining the charge in a short sentence would be a project itself! So, they have requested we drop the output altogether and leave it blank.