### PR TITLE
Update CI to for SonarQube

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of sonarcloud analysis
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of SonarQube analysis
 
       # Before we do anything, check we haven't accidentally left any `describe.only()` or `it.only(` statements in the
       # tests
@@ -106,9 +106,9 @@ jobs:
         run: |
           npm run migrate-test-db
 
-      # This includes an extra run step. The sonarcloud analysis will be run in a docker container with the current
+      # This includes an extra run step. The SonarQube analysis will be run in a docker container with the current
       # folder mounted as `/github/workspace`. The problem is when the lcov.info file is generated it will reference the
-      # code in the current folder. So to enable sonarcloud to matchup code coverage with the files we use sed to update
+      # code in the current folder. So to enable SonarQube to matchup code coverage with the files we use sed to update
       # the references in lcov.info
       # https://community.sonarsource.com/t/code-coverage-doesnt-work-with-github-action/16747/6
       - name: Run unit tests
@@ -116,9 +116,9 @@ jobs:
           npm test
           sed -i 's/\/home\/runner\/work\/sroc-charging-module-api\/sroc-charging-module-api\//\/github\/workspace\//g' coverage/lcov.info
 
-      - name: Analyze with SonarCloud
+      - name: Analyze with SonarQube
         if: github.actor != 'dependabot[bot]'
-        uses: sonarsource/sonarcloud-github-action@master
+        uses: sonarsource/sonarqube-scan-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This is provided automatically by GitHub
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }} # This needs to be set in your repo; settings -> secrets

--- a/.labrc.js
+++ b/.labrc.js
@@ -3,7 +3,7 @@
 module.exports = {
   verbose: true,
   coverage: true,
-  // lcov reporter required for SonarCloud
+  // lcov reporter required for SonarQube
   reporter: ['console', 'html', 'lcov'],
   output: ['stdout', 'coverage/coverage.html', 'coverage/lcov.info'],
   // @aws-sdk/s3 exposes global variables which cause errors during test if we don't ignore them. lab expects the list


### PR DESCRIPTION
The SonarCloud CI action is deprecated in favour of SonarQube; we therefore amend our `ci.yml` to use the SonarQube action.